### PR TITLE
Retry command execution on concurrency error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Aggregate state snapshots ([#121](https://github.com/commanded/commanded/pull/121)).
 - New `error/3` callback for process manager and deprecated `error/4` ([#124](https://github.com/commanded/commanded/pull/124))
 - Router support for identity prefix function.
+- Retry command execution on concurrency error ([#132](https://github.com/commanded/commanded/pull/132)).
 
 ## v0.15.1
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 alias Commanded.EventStore.Adapters.InMemory
+alias Commanded.Serialization.JsonSerializer
 
 config :logger, :console, level: :warn, format: "[$level] $message\n"
 
@@ -12,5 +13,5 @@ config :commanded,
   dispatch_consistency_timeout: 100,
   event_store_adapter: InMemory,
   reset_storage: fn ->
-    {:ok, _event_store} = InMemory.start_link(serializer: Commanded.Serialization.JsonSerializer)
+    {:ok, _event_store} = InMemory.start_link(serializer: JsonSerializer)
   end

--- a/lib/commanded/aggregates/aggregate_inspect.ex
+++ b/lib/commanded/aggregates/aggregate_inspect.ex
@@ -1,0 +1,15 @@
+alias Commanded.Aggregates.Aggregate
+
+defimpl Inspect, for: Aggregate do
+  import Inspect.Algebra
+
+  def inspect(%Aggregate{} = aggregate, opts) do
+    %Aggregate{
+      aggregate_module: aggregate_module,
+      aggregate_uuid: aggregate_uuid,
+      aggregate_version: aggregate_version
+    } = aggregate
+
+    concat(["#", to_doc(aggregate_module, opts), "<#{aggregate_uuid}@#{aggregate_version}>"])
+  end
+end

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -7,6 +7,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
     - `command` - the command to execute, typically a struct
       (e.g. `%OpenBankAccount{...}`).
 
+    - `retry_attempts` - the number of retries permitted if an
+      `{:error, :wrong_expected_version}` is encountered when appending events.
+
     - `causation_id` - the UUID assigned to the dispatched command.
 
     - `correlation_id` - a UUID used to correlate related commands/events.
@@ -33,6 +36,7 @@ defmodule Commanded.Aggregates.ExecutionContext do
 
   defstruct [
     :command,
+    :retry_attempts,
     :causation_id,
     :correlation_id,
     :function,

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -27,6 +27,7 @@ defmodule Commanded.Commands.Dispatcher do
       lifespan: nil,
       metadata: nil,
       middleware: [],
+      retry_attempts: nil
     ]
   end
 
@@ -96,10 +97,21 @@ defmodule Commanded.Commands.Dispatcher do
      end
   end
 
-  defp to_execution_context(
-    %Pipeline{command: command, command_uuid: command_uuid, metadata: metadata},
-    %Payload{correlation_id: correlation_id, handler_module: handler_module, handler_function: handler_function, lifespan: lifespan})
-  do
+  defp to_execution_context(%Pipeline{} = pipeline, %Payload{} = payload) do
+    %Pipeline{
+      command: command,
+      command_uuid: command_uuid,
+      metadata: metadata
+    } = pipeline
+
+    %Payload{
+      correlation_id: correlation_id,
+      handler_module: handler_module,
+      handler_function: handler_function,
+      lifespan: lifespan,
+      retry_attempts: retry_attempts
+    } = payload
+
     %ExecutionContext{
       command: command,
       causation_id: command_uuid,
@@ -108,6 +120,7 @@ defmodule Commanded.Commands.Dispatcher do
       handler: handler_module,
       function: handler_function,
       lifespan: lifespan,
+      retry_attempts: retry_attempts
     }
   end
 


### PR DESCRIPTION
Retry executing a command if appending events to the aggregate's stream fails with an `{:error, :wrong_expected_version}` concurrency error. The missing event(s) are fetched from the event store to update the aggregate state and attempt the command again.

Aggregate instances are singletons when run on a single node, or cluster if using the distributed registry, so should not fail with this error. However, the change allows Commanded to work when run on multiple nodes that are not connected to form a cluster.