### PR TITLE
Feature: Process manager state on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support composite command routers ([#111](https://github.com/commanded/commanded/pull/111)).
 - Aggregate state snapshots ([#121](https://github.com/commanded/commanded/pull/121)).
+- New `error/3` callback for process manager and deprecated `error/4` ([#124](https://github.com/commanded/commanded/pull/124))
 
 ## v0.15.1
 

--- a/guides/Process Managers.md
+++ b/guides/Process Managers.md
@@ -25,11 +25,11 @@ The `apply/2` function is used to mutate the process manager's state. It receive
 
 This callback function is optional, the default behaviour is to retain the process manager's current state.
 
-## `error/4`
+## `error/3`
 
-You can define an `error/4` callback function to handle any errors returned from command dispatch. The function is passed the command dispatch error (e.g. `{:error, :failure}`), the failed command, any pending commands, and a context map containing state passed between retries. Use pattern matching on the error and/or failed command to explicitly handle certain errors or commands.
+You can define an `error/3` callback function to handle any errors returned from command dispatch. The function is passed the command dispatch error (e.g. `{:error, :failure}`), the failed command, and a failure context. The failure context contains the process manager state, the last received event (which triggered the command that failed), all the pending commands and a context map (which contains a state that is passed between retries). Use pattern matching on the error and/or failed command to explicitly handle certain errors or commands.
 
-The `error/4` callback function must return one of the following responses depending upon the severity of error and how you choose to handle it:
+The `error/3` callback function must return one of the following responses depending upon the severity of error and how you choose to handle it:
 
 - `{:retry, context}` - retry the failed command, provide a context map containing any state passed to subsequent failures. This could be used to count the number of retries, failing after too many attempts.
 
@@ -42,6 +42,13 @@ The `error/4` callback function must return one of the following responses depen
 - `{:continue, commands, context}` - continue dispatching the given commands. This allows you to retry the failed command, modify it and retry, drop it, or drop all pending commands by passing an empty list `[]`.
 
 - `{:stop, reason}` - stop the process manager with the given reason.
+
+## Deprecated: `error/4`
+
+**WARNING: This will be removed in future versions.**
+
+If you received a warning `Process manager *** defined error/4 callback. This is deprecated in favor of error/3` it means one of your process managers implements the old `error/4` callback.
+That old version receives only the dispatch error, the failed command, the pending commands and the context map. You should change your implementation to the `error/3` callback instead.
 
 ### Error handling example
 

--- a/lib/commanded/process_managers/failure_context.ex
+++ b/lib/commanded/process_managers/failure_context.ex
@@ -1,0 +1,28 @@
+defmodule Commanded.ProcessManagers.FailureContext do
+  @moduledoc """
+  Contains the data related to a failure.
+
+  The available fields are:
+
+  - `pending_commands` - the pending commands that were not executed yet
+  - `process_manager_state` - the state the process manager would be in
+    if the command would not fail.
+  - `last_event` - the last event the process manager received
+  - `context` - the context of failures (to be passed between each failure),
+    used in example to count retries.
+  """
+
+  @type t :: %__MODULE__{
+    pending_commands: [struct()],
+    process_manager_state: struct(),
+    last_event: struct(),
+    context: map()
+  }
+
+  defstruct [
+    pending_commands: nil,
+    process_manager_state: nil,
+    last_event: nil,
+    context: nil
+  ]
+end

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -255,6 +255,11 @@ defmodule Commanded.ProcessManagers.ProcessManager do
       def apply(process_manager, _event), do: process_manager
 
       @doc false
+      def error({:error, reason}, failed, %{pending_commands: pending, context: context}) do
+        error({:error, reason}, failed, pending, context)
+      end
+
+      @doc false
       def error({:error, reason}, _failed_command, _pending_commands, _context),
         do: {:stop, reason}
     end

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -283,6 +283,6 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   end
 
   defp error_deprecation_message(mod) do
-    "Commanded Deprecation Warning:\nProcess manager #{mod} defined error/4 callback.\nThis is deprecated in favor of error/3"
+    "Commanded Deprecation Warning:\nProcess manager #{mod} defined error/4 callback.\nThis is deprecated in favor of error/3\nSee https://github.com/commanded/commanded/blob/master/guides/Process%20Managers.md#deprecated-error4"
   end
 end

--- a/test/process_managers/process_manager_error_handling_state_test.exs
+++ b/test/process_managers/process_manager_error_handling_state_test.exs
@@ -1,0 +1,26 @@
+defmodule Commanded.ProcessManager.ProcessManagerErrorHandlingStateTest do
+  use Commanded.StorageCase
+
+  alias Commanded.ProcessManagers.{
+    StateErrorHandlingProcessManager,
+    ErrorRouter,
+  }
+  alias Commanded.ProcessManagers.ErrorAggregate.Commands.StartProcess
+
+  @tag :bamorim
+  test "should receive the aggregate state in the context" do
+    process_uuid = UUID.uuid4()
+    command = %StartProcess{
+      process_uuid: process_uuid,
+      reply_to: reply_to(),
+    }
+
+    {:ok, _process_router} = StateErrorHandlingProcessManager.start_link()
+
+    assert :ok = ErrorRouter.dispatch(command)
+
+    assert_receive :got_from_context
+  end
+
+  defp reply_to, do: self() |> :erlang.pid_to_list()
+end

--- a/test/process_managers/support/error/context_error_handling_process_manager.ex
+++ b/test/process_managers/support/error/context_error_handling_process_manager.ex
@@ -1,0 +1,36 @@
+defmodule Commanded.ProcessManagers.StateErrorHandlingProcessManager do
+  @moduledoc false
+
+  alias Commanded.ProcessManagers.{
+    StateErrorHandlingProcessManager,
+    ExampleRouter,
+  }
+  alias Commanded.ProcessManagers.ErrorAggregate.Commands.{
+    AttemptProcess,
+  }
+  alias Commanded.ProcessManagers.ErrorAggregate.Events.{
+    ProcessStarted,
+  }
+
+  use Commanded.ProcessManagers.ProcessManager,
+    name: "StateErrorHandlingProcessManager",
+    router: ExampleRouter
+
+  defstruct [:process_uuid, :reply_to]
+
+  def interested?(%ProcessStarted{process_uuid: process_uuid}), do: {:start, process_uuid}
+
+  def handle(%StateErrorHandlingProcessManager{}, %ProcessStarted{process_uuid: process_uuid}) do
+    %AttemptProcess{process_uuid: process_uuid}
+  end
+
+  def apply(_, %ProcessStarted{reply_to: reply_to, process_uuid: process_uuid}) do
+    %StateErrorHandlingProcessManager{reply_to: reply_to, process_uuid: process_uuid}
+  end
+
+  def error(_, _, failure_context) do
+    %{process_manager_state: %{reply_to: reply_to}} = failure_context
+    send(:erlang.list_to_pid(reply_to), :got_from_context)
+    {:stop, :stopping}
+  end
+end


### PR DESCRIPTION
This adds a new callback (error/3) for process managers and adds a compile-time warning for those who defines as error/4 to know they have to change.

This is to solve the problem pointed by #123 

Some things that are missing (maybe can be done after this is merged, I'll take a look later, have to go now):
- Add documentation to that
- Reference to a link telling how to change the behaviour in the warning
- Backwards compatibility test? I'm not sure about this and how deep we should test this.

How do we organize these breaking changes to add to a changelog later?

Anyway, what do you think? Is it looking good?

Cheers