### PR TITLE
Support distributed dispatch consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Router support for identity prefix function.
 - Retry command execution on concurrency error ([#132](https://github.com/commanded/commanded/pull/132)).
 - Event handler `error/3` callback ([#133](https://github.com/commanded/commanded/pull/133)).
+- Support distributed dispatch consistency ([#135](https://github.com/commanded/commanded/pull/135)).
 
 ## v0.15.1
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -1,6 +1,6 @@
 defmodule Commanded.Commands.Dispatcher do
   @moduledoc false
-  use GenServer
+
   require Logger
 
   alias Commanded.Aggregates
@@ -10,6 +10,7 @@ defmodule Commanded.Commands.Dispatcher do
 
   defmodule Payload do
     @moduledoc false
+
     defstruct [
       command: nil,
       command_uuid: nil,

--- a/lib/commanded/pubsub.ex
+++ b/lib/commanded/pubsub.ex
@@ -3,8 +3,6 @@ defmodule Commanded.PubSub do
   Pub/sub behaviour for use by Commanded to subcribe to and broadcast messages.
   """
 
-  @behaviour Commanded.PubSub
-
   @doc """
   Return an optional supervisor spec for pub/sub.
   """
@@ -87,7 +85,7 @@ defmodule Commanded.PubSub do
             nil ->
               raise "Unsupported pubsub adapter: #{inspect(config)}"
 
-            phoenix_pubsub ->
+            _phoenix_pubsub ->
               Commanded.PubSub.PhoenixPubSub
           end
         else

--- a/lib/commanded/pubsub.ex
+++ b/lib/commanded/pubsub.ex
@@ -1,0 +1,81 @@
+defmodule Commanded.PubSub do
+  @moduledoc """
+  Pub/sub behaviour for use by Commanded to subcribe to and broadcast messages.
+  """
+
+  @behaviour Commanded.PubSub
+
+  @doc """
+  Return an optional supervisor spec for pub/sub.
+  """
+  @callback child_spec() :: [:supervisor.child_spec()]
+
+  @doc """
+  Subscribes the caller to the PubSub adapter's topic.
+  """
+  @callback subscribe(atom) :: :ok | {:error, term}
+
+  @doc """
+  Broadcasts message on given topic.
+
+    * `topic` - The topic to broadcast to, ie: `"users:123"`
+    * `message` - The payload of the broadcast
+
+  """
+  @callback broadcast(String.t, term) :: :ok | {:error, term}
+
+  @doc """
+  Track the current process under the given `topic`, uniquely identified by
+  `key`.
+  """
+  @callback track(String.t, term) :: :ok | {:error, term}
+
+  @doc """
+  List tracked PIDs for a given topic.
+  """
+  @callback list(String.t) :: [{term, pid}]
+
+  @doc """
+  Return an optional supervisor spec for pub/sub.
+  """
+  @spec child_spec() :: [:supervisor.child_spec()]
+  def child_spec, do: pubsub_provider().child_spec()
+
+  @doc """
+  Subscribes the caller to the PubSub adapter's topic.
+  """
+  @callback subscribe(atom) :: :ok | {:error, term}
+  def subscribe(topic), do: pubsub_provider().subscribe(topic)
+
+  @doc """
+  Broadcasts message on given topic.
+  """
+  @callback broadcast(String.t, term) :: :ok | {:error, term}
+  def broadcast(topic, message), do: pubsub_provider().broadcast(topic, message)
+
+  @doc """
+  Track the current process under the given `topic`, uniquely identified by
+  `key`.
+  """
+  @spec track(String.t, term) :: :ok
+  def track(topic, key), do: pubsub_provider().track(topic, key)
+
+  @doc """
+  List tracked PIDs for a given topic.
+  """
+  @spec list(String.t) :: [{term, pid}]
+  def list(topic), do: pubsub_provider().list(topic)
+
+  @doc """
+  Get the configured pub/sub adapter.
+
+  Defaults to a local pub/sub, restricted to running on a single node.
+  """
+  @spec pubsub_provider() :: module()
+  def pubsub_provider do
+    case Application.get_env(:commanded, :pubsub, :local) do
+      :local -> Commanded.PubSub.LocalRegistry
+      other -> other
+    end
+  end
+end

--- a/lib/commanded/pubsub/local_pubsub.ex
+++ b/lib/commanded/pubsub/local_pubsub.ex
@@ -1,7 +1,14 @@
-defmodule Commanded.PubSub.LocalRegistry do
+defmodule Commanded.PubSub.LocalPubSub do
   @moduledoc """
   Local pub/sub adapter, restricted to a single node, using Elixir's
   [Registry](https://hexdocs.pm/elixir/Registry.html) module.
+
+  You can configure this adapter in your environment config file:
+
+      # `config/config.exs`
+      config :commanded, pubsub: :local
+
+  This adapter will be used by default when none is specified in config.
   """
 
   @behaviour Commanded.PubSub
@@ -20,9 +27,9 @@ defmodule Commanded.PubSub.LocalRegistry do
   @doc """
   Subscribes the caller to the topic.
   """
-  @spec subscribe(atom) :: :ok | {:error, term}
+  @spec subscribe(String.t()) :: :ok | {:error, term}
   @impl Commanded.PubSub
-  def subscribe(topic) do
+  def subscribe(topic) when is_binary(topic) do
     {:ok, _} = Registry.register(__MODULE__, topic, [])
     :ok
   end
@@ -32,7 +39,7 @@ defmodule Commanded.PubSub.LocalRegistry do
   """
   @spec broadcast(String.t(), term) :: :ok | {:error, term}
   @impl Commanded.PubSub
-  def broadcast(topic, message) do
+  def broadcast(topic, message) when is_binary(topic) do
     Registry.dispatch(__MODULE__, topic, fn entries ->
       for {pid, _} <- entries, do: send(pid, message)
     end)
@@ -44,7 +51,7 @@ defmodule Commanded.PubSub.LocalRegistry do
   """
   @spec track(String.t(), term) :: :ok
   @impl Commanded.PubSub
-  def track(topic, key) do
+  def track(topic, key) when is_binary(topic) do
     {:ok, _} = Registry.register(__MODULE__, topic, key)
 
     :ok
@@ -55,7 +62,7 @@ defmodule Commanded.PubSub.LocalRegistry do
   """
   @spec list(String.t()) :: [{term, pid}]
   @impl Commanded.PubSub
-  def list(topic) do
+  def list(topic) when is_binary(topic) do
     Registry.match(__MODULE__, topic, :_) |> Enum.map(fn {pid, key} -> {key, pid} end)
   end
 end

--- a/lib/commanded/pubsub/local_pubsub.ex
+++ b/lib/commanded/pubsub/local_pubsub.ex
@@ -1,0 +1,61 @@
+defmodule Commanded.PubSub.LocalRegistry do
+  @moduledoc """
+  Local pub/sub adapter, restricted to a single node, using Elixir's
+  [Registry](https://hexdocs.pm/elixir/Registry.html) module.
+  """
+
+  @behaviour Commanded.PubSub
+
+  @doc """
+  Start a `Registry` for local pub/sub.
+  """
+  @spec child_spec() :: [:supervisor.child_spec()]
+  @impl Commanded.PubSub
+  def child_spec do
+    [
+      {Registry, keys: :duplicate, name: __MODULE__, partitions: System.schedulers_online()}
+    ]
+  end
+
+  @doc """
+  Subscribes the caller to the topic.
+  """
+  @spec subscribe(atom) :: :ok | {:error, term}
+  @impl Commanded.PubSub
+  def subscribe(topic) do
+    {:ok, _} = Registry.register(__MODULE__, topic, [])
+    :ok
+  end
+
+  @doc """
+  Broadcasts message on given topic.
+  """
+  @spec broadcast(String.t(), term) :: :ok | {:error, term}
+  @impl Commanded.PubSub
+  def broadcast(topic, message) do
+    Registry.dispatch(__MODULE__, topic, fn entries ->
+      for {pid, _} <- entries, do: send(pid, message)
+    end)
+  end
+
+  @doc """
+  Track the current process under the given `topic`, uniquely identified by
+  `key`.
+  """
+  @spec track(String.t(), term) :: :ok
+  @impl Commanded.PubSub
+  def track(topic, key) do
+    {:ok, _} = Registry.register(__MODULE__, topic, key)
+
+    :ok
+  end
+
+  @doc """
+  List tracked terms and associated PIDs for a given topic.
+  """
+  @spec list(String.t()) :: [{term, pid}]
+  @impl Commanded.PubSub
+  def list(topic) do
+    Registry.match(__MODULE__, topic, :_) |> Enum.map(fn {pid, key} -> {key, pid} end)
+  end
+end

--- a/lib/commanded/pubsub/phoenix_pubsub.ex
+++ b/lib/commanded/pubsub/phoenix_pubsub.ex
@@ -1,0 +1,112 @@
+defmodule Commanded.PubSub.PhoenixPubSub do
+  @moduledoc """
+  Pub/sub adapter using Phoenix's distributed pub/sub and presence platform [1].
+
+  [1] https://hex.pm/packages/phoenix_pubsub
+
+  You must configure this adapter in your environment config file:
+
+      # `config/config.exs`
+      config :commanded, pubsub: [
+        phoenix_pubsub: [
+          adapter: Phoenix.PubSub.PG2,
+          pool_size: 1
+        ]
+      ]
+
+  Specify the Phoenix pub/sub adapter you wish to use from:
+
+    * `Phoenix.PubSub.PG2` - uses Distributed Elixir, directly exchanging
+      notifications between servers
+
+    * `Phoenix.PubSub.Redis` - uses Redis to exchange data between servers
+
+  """
+
+  @behaviour Commanded.PubSub
+
+  alias Phoenix.PubSub
+
+  defmodule Tracker do
+    @behaviour Phoenix.Tracker
+
+    def start_link(opts) do
+      opts = Keyword.merge([name: __MODULE__], opts)
+      GenServer.start_link(Phoenix.Tracker, [__MODULE__, opts, opts], name: __MODULE__)
+    end
+
+    def init(opts) do
+      server = Keyword.fetch!(opts, :pubsub_server)
+      {:ok, %{pubsub_server: server, node_name: Phoenix.PubSub.node_name(server)}}
+    end
+
+    def handle_diff(_diff, state) do
+      {:ok, state}
+    end
+  end
+
+  @doc """
+  Start a `Registry` for local pub/sub.
+  """
+  @spec child_spec() :: [:supervisor.child_spec()]
+  @impl Commanded.PubSub
+  def child_spec do
+    phoenix_pubsub_config =
+      Application.get_env(:commanded, :pubsub)
+      |> Keyword.get(:phoenix_pubsub)
+      |> Keyword.put(:name, __MODULE__)
+
+    {adapter, phoenix_pubsub_config} = Keyword.pop(phoenix_pubsub_config, :adapter)
+
+    [
+      %{
+        id: adapter,
+        start: {adapter, :start_link, [__MODULE__, phoenix_pubsub_config]},
+        type: :supervisor
+      },
+      %{
+        id: Tracker,
+        start: {Tracker, :start_link, [[pubsub_server: __MODULE__]]},
+        type: :worker
+      }
+    ]
+  end
+
+  @doc """
+  Subscribes the caller to the topic.
+  """
+  @spec subscribe(atom) :: :ok | {:error, term}
+  @impl Commanded.PubSub
+  def subscribe(topic) when is_binary(topic) do
+    PubSub.subscribe(__MODULE__, topic)
+  end
+
+  @doc """
+  Broadcasts message on given topic.
+  """
+  @spec broadcast(String.t(), term) :: :ok | {:error, term}
+  @impl Commanded.PubSub
+  def broadcast(topic, message) when is_binary(topic) do
+    PubSub.broadcast(__MODULE__, topic, message)
+  end
+
+  @doc """
+  Track the current process under the given `topic`, uniquely identified by
+  `key`.
+  """
+  @spec track(String.t(), term) :: :ok
+  @impl Commanded.PubSub
+  def track(topic, key) when is_binary(topic) do
+    {:ok, _ref} = Phoenix.Tracker.track(Tracker, self(), topic, key, %{pid: self()})
+    :ok
+  end
+
+  @doc """
+  List tracked terms and associated PIDs for a given topic.
+  """
+  @spec list(String.t()) :: [{term, pid}]
+  @impl Commanded.PubSub
+  def list(topic) when is_binary(topic) do
+    Phoenix.Tracker.list(Tracker, topic) |> Enum.map(fn {key, %{pid: pid}} -> {key, pid} end)
+  end
+end

--- a/lib/commanded/pubsub/phoenix_pubsub.ex
+++ b/lib/commanded/pubsub/phoenix_pubsub.ex
@@ -4,7 +4,17 @@ defmodule Commanded.PubSub.PhoenixPubSub do
 
   [1] https://hex.pm/packages/phoenix_pubsub
 
-  You must configure this adapter in your environment config file:
+  To use Phoenix pub/sub you must add it as a dependency in your project's
+  `mix.exs` file:
+
+      defp deps do
+        [
+          {:phoenix_pubsub, "~> 1.0"}
+        ]
+      end
+
+  Fetch mix deps and configure the pubsub settings in your environment config
+  file:
 
       # `config/config.exs`
       config :commanded, pubsub: [

--- a/lib/commanded/supervisor.ex
+++ b/lib/commanded/supervisor.ex
@@ -2,18 +2,20 @@ defmodule Commanded.Supervisor do
   @moduledoc false
   use Supervisor
 
-  alias Commanded.Registration
+  alias Commanded.{PubSub, Registration}
 
   def start_link do
     Supervisor.start_link(__MODULE__, [])
   end
 
   def init(_) do
-    children = [
-      {Task.Supervisor, name: Commanded.Commands.TaskDispatcher},
-      {Commanded.Aggregates.Supervisor, []},
-      {Commanded.Subscriptions, []},
-    ] ++ Registration.child_spec()
+    children =
+      Registration.child_spec() ++ PubSub.child_spec() ++
+      [
+        {Task.Supervisor, name: Commanded.Commands.TaskDispatcher},
+        {Commanded.Aggregates.Supervisor, []},
+        {Commanded.Subscriptions, []}
+      ]
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,9 @@ defmodule Commanded.Mixfile do
       {:mix_test_watch, "~> 0.5", only: :dev},
       {:poison, "~> 3.1"},
       {:uuid, "~> 1.1"},
+
+      # optional deps
+      {:phoenix_pubsub, "~> 1.0", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,6 @@
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"}}

--- a/test/commands/support/open_account_bonus_handler.ex
+++ b/test/commands/support/open_account_bonus_handler.ex
@@ -17,7 +17,7 @@ defmodule Commanded.Commands.OpenAccountBonusHandler do
 
     BankRouter.dispatch(deposit_welcome_bonus,
       causation_id: causation_id,
-      correlation_id: correlation_id,
+      correlation_id: correlation_id
     )
   end
 end

--- a/test/pubsub/local_pubsub_test.exs
+++ b/test/pubsub/local_pubsub_test.exs
@@ -1,0 +1,23 @@
+defmodule Commanded.PubSub.LocalPubSubTest do
+  use ExUnit.Case
+
+  alias Commanded.PubSub.LocalRegistry
+
+  describe "pub/sub" do
+    test "should receive broadcast message" do
+      assert :ok = LocalRegistry.subscribe(:test)
+      assert :ok = LocalRegistry.broadcast(:test, :message)
+
+      assert_receive(:message)
+    end
+  end
+
+  describe "tracker" do
+    test "should list tracked processes" do
+      self = self()
+
+      assert :ok = LocalRegistry.track(:test, :example)
+      assert [{:example, ^self}] = LocalRegistry.list(:test)
+    end
+  end
+end

--- a/test/pubsub/local_pubsub_test.exs
+++ b/test/pubsub/local_pubsub_test.exs
@@ -1,12 +1,22 @@
 defmodule Commanded.PubSub.LocalPubSubTest do
   use ExUnit.Case
 
-  alias Commanded.PubSub.LocalRegistry
+  alias Commanded.PubSub.LocalPubSub
+
+  @topic "test"
+
+  setup do
+    Application.put_env(:commanded, :pubsub, :local)
+
+    on_exit(fn ->
+      Application.delete_env(:commanded, :pubsub)
+    end)
+  end
 
   describe "pub/sub" do
     test "should receive broadcast message" do
-      assert :ok = LocalRegistry.subscribe(:test)
-      assert :ok = LocalRegistry.broadcast(:test, :message)
+      assert :ok = LocalPubSub.subscribe(@topic)
+      assert :ok = LocalPubSub.broadcast(@topic, :message)
 
       assert_receive(:message)
     end
@@ -16,8 +26,8 @@ defmodule Commanded.PubSub.LocalPubSubTest do
     test "should list tracked processes" do
       self = self()
 
-      assert :ok = LocalRegistry.track(:test, :example)
-      assert [{:example, ^self}] = LocalRegistry.list(:test)
+      assert :ok = LocalPubSub.track(@topic, :example)
+      assert [{:example, ^self}] = LocalPubSub.list(@topic)
     end
   end
 end

--- a/test/pubsub/phoenix_pubsub_test.exs
+++ b/test/pubsub/phoenix_pubsub_test.exs
@@ -1,0 +1,47 @@
+defmodule Commanded.PubSub.PhoenixPubSubTest do
+  use ExUnit.Case
+
+  alias Commanded.PubSub.PhoenixPubSub
+  alias Commanded.Helpers.ProcessHelper
+
+  @topic "test"
+
+  setup do
+    Application.put_env(
+      :commanded,
+      :pubsub,
+      phoenix_pubsub: [
+        adapter: Phoenix.PubSub.PG2,
+        pool_size: 1
+      ]
+    )
+
+    children = PhoenixPubSub.child_spec()
+
+    {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+
+    on_exit(fn ->
+      Application.delete_env(:commanded, :pubsub)
+
+      ProcessHelper.shutdown(pid)
+    end)
+  end
+
+  describe "pub/sub" do
+    test "should receive broadcast message" do
+      assert :ok = PhoenixPubSub.subscribe(@topic)
+      assert :ok = PhoenixPubSub.broadcast(@topic, :message)
+
+      assert_receive(:message)
+    end
+  end
+
+  describe "tracker" do
+    test "should list tracked processes" do
+      self = self()
+
+      assert :ok = PhoenixPubSub.track(@topic, :example)
+      assert [{:example, ^self}] = PhoenixPubSub.list(@topic)
+    end
+  end
+end

--- a/test/subscriptions/subscriptions_test.exs
+++ b/test/subscriptions/subscriptions_test.exs
@@ -41,15 +41,6 @@ defmodule Commanded.SubscriptionsTest do
       assert Subscriptions.handled?("stream1", 2)
     end
 
-    test "should register handler during ack event if unknown" do
-      assert Subscriptions.all() == []
-
-      :ok = Subscriptions.ack_event("handler1", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 2})
-
-      assert Subscriptions.all() == [{"handler1", self()}]
-      assert Subscriptions.handled?("stream1", 2)
-    end
-
     test "should ignore current process as handler" do
       :ok = Subscriptions.register("handler1", :strong)
 


### PR DESCRIPTION
Allow strongly consistent command dispatch to work when Commanded is run on multiple nodes, but not formed as a cluster.

Phoenix's pub/sub library is optionally used since it supports broadcasting messages and tracking presence using PG2 or Redis. The Redis adapter can be used when running multiple nodes that are not connected together. 

### Usage

The new `Commanded.PubSub` behaviour defines basic pub/sub and process tracking functions. The default implementation uses Elixir's local-only `Registry` module. 

```elixir
# `config/config.exs`
config :commanded, pubsub: :local
```

To use Phoenix pub/sub you must add it to your project's depedencies in `mix.exs`:

```elixir
defp deps do
  [
    {:phoenix_pubsub, "~> 1.0"}
  ]
end
```

Then configure the Phoenix pub/sub adapter you'd like to use:

```elixir
# `config/config.exs`
config :commanded, pubsub: [
  phoenix_pubsub: [
    adapter: Phoenix.PubSub.PG2,
    pool_size: 1
  ]
]
```

The available options are:

* `Phoenix.PubSub.PG2` - uses Distributed Elixir, directly exchanging notifications between servers
* `Phoenix.PubSub.Redis` - uses Redis to exchange data between servers


