### PR TITLE
Support composite command routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ MIT License
       - [Dispatch consistency guarantee](guides/Commands.md#command-dispatch-consistency-guarantee)
       - [Dispatch returning execution result](guides/Commands.md#dispatch-returning-execution-result)
       - [Aggregate lifespan](guides/Commands.md#aggregate-lifespan)
+      - [Composite command routers](guides/Commands.md#composite-command-routers)
     - [Middleware](guides/Commands.md#middleware)
       - [Example middleware](guides/Commands.md#example-middleware)
   - [Events](guides/Events.md)

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -345,3 +345,24 @@ end
 ```
 
 Commanded provides a `Commanded.Middleware.Logger` middleware for logging the name of each dispatched command and its execution duration.
+
+## Composite command routers
+
+You can use the `Commanded.Commands.CompositeRouter` macro to define a router comprised of other router modules. This approach is useful if you prefer to construct a router per context and then combine them together to form a top level application router.
+
+By using `Commanded.Commands.CompositeRouter` in your own module you can include other routers via the `router` macro:
+
+```elixir
+defmodule ApplicationRouter do
+  use Commanded.Commands.CompositeRouter
+
+  router BankAccountRouter
+  router MoneyTransferRouter
+end
+```
+
+Command dispatch works the same as any other router:
+
+```elixir
+:ok = ApplicationRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+```

--- a/lib/commanded/commands/composite_router.ex
+++ b/lib/commanded/commands/composite_router.ex
@@ -1,0 +1,70 @@
+defmodule Commanded.Commands.CompositeRouter do
+  @moduledoc """
+  Composite router allows you to combine multiple router modules into a single
+  router able to dispatch any registered command using its corresponding router.
+
+  ## Example
+
+      defmodule ExampleCompositeRouter do
+        use Commanded.Commands.CompositeRouter
+
+        router BankAccountRouter
+        router MoneyTransferRouter
+      end
+
+      :ok = ExampleCompositeRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+  """
+
+  defmacro __using__(_) do
+    quote do
+      require Logger
+
+      import unquote(__MODULE__)
+
+      @registered_commands %{}
+
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro router(router_module) do
+    quote location: :keep do
+      for command <- unquote(router_module).registered_commands() do
+        case Map.get(@registered_commands, command) do
+          nil ->
+            @registered_commands Map.put(@registered_commands, command, unquote(router_module))
+
+          existing_router ->
+            raise "duplicate registration for #{inspect command} command, registered in both #{inspect existing_router} and #{inspect unquote(router_module)}"
+        end
+      end
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      @doc false
+      def dispatch(command), do: dispatch(command, [])
+
+      Enum.map(@registered_commands, fn {command_module, router} ->
+        Module.eval_quoted(__MODULE__, quote do
+          @doc false
+          def dispatch(%unquote(command_module){} = command, opts) do
+            unquote(router).dispatch(command, opts)
+          end
+        end)
+      end)
+
+      @doc """
+      Return an error if an unregistered command is dispatched.
+      """
+      def dispatch(command), do: unregistered_command(command)
+      def dispatch(command, opts), do: unregistered_command(command)
+
+      defp unregistered_command(command) do
+        Logger.error(fn -> "attempted to dispatch an unregistered command: #{inspect command}" end)
+        {:error, :unregistered_command}
+      end
+    end
+  end
+end

--- a/test/commands/composite_router_test.exs
+++ b/test/commands/composite_router_test.exs
@@ -1,0 +1,81 @@
+defmodule Commanded.Commands.CompositeRouterTest do
+  use Commanded.StorageCase
+
+  alias Commanded.ExampleDomain.{BankAccount,MoneyTransfer}
+  alias Commanded.ExampleDomain.{OpenAccountHandler,DepositMoneyHandler,TransferMoneyHandler,WithdrawMoneyHandler}
+  alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount,DepositMoney,WithdrawMoney}
+  alias Commanded.ExampleDomain.MoneyTransfer.Commands.TransferMoney
+  alias Commanded.Commands.ExecutionResult
+
+  defmodule UnregisteredCommand do
+    @moduledoc false
+    defstruct [:uuid]
+  end
+
+  defmodule BankAccountRouter do
+    @moduledoc false
+    use Commanded.Commands.Router
+
+    identify BankAccount, by: :account_number
+
+    dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount
+    dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount
+    dispatch WithdrawMoney, to: WithdrawMoneyHandler, aggregate: BankAccount
+  end
+
+  defmodule MoneyTransferRouter do
+    @moduledoc false
+    use Commanded.Commands.Router
+
+    identify MoneyTransfer, by: :transfer_uuid
+    dispatch TransferMoney, to: TransferMoneyHandler, aggregate: MoneyTransfer
+  end
+
+  defmodule ExampleCompositeRouter do
+    @moduledoc false
+    use Commanded.Commands.CompositeRouter
+
+    router BankAccountRouter
+    router MoneyTransferRouter
+  end
+
+  describe "composite router" do
+    test "should dispatch command to registered handler" do
+      assert :ok = ExampleCompositeRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+      assert :ok = ExampleCompositeRouter.dispatch(%TransferMoney{transfer_uuid: UUID.uuid4(), debit_account: "ACC123", credit_account: "ACC456", amount: 500})
+    end
+
+    test "should dispatch command to registered handler with options" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
+      assert {:ok, %ExecutionResult{}} = ExampleCompositeRouter.dispatch(command, include_execution_result: true)
+    end
+
+    test "should fail to dispatch unregistered command" do
+      assert {:error, :unregistered_command} = ExampleCompositeRouter.dispatch(%UnregisteredCommand{})
+    end
+
+    test "should fail to compile when duplicate commands registered" do
+      assert_raise RuntimeError, "duplicate registration for Commanded.ExampleDomain.MoneyTransfer.Commands.TransferMoney command, registered in both Commanded.Commands.CompositeRouterTest.MoneyTransferRouter and DuplicateMoneyTransferRouter", fn ->
+        Code.eval_string """
+          alias Commanded.ExampleDomain.{MoneyTransfer,TransferMoneyHandler}
+          alias Commanded.ExampleDomain.MoneyTransfer.Commands.TransferMoney
+          alias Commanded.Commands.CompositeRouterTest.MoneyTransferRouter
+
+          defmodule DuplicateMoneyTransferRouter do
+            use Commanded.Commands.Router
+
+            identify MoneyTransfer, by: :transfer_uuid
+            dispatch TransferMoney, to: TransferMoneyHandler, aggregate: MoneyTransfer
+          end
+
+          defmodule ExampleCompositeRouter do
+            use Commanded.Commands.CompositeRouter
+
+            router MoneyTransferRouter
+            router DuplicateMoneyTransferRouter
+          end
+        """
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can use the `Commanded.Commands.CompositeRouter` macro to define a router comprised of other router modules.

This approach is useful if you prefer to construct a router per context and then combine them together to form a top level application router.

By using `Commanded.Commands.CompositeRouter` in your own module you can include other routers via the `router` macro:

```elixir
defmodule ApplicationRouter do
  use Commanded.Commands.CompositeRouter

  router BankAccountRouter
  router MoneyTransferRouter
end
```