### PR TITLE
Aggregate state snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Support composite command routers ([#111](https://github.com/commanded/commanded/pull/111)).
+- Aggregate state snapshots ([#121](https://github.com/commanded/commanded/pull/121)).
 
 ## v0.15.1
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ MIT License
   - [Aggregates](guides/Aggregates.md)
     - [Example aggregate](guides/Aggregates.md#example-aggregate)
     - [`Commanded.Aggregate.Multi`](guides/Aggregates.md#using-commandedaggregatemulti-to-return-multiple-events)
+    - [Aggregate state snapshots](guides/Aggregates.md#aggregate-state-snapshots)
   - [Commands](guides/Commands.md)
     - [Command handlers](guides/Commands.md#command-handlers)
     - [Command dispatch and routing](guides/Commands.md#command-dispatch-and-routing)

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+alias Commanded.EventStore.Adapters.InMemory
+
 config :logger, :console, level: :warn, format: "[$level] $message\n"
 
 config :ex_unit,
@@ -8,7 +10,7 @@ config :ex_unit,
 
 config :commanded,
   dispatch_consistency_timeout: 100,
-  event_store_adapter: Commanded.EventStore.Adapters.InMemory,
+  event_store_adapter: InMemory,
   reset_storage: fn ->
-    {:ok, _event_store} = Commanded.EventStore.Adapters.InMemory.start_link()
+    {:ok, _event_store} = InMemory.start_link(serializer: Commanded.Serialization.JsonSerializer)
   end

--- a/guides/Aggregates.md
+++ b/guides/Aggregates.md
@@ -143,3 +143,33 @@ defmodule BankAccount do
   defp check_balance(%BankAccount{}), do: []
 end
 ```
+
+## Aggregate state snapshots
+
+A snapshot represents the aggregate state when all events to that point in time have been replayed. By default snapshotting is disabled for all aggregates.
+
+You can optionally configure state snapshotting for individual aggregates in your app configuration. Instead of loading every event for an aggregate when rebuilding its state, only the snapshot and any events appended since its creation are read.
+
+As an example, assume the snapshot was taken after persisting an event for the aggregate at version 100. When the aggregate process is restarted we load and deserialize the snapshot data as the aggregate's state. Then we fetch and replay the aggregate's events after version 100.
+
+This is a performance optimisation for aggregate's that have a long lifetime or raise a large number of events. It limits the worst case scenario when rebuilding the aggregate state: it will need to read at most this many events.
+
+The following options are configure snapshots for an aggregate:
+
+  - `snapshot_every` - snapshot aggregate state every so many events. Use
+    `nil` to disable snapshotting, or exclude the configuration entirely.
+
+  - `snapshot_version` - a non-negative integer indicating the version of
+    the aggregate state snapshot. Incrementing this version forces any
+    earlier recorded snapshots to be ignored when rebuilding aggregate
+    state.
+
+### Example
+
+In `config/config.exs` enable snapshots for `ExampleAggregate` after every ten events:
+
+```elixir
+config :commanded, ExampleAggregate
+  snapshot_every: 10,
+  snapshot_version: 1
+```

--- a/guides/Aggregates.md
+++ b/guides/Aggregates.md
@@ -4,23 +4,52 @@ Build your aggregates using standard Elixir modules and functions, with structs 
 
 An aggregate is comprised of its state, public command functions, and state mutators.
 
+## Aggregate state
+
+Use the `defstruct` keyword to define the aggregate state and fields.
+
+```elixir
+defmodule ExampleAggregate do
+  defstruct [:uuid, :name]
+end
+```
+
 ## Command functions
 
-A command function receives the aggregate's state and the command to execute. It must return the resultant domain events. This may be none, one, or multiple events.
+A command function receives the aggregate's state and the command to execute. It must return the resultant domain events. This may be none, one, or many events.
 
 For business rule violations and errors you may return an `{:error, reason}` tagged tuple or raise an exception.
 
+Name your public command functions `execute/2` to dispatch commands directly to the aggregate without requiring an intermediate command handler.
+
+```elixir
+defmodule ExampleAggregate do
+  def execute(%ExampleAggregate{uuid: nil}, %Create{uuid: uuid, name: name}) do
+    %Created{uuid: uuid, name: name}
+  end
+
+  def execute(%ExampleAggregate{}, %Create{}),
+    do: {:error, :already_created}
+end
+```
+
 ## State mutators
 
-The state of an aggregate can only be mutated by applying a raised domain event to its state. This is achieved by an `apply/2` function that receives the state and the domain event. It returns the modified state.
+The state of an aggregate can only be mutated by applying a domain event to its state. This is achieved by an `apply/2` function that receives the state and the domain event. It returns the modified state.
 
-Pattern matching is used to invoke the respective `apply/2` function for an event. These functions *must never fail* as they are used when rebuilding the aggregate state from its history of raised domain events. You cannot reject the event once it has occurred.
+Pattern matching is used to invoke the respective `apply/2` function for an event. These functions *must never fail* as they are used when rebuilding the aggregate state from its history of domain events. You cannot reject the event once it has occurred.
+
+```elixir
+defmodule ExampleAggregate do
+  def apply(%ExampleAggregate{}, %Created{uuid: uuid, name: name}) do
+    %ExampleAggregate{uuid: uuid, name: name}
+  end
+end
+```
 
 ## Example aggregate
 
-You can write your aggregate with public API functions using the language of your domain.
-
-In this bank account example, the public function to open a new account is `open_account/3`:
+You can define your aggregate with public API functions using the language of your domain. In this bank account example, the public function to open a new account is `open_account/3`:
 
 ```elixir
 defmodule BankAccount do
@@ -40,7 +69,7 @@ defmodule BankAccount do
     {:error, :initial_balance_must_be_above_zero}
   end
 
-  def open_account(%BankAccount{account_number: account_number}, account_number, _initial_balance) do
+  def open_account(%BankAccount{}, _account_number, _initial_balance) do
     {:error, :account_already_opened}
   end
 
@@ -55,9 +84,24 @@ defmodule BankAccount do
 end
 ```
 
-An alternative approach is to expose one or more public command functions, `execute/2`, and use pattern matching on the command argument. With this approach you can route your commands directly to the aggregate, without requiring a command handler module.
+With this approach you must dispatch the command to a command handler:
 
-In this case the example function matches on the `OpenAccount` command module:
+```elixir
+defmodule Commanded.ExampleDomain.OpenAccountHandler do
+  alias BankAccount
+  alias Commands.OpenAccount
+
+  @behaviour Commanded.Commands.Handler
+
+  def handle(%BankAccount{} = aggregate, %OpenAccount{account_number: account_number, initial_balance: initial_balance}) do
+    BankAccount.open_account(aggregate, account_number, initial_balance)
+  end
+end
+```
+
+An alternative approach is to expose one or more public command functions, `execute/2`, and use pattern matching on the command argument. With this approach you can route your commands directly to the aggregate.
+
+In this example the `execute/2` function pattern matches on the `OpenAccount` command module:
 
 ```elixir
 defmodule BankAccount do
@@ -77,7 +121,7 @@ defmodule BankAccount do
     {:error, :initial_balance_must_be_above_zero}
   end
 
-  def execute(%BankAccount{account_number: account_number}, %OpenAccount{account_number: account_number}) do
+  def execute(%BankAccount{}, %OpenAccount{}) do
     {:error, :account_already_opened}
   end
 
@@ -114,7 +158,7 @@ defmodule BankAccount do
 
   # public command API
 
-  def withdraw(
+  def execute(
     %BankAccount{state: :active} = account,
     %WithdrawMoney{amount: amount})
     when is_number(amount) and amount > 0
@@ -124,6 +168,14 @@ defmodule BankAccount do
     |> Multi.execute(&withdraw_money(&1, amount))
     |> Multi.execute(&check_balance/1)
   end
+
+  # state mutatators
+
+  def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}),
+    do: %BankAccount{state | balance: balance}
+
+  def apply(%BankAccount{} = state, %AccountOverdrawn{}),
+    do: %BankAccount{state | state: :overdrawn}
 
   # private helpers
 

--- a/lib/commanded/aggregates/default_lifespan.ex
+++ b/lib/commanded/aggregates/default_lifespan.ex
@@ -10,5 +10,5 @@ defmodule Commanded.Aggregates.DefaultLifespan do
   @doc """
   Aggregate will run indefinitely once started
   """
-  def after_command(_), do: :infinity
+  def after_command(_command), do: :infinity
 end

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -22,6 +22,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
       to the aggregate module. For command handlers the `:handle` function is
       used.
 
+    - `snapshot_every` - snapshot aggregate state every X events. Use `nil` to
+      disable snapshotting.
+
     - `lifespan` - a module implementing the `Commanded.Aggregates.AggregateLifespan`
       behaviour to control the aggregate instance process lifespan. The default
       value, `Commanded.Aggregates.DefaultLifespan`, keeps the process running
@@ -32,12 +35,13 @@ defmodule Commanded.Aggregates.ExecutionContext do
   alias Commanded.Aggregates.DefaultLifespan
 
   defstruct [
-    command: nil,
-    causation_id: nil,
-    correlation_id: nil,
-    metadata: %{},
-    handler: nil,
-    function: nil,
+    :command,
+    :causation_id,
+    :correlation_id,
+    :function,
+    :handler,
+    :snapshot_every,
     lifespan: DefaultLifespan,
+    metadata: %{},
   ]
 end

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -22,9 +22,6 @@ defmodule Commanded.Aggregates.ExecutionContext do
       to the aggregate module. For command handlers the `:handle` function is
       used.
 
-    - `snapshot_every` - snapshot aggregate state every X events. Use `nil` to
-      disable snapshotting.
-
     - `lifespan` - a module implementing the `Commanded.Aggregates.AggregateLifespan`
       behaviour to control the aggregate instance process lifespan. The default
       value, `Commanded.Aggregates.DefaultLifespan`, keeps the process running
@@ -40,7 +37,6 @@ defmodule Commanded.Aggregates.ExecutionContext do
     :correlation_id,
     :function,
     :handler,
-    :snapshot_every,
     lifespan: DefaultLifespan,
     metadata: %{},
   ]

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -107,36 +107,6 @@ defmodule Commanded.Commands.Router do
 
       :ok = BankRouter.dispatch(command, metadata: %{"ip_address" => "127.0.0.1"})
 
-  ## Aggregate state snapshots
-
-  A snapshot represents the aggregate state when all events to that point in
-  time have been replayed. By default snapshotting is disabled for all
-  aggregates.
-
-  You can optionally configure state snapshotting for individual aggregates in
-  the router. Instead of loading every event for an aggregate when rebuilding
-  its state, only the snapshot and any events appended since its creation are
-  read.
-
-  As an example, assume the snapshot was taken after persisting an event for the
-  aggregate at version 100. When the aggregate process is restarted we load and
-  deserialize the snapshot data as the aggregate's state. Then we fetch and
-  replay the aggregate's events after version 100.
-
-  This is a performance optimisation for aggregate's that have a long lifetime
-  or raise a large number of events.
-
-  You define how frequently snapshots must be taken by providing the `every`
-  option to the `snapshot` macro for an individual aggregate. It limits the
-  worst case scenario when rebuilding the aggregate state: it will need to read
-  at most this many events.
-
-      defmodule BankRouter do
-        use Commanded.Commands.Router
-
-        snapshot BankAccount, every: 100
-      end
-
   """
 
   defmacro __using__(_) do
@@ -149,7 +119,6 @@ defmodule Commanded.Commands.Router do
       @registered_commands []
       @registered_identities %{}
       @registered_middleware []
-      @registered_snapshots %{}
 
       @default [
         middleware: [
@@ -223,39 +192,6 @@ defmodule Commanded.Commands.Router do
 
         [by: existing_identity] ->
           raise "#{inspect unquote(aggregate_module)} aggregate has already been identified by: `#{inspect existing_identity}`"
-      end
-    end
-  end
-
-  @doc """
-  Configure an aggregate state snapshot interval.
-
-  You specify after how many events should a snapshot be recorded for an
-  individual aggregate's state. This will be used when rebuilding the state
-  instead of replaying all events from its historical event stream.
-
-  Snapshot frequency must be a positive integer.
-
-  ## Example
-
-      defmodule BankRouter do
-        use Commanded.Commands.Router
-
-        # snapshot every 100 events (100, 200, 300, 400, ...)
-        snapshot BankAccount, every: 100
-      end
-
-  """
-  defmacro snapshot(aggregate_module, every: frequency)
-    when is_integer(frequency) and frequency > 0
-  do
-    quote location: :keep do
-      case Map.get(@registered_snapshots, unquote(aggregate_module)) do
-        nil ->
-          @registered_snapshots Map.put(@registered_snapshots, unquote(aggregate_module), unquote(frequency))
-
-        _frequency ->
-          raise "#{inspect unquote(aggregate_module)} aggregate has already been configured for snapshotting"
       end
     end
   end

--- a/lib/commanded/event_store/snapshot_data.ex
+++ b/lib/commanded/event_store/snapshot_data.ex
@@ -13,11 +13,11 @@ defmodule Commanded.EventStore.SnapshotData do
   }
 
   defstruct [
-    source_uuid: nil,
-    source_version: nil,
-    source_type: nil,
-    data: nil,
-    metadata: nil,
-    created_at: nil,
+    :source_uuid,
+    :source_version,
+    :source_type,
+    :data,
+    :metadata,
+    :created_at,
   ]
 end

--- a/lib/commanded/serialization/json_serializer.ex
+++ b/lib/commanded/serialization/json_serializer.ex
@@ -16,6 +16,7 @@ defmodule Commanded.Serialization.JsonSerializer do
   @doc """
   Deserialize given JSON binary data to the expected type.
   """
+  def deserialize(binary, config \\ [])
   def deserialize(binary, config) do
     type = case Keyword.get(config, :type) do
       nil -> nil

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -1,0 +1,110 @@
+defmodule Commanded.Aggregates.SnapshottingTest do
+  use Commanded.StorageCase
+
+  alias Commanded.Aggregates.{
+    Aggregate,
+    AppendItemsHandler,
+    ExampleAggregate,
+    ExecutionContext,
+  }
+  alias Commanded.Aggregates.ExampleAggregate.Commands.AppendItems
+  alias Commanded.EventStore
+  alias Commanded.EventStore.SnapshotData
+
+  test "should not shapshot when not configured" do
+    aggregate_uuid = UUID.uuid4()
+    append_items(aggregate_uuid, 1, snapshot_every: nil)
+
+    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+  end
+
+  test "should not shapshot when set to 0" do
+    aggregate_uuid = UUID.uuid4()
+    append_items(aggregate_uuid, 1, snapshot_every: 0)
+
+    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+  end
+
+
+  test "should not shapshot when fewer snapshot interval" do
+    aggregate_uuid = UUID.uuid4()
+    append_items(aggregate_uuid, 9, snapshot_every: 10)
+
+    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+  end
+
+  test "should shapshot when exactly snapshot interval" do
+    aggregate_uuid = UUID.uuid4()
+    append_items(aggregate_uuid, 10, snapshot_every: 10)
+
+    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+    assert snapshot == %SnapshotData{
+      source_uuid: aggregate_uuid,
+      source_version: 10,
+      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+      data: %ExampleAggregate{
+        items: Enum.to_list(1..10),
+        last_index: 10,
+      },
+      metadata: nil,
+      created_at: nil,
+    }
+  end
+
+  test "should shapshot when more than snapshot interval" do
+    aggregate_uuid = UUID.uuid4()
+    append_items(aggregate_uuid, 11, snapshot_every: 10)
+
+    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+    assert snapshot == %SnapshotData{
+      source_uuid: aggregate_uuid,
+      source_version: 11,
+      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+      data: %ExampleAggregate{
+        items: Enum.to_list(1..11),
+        last_index: 11,
+      },
+      metadata: nil,
+      created_at: nil,
+    }
+  end
+
+  test "should shapshot again when interval reached" do
+    aggregate_uuid = UUID.uuid4()
+
+    append_items(aggregate_uuid, 10, snapshot_every: 10)
+    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+    assert snapshot.source_version == 10
+
+    append_items(aggregate_uuid, 1, snapshot_every: 10)
+    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+    assert snapshot.source_version == 10
+
+    append_items(aggregate_uuid, 10, snapshot_every: 10)
+
+    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+    assert snapshot == %SnapshotData{
+      source_uuid: aggregate_uuid,
+      source_version: 21,
+      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+      data: %ExampleAggregate{
+        items: Enum.to_list(1..21),
+        last_index: 21,
+      },
+      metadata: nil,
+      created_at: nil,
+    }
+  end
+
+  defp append_items(aggregate_uuid, count, snapshot_every: snapshot_every) do
+    execution_context = %ExecutionContext{
+      command: %AppendItems{count: count},
+      handler: AppendItemsHandler,
+      function: :handle,
+      snapshot_every: snapshot_every,
+    }
+
+    {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
+    {:ok, _count, _events} = Aggregate.execute(ExampleAggregate, aggregate_uuid, execution_context)
+  end
+end

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -5,95 +5,168 @@ defmodule Commanded.Aggregates.SnapshottingTest do
     Aggregate,
     AppendItemsHandler,
     ExampleAggregate,
-    ExecutionContext,
+    ExecutionContext
   }
+
   alias Commanded.Aggregates.ExampleAggregate.Commands.AppendItems
   alias Commanded.EventStore
   alias Commanded.EventStore.SnapshotData
 
-  test "should not shapshot when not configured" do
-    aggregate_uuid = UUID.uuid4()
-    append_items(aggregate_uuid, 1, snapshot_every: nil)
+  describe "take snapshot" do
+    test "should not shapshot when not configured" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 1, snapshot_every: nil)
 
-    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+      assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+    end
+
+    test "should not shapshot when set to 0" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 1, snapshot_every: 0)
+
+      assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+    end
+
+    test "should not shapshot when fewer snapshot interval" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 9, snapshot_every: 10)
+
+      assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+    end
+
+    test "should shapshot when exactly snapshot interval" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 10, snapshot_every: 10)
+
+      assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+
+      assert snapshot == %SnapshotData{
+               source_uuid: aggregate_uuid,
+               source_version: 10,
+               source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+               data: %ExampleAggregate{
+                 items: Enum.to_list(1..10),
+                 last_index: 10
+               },
+               metadata: nil,
+               created_at: nil
+             }
+    end
+
+    test "should shapshot when more than snapshot interval" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 11, snapshot_every: 10)
+
+      assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+
+      assert snapshot == %SnapshotData{
+               source_uuid: aggregate_uuid,
+               source_version: 11,
+               source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+               data: %ExampleAggregate{
+                 items: Enum.to_list(1..11),
+                 last_index: 11
+               },
+               metadata: nil,
+               created_at: nil
+             }
+    end
+
+    test "should shapshot again when interval reached" do
+      aggregate_uuid = UUID.uuid4()
+
+      append_items(aggregate_uuid, 10, snapshot_every: 10)
+      assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+      assert snapshot.source_version == 10
+
+      append_items(aggregate_uuid, 1, snapshot_every: 10)
+      assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+      assert snapshot.source_version == 10
+
+      append_items(aggregate_uuid, 10, snapshot_every: 10)
+
+      assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
+
+      assert snapshot == %SnapshotData{
+         source_uuid: aggregate_uuid,
+         source_version: 21,
+         source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
+         data: %ExampleAggregate{
+           items: Enum.to_list(1..21),
+           last_index: 21
+         },
+         metadata: nil,
+         created_at: nil
+       }
+    end
   end
 
-  test "should not shapshot when set to 0" do
-    aggregate_uuid = UUID.uuid4()
-    append_items(aggregate_uuid, 1, snapshot_every: 0)
+  describe "restore snapshot" do
+    test "should restore state from events when no snapshot" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 1, snapshot_every: 10)
+      restart_aggregate(aggregate_uuid)
 
-    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+      assert_aggregate_state aggregate_uuid, %ExampleAggregate{
+        items: [1],
+        last_index: 1
+      }
+      assert_aggregate_version aggregate_uuid, 1
+    end
+
+    test "should restore state from snapshot when present" do
+      aggregate_uuid = UUID.uuid4()
+      append_items(aggregate_uuid, 2, snapshot_every: 10)
+
+      # record our own snapshot
+      snapshot_aggregate(aggregate_uuid, 2, %ExampleAggregate{
+        items: [],
+      })
+
+      restart_aggregate(aggregate_uuid)
+
+      assert_aggregate_state aggregate_uuid, %ExampleAggregate{
+        items: [],
+      }
+      assert_aggregate_version aggregate_uuid, 2
+    end
+
+    test "should restore state from snapshot and any newer events when present" do
+      aggregate_uuid = UUID.uuid4()
+
+      append_items(aggregate_uuid, 5, snapshot_every: 10)
+
+      # record our own snapshot
+      snapshot_aggregate(aggregate_uuid, 2, %ExampleAggregate{
+        items: [],
+        last_index: 2
+      })
+
+      restart_aggregate(aggregate_uuid)
+
+      assert_aggregate_state aggregate_uuid, %ExampleAggregate{
+        items: [3, 4, 5],
+        last_index: 5
+      }
+      assert_aggregate_version aggregate_uuid, 5
+    end
   end
 
-
-  test "should not shapshot when fewer snapshot interval" do
-    aggregate_uuid = UUID.uuid4()
-    append_items(aggregate_uuid, 9, snapshot_every: 10)
-
-    assert EventStore.read_snapshot(aggregate_uuid) == {:error, :snapshot_not_found}
+  # assert aggregate's state equals the given expected state
+  defp assert_aggregate_state(aggregate_uuid, expected_state) do
+    assert Aggregate.aggregate_state(ExampleAggregate, aggregate_uuid) == expected_state
   end
 
-  test "should shapshot when exactly snapshot interval" do
-    aggregate_uuid = UUID.uuid4()
-    append_items(aggregate_uuid, 10, snapshot_every: 10)
-
-    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
-    assert snapshot == %SnapshotData{
-      source_uuid: aggregate_uuid,
-      source_version: 10,
-      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
-      data: %ExampleAggregate{
-        items: Enum.to_list(1..10),
-        last_index: 10,
-      },
-      metadata: nil,
-      created_at: nil,
-    }
+  # assert aggregate's version equals the given expected version
+  defp assert_aggregate_version(aggregate_uuid, expected_version) do
+    assert Aggregate.aggregate_version(ExampleAggregate, aggregate_uuid) == expected_version
   end
 
-  test "should shapshot when more than snapshot interval" do
-    aggregate_uuid = UUID.uuid4()
-    append_items(aggregate_uuid, 11, snapshot_every: 10)
+  # restart the aggregate process
+  defp restart_aggregate(aggregate_uuid) do
+    assert :ok = Aggregate.shutdown(ExampleAggregate, aggregate_uuid)
 
-    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
-    assert snapshot == %SnapshotData{
-      source_uuid: aggregate_uuid,
-      source_version: 11,
-      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
-      data: %ExampleAggregate{
-        items: Enum.to_list(1..11),
-        last_index: 11,
-      },
-      metadata: nil,
-      created_at: nil,
-    }
-  end
-
-  test "should shapshot again when interval reached" do
-    aggregate_uuid = UUID.uuid4()
-
-    append_items(aggregate_uuid, 10, snapshot_every: 10)
-    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
-    assert snapshot.source_version == 10
-
-    append_items(aggregate_uuid, 1, snapshot_every: 10)
-    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
-    assert snapshot.source_version == 10
-
-    append_items(aggregate_uuid, 10, snapshot_every: 10)
-
-    assert {:ok, snapshot} = EventStore.read_snapshot(aggregate_uuid)
-    assert snapshot == %SnapshotData{
-      source_uuid: aggregate_uuid,
-      source_version: 21,
-      source_type: "Elixir.Commanded.Aggregates.ExampleAggregate",
-      data: %ExampleAggregate{
-        items: Enum.to_list(1..21),
-        last_index: 21,
-      },
-      metadata: nil,
-      created_at: nil,
-    }
+    assert {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
   end
 
   defp append_items(aggregate_uuid, count, snapshot_every: snapshot_every) do
@@ -101,10 +174,22 @@ defmodule Commanded.Aggregates.SnapshottingTest do
       command: %AppendItems{count: count},
       handler: AppendItemsHandler,
       function: :handle,
-      snapshot_every: snapshot_every,
+      snapshot_every: snapshot_every
     }
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
+
     {:ok, _count, _events} = Aggregate.execute(ExampleAggregate, aggregate_uuid, execution_context)
+  end
+
+  defp snapshot_aggregate(aggregate_uuid, aggregate_version, aggregate_state) do
+    snapshot = %SnapshotData{
+      source_uuid: aggregate_uuid,
+      source_version: aggregate_version,
+      source_type: Atom.to_string(aggregate_state.__struct__),
+      data: aggregate_state,
+    }
+
+    :ok = Commanded.EventStore.record_snapshot(snapshot)
   end
 end

--- a/test/aggregates/support/snapshot_aggregate.ex
+++ b/test/aggregates/support/snapshot_aggregate.ex
@@ -1,0 +1,51 @@
+defmodule Commanded.Aggregates.SnapshotAggregate do
+  @moduledoc false
+  defstruct [
+    :name,
+    :date,
+  ]
+
+  defmodule Commands do
+    defmodule Create, do: defstruct [:name, :date]
+  end
+
+  defmodule Events do
+    defmodule Created, do: defstruct [:name, :date]
+  end
+
+  alias Commanded.Aggregates.SnapshotAggregate
+  alias Commands.Create
+  alias Events.Created
+
+  def execute(
+    %SnapshotAggregate{name: nil},
+    %Create{name: name, date: date})
+  do
+    %Created{name: name, date: date}
+  end
+
+  # state mutatators
+
+  def apply(
+    %SnapshotAggregate{} = state,
+    %Created{name: name, date: date})
+  do
+    %SnapshotAggregate{state |
+      name: name,
+      date: date
+    }
+  end
+end
+
+alias Commanded.Aggregates.SnapshotAggregate
+
+defimpl Commanded.Serialization.JsonDecoder, for: SnapshotAggregate do
+  @doc """
+  Parse the date included in the aggregate state
+  """
+  def decode(%SnapshotAggregate{date: date} = state) do
+    %SnapshotAggregate{state |
+      date: NaiveDateTime.from_iso8601!(date)
+    }
+  end
+end


### PR DESCRIPTION
Allow per aggregate snapshotting to be configured within your app config (e.g. `config/config.exs`). You can define how frequently snapshots should be taken (after every x events) and an optional snapshot version.

### Example

```elixir
# config/config.exs

config :commanded, ExampleAggregate
  snapshot_every: 100,
  snapshot_version: 1
```

Incrementing the snapshot version will ignore any existing snapshot taken at an earlier version during aggregate state rebuild. This allows you to change the aggregate structure without requiring a snapshot data migration.
 
Fixes #27.
  