### PR TITLE
fix: use IO.warn for compile time warning

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -274,7 +274,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
         if Module.defines?(mod, {name, arity}) do
           mod
           |> error_deprecation_message
-          |> :elixir_errors.warn
+          |> IO.warn
         end
       _ ->
 


### PR DESCRIPTION
This fixes #130 

Sorry about that. I was messing with elixir internals (`:elixir_errors.warn/1`) for compile time warnings and that was removed in Elixir 1.6.0.
I'm now using the public api `IO.warn/1`.