### PR TITLE
Defer event handler and process router init until after subscribed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Retry command execution on concurrency error ([#132](https://github.com/commanded/commanded/pull/132)).
 - Event handler `error/3` callback ([#133](https://github.com/commanded/commanded/pull/133)).
 - Support distributed dispatch consistency ([#135](https://github.com/commanded/commanded/pull/135)).
+- Defer event handler and process router init until after subscribed ([#138](https://github.com/commanded/commanded/pull/138)).
 
 ## v0.15.1
 

--- a/guides/Events.md
+++ b/guides/Events.md
@@ -64,7 +64,9 @@ You should start your event handlers using a [supervisor](#supervision) to ensur
 
 ### `init/0` callback
 
-You can define an `init/0` function in your handler to be called when it starts. This callback function must return `:ok`, any other return value will prevent the handler from starting.
+You can define an `init/0` function in your handler to be called once it has started and successfully subscribed to the event store.
+
+This callback function must return `:ok`, any other return value will terminate the event handler with an error.
 
 ```elixir
 defmodule ExampleHandler do

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -153,8 +153,6 @@ defmodule Commanded.EventStore.Adapters.InMemory do
       _subscription -> {{:error, :subscription_already_exists}, state}
     end
 
-    send(subscriber, {:subscribed, subscriber})
-
     {:reply, reply, state}
   end
 
@@ -265,6 +263,8 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
   defp subscribe(%Subscription{name: subscription_name, subscriber: subscriber} = subscription, %State{persistent_subscriptions: subscriptions, persisted_events: persisted_events} = state) do
     Process.monitor(subscriber)
+
+    send(subscriber, {:subscribed, subscriber})
 
     catch_up(subscription, persisted_events, state)
 

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -9,6 +9,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
   defmodule State do
     @moduledoc false
+
     defstruct [
       serializer: nil,
       persisted_events: [],
@@ -22,6 +23,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
   defmodule Subscription do
     @moduledoc false
+
     defstruct [
       name: nil,
       subscriber: nil,
@@ -34,6 +36,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
     State,
     Subscription,
   }
+
   alias Commanded.EventStore.{
     EventData,
     RecordedEvent,
@@ -149,6 +152,8 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
       _subscription -> {{:error, :subscription_already_exists}, state}
     end
+
+    send(subscriber, {:subscribed, subscriber})
 
     {:reply, reply, state}
   end

--- a/lib/commanded/event_store/event_store.ex
+++ b/lib/commanded/event_store/event_store.ex
@@ -39,6 +39,10 @@ defmodule Commanded.EventStore do
   Restarting the named subscription will resume from the next event following
   the last seen.
 
+  Once subscribed, the subscriber process should be sent a
+  `{:subscribed, subscription}` message to allow it to defer initialisation
+  until the subscription has started.
+
   The subscriber process will be sent all events persisted to any stream. It
   will receive a `{:events, events}` message for each batch of events persisted
   for a single aggregate.

--- a/mix.exs
+++ b/mix.exs
@@ -39,16 +39,20 @@ defmodule Commanded.Mixfile do
     "test/helpers",
     "test/process_managers",
     "test/subscriptions",
+    "test/support"
   ]
   defp elixirc_paths(_), do: ["lib", "test/helpers"]
 
   defp deps do
     [
+      {:poison, "~> 3.1"},
+      {:uuid, "~> 1.1"},
+
+      # build & test tools
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},
       {:ex_doc, "~> 0.17", only: :dev},
       {:mix_test_watch, "~> 0.5", only: :dev},
-      {:poison, "~> 3.1"},
-      {:uuid, "~> 1.1"},
+      {:mox, "~> 0.3", only: :test},
 
       # optional deps
       {:phoenix_pubsub, "~> 1.0", optional: true}

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
-%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
+  "mox": {:hex, :mox, "0.3.1", "2ab1dce006387a91fbe1e727ba468d3e0691eacfd4e2fc7308d53676ec335c46", [], [], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"}}
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
+}

--- a/test/event/event_handler_macro_test.exs
+++ b/test/event/event_handler_macro_test.exs
@@ -15,6 +15,10 @@ defmodule Commanded.Event.EventHandlerMacroTest do
   test "should handle published events" do
     {:ok, handler} = AccountBalanceHandler.start_link()
 
+    Wait.until(fn ->
+      assert AccountBalanceHandler.subscribed?()
+    end)
+
     recorded_events =
       [
         %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -11,128 +11,147 @@ defmodule Commanded.Event.HandleEventTest do
   alias Commanded.ExampleDomain.BankAccount.AccountBalanceHandler
   alias Commanded.ExampleDomain.BankAccount.Events.{BankAccountOpened,MoneyDeposited}
 
-  setup do
-    on_exit fn ->
-      ProcessHelper.shutdown(AccountBalanceHandler)
-      ProcessHelper.shutdown(AppendingEventHandler)
+  describe "balance handler" do
+    setup do
+      {:ok, handler} = AccountBalanceHandler.start_link()
+
+      Wait.until(fn ->
+        assert AccountBalanceHandler.subscribed?()
+      end)
+
+      on_exit fn ->
+        ProcessHelper.shutdown(handler)
+      end
+
+      [handler: handler]
+    end
+
+    test "should be notified of events", %{handler: handler} do
+      events = [
+        %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
+        %MoneyDeposited{amount: 50, balance: 1_050}
+      ]
+      recorded_events = EventFactory.map_to_recorded_events(events)
+
+      send(handler, {:events, recorded_events})
+
+      Wait.until(fn ->
+        assert AccountBalanceHandler.current_balance == 1_050
+      end)
+    end
+
+    test "should ignore uninterested events" do
+      {:ok, handler} = AccountBalanceHandler.start_link()
+
+      # include uninterested events within those the handler is interested in
+      events = [
+        %UninterestingEvent{},
+        %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
+        %UninterestingEvent{},
+        %MoneyDeposited{amount: 50, balance: 1_050},
+        %UninterestingEvent{}
+      ]
+      recorded_events = EventFactory.map_to_recorded_events(events)
+
+      send(handler, {:events, recorded_events})
+
+      Wait.until(fn ->
+        assert AccountBalanceHandler.current_balance == 1_050
+      end)
     end
   end
 
-  test "should be notified of events" do
-    {:ok, handler} = AccountBalanceHandler.start_link()
+  describe "appending handler" do
+    setup do
+      on_exit fn ->
+        ProcessHelper.shutdown(AppendingEventHandler)
+      end
+    end
 
-    events = [
-      %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
-      %MoneyDeposited{amount: 50, balance: 1_050}
-    ]
-    recorded_events = EventFactory.map_to_recorded_events(events)
+    test "should ignore events created before the event handler's subscription when starting from `:current`" do
+      stream_uuid = UUID.uuid4
+      initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
+      new_events = [%MoneyDeposited{amount: 50, balance: 1_050}]
 
-    send(handler, {:events, recorded_events})
+      {:ok, 1} = EventStore.append_to_stream(stream_uuid, 0, Commanded.Event.Mapper.map_to_event_data(initial_events, UUID.uuid4(), UUID.uuid4(), %{}))
 
-    Wait.until(fn ->
-      assert AccountBalanceHandler.current_balance == 1_050
-    end)
-  end
+      wait_for_event BankAccountOpened
 
-  test "should ignore uninterested events" do
-    {:ok, handler} = AccountBalanceHandler.start_link()
+      {:ok, handler} = AppendingEventHandler.start_link(start_from: :current)
 
-    # include uninterested events within those the handler is interested in
-    events = [
-      %UninterestingEvent{},
-      %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
-      %UninterestingEvent{},
-      %MoneyDeposited{amount: 50, balance: 1_050},
-      %UninterestingEvent{}
-    ]
-    recorded_events = EventFactory.map_to_recorded_events(events)
+      assert GenServer.call(handler, :last_seen_event) == nil
 
-    send(handler, {:events, recorded_events})
+      {:ok, 2} = EventStore.append_to_stream(stream_uuid, 1, Commanded.Event.Mapper.map_to_event_data(new_events, UUID.uuid4(), UUID.uuid4(), %{}))
 
-    Wait.until(fn ->
-      assert AccountBalanceHandler.current_balance == 1_050
-    end)
-  end
+      wait_for_event MoneyDeposited
 
-  test "should ignore events created before the event handler's subscription when starting from `:current`" do
-    stream_uuid = UUID.uuid4
-    initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
-    new_events = [%MoneyDeposited{amount: 50, balance: 1_050}]
+      Wait.until(fn ->
+        assert AppendingEventHandler.received_events() == new_events
 
-    {:ok, 1} = EventStore.append_to_stream(stream_uuid, 0, Commanded.Event.Mapper.map_to_event_data(initial_events, UUID.uuid4(), UUID.uuid4(), %{}))
+        [ metadata ] = AppendingEventHandler.received_metadata()
 
-    wait_for_event BankAccountOpened
-
-    {:ok, handler} = AppendingEventHandler.start_link(start_from: :current)
-
-    assert GenServer.call(handler, :last_seen_event) == nil
-
-    {:ok, 2} = EventStore.append_to_stream(stream_uuid, 1, Commanded.Event.Mapper.map_to_event_data(new_events, UUID.uuid4(), UUID.uuid4(), %{}))
-
-    wait_for_event MoneyDeposited
-
-    Wait.until(fn ->
-      assert AppendingEventHandler.received_events() == new_events
-
-      [ metadata ] = AppendingEventHandler.received_metadata()
-
-      assert Map.get(metadata, :event_number) == 2
-      assert Map.get(metadata, :stream_id) == stream_uuid
-      assert Map.get(metadata, :stream_version) == 2
-      assert %NaiveDateTime{} = Map.get(metadata, :created_at)
-
-      assert GenServer.call(handler, :last_seen_event) == 2
-    end)
-	end
-
-  test "should receive events created before the event handler's subscription when starting from `:origin`" do
-    stream_uuid = UUID.uuid4
-    initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
-    new_events = [%MoneyDeposited{amount: 50, balance: 1_050}]
-
-    {:ok, 1} = EventStore.append_to_stream(stream_uuid, 0, Commanded.Event.Mapper.map_to_event_data(initial_events, UUID.uuid4(), UUID.uuid4(), %{}))
-
-    {:ok, _handler} = AppendingEventHandler.start_link(start_from: :origin)
-
-    {:ok, 2} = EventStore.append_to_stream(stream_uuid, 1, Commanded.Event.Mapper.map_to_event_data(new_events, UUID.uuid4(), UUID.uuid4(), %{}))
-
-    wait_for_event MoneyDeposited
-
-    Wait.until(fn ->
-      assert AppendingEventHandler.received_events() == initial_events ++ new_events
-
-      received_metadata = AppendingEventHandler.received_metadata()
-
-      assert pluck(received_metadata, :event_number) == [1, 2]
-      assert pluck(received_metadata, :stream_version) == [1, 2]
-
-      Enum.each(received_metadata, fn metadata ->
+        assert Map.get(metadata, :event_number) == 2
         assert Map.get(metadata, :stream_id) == stream_uuid
+        assert Map.get(metadata, :stream_version) == 2
         assert %NaiveDateTime{} = Map.get(metadata, :created_at)
+
+        assert GenServer.call(handler, :last_seen_event) == 2
       end)
-    end)
-	end
+  	end
 
-	test "should ignore already seen events" do
-    {:ok, handler} = AppendingEventHandler.start_link()
+    test "should receive events created before the event handler's subscription when starting from `:origin`" do
+      stream_uuid = UUID.uuid4
+      initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
+      new_events = [%MoneyDeposited{amount: 50, balance: 1_050}]
 
-    events = [
-      %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
-      %MoneyDeposited{amount: 50, balance: 1_050}
-    ]
-    recorded_events = EventFactory.map_to_recorded_events(events)
+      {:ok, 1} = EventStore.append_to_stream(stream_uuid, 0, Commanded.Event.Mapper.map_to_event_data(initial_events, UUID.uuid4(), UUID.uuid4(), %{}))
 
-    # send each event twice to simulate duplicate receives
-    Enum.each(recorded_events, fn recorded_event ->
-      send(handler, {:events, [recorded_event]})
-      send(handler, {:events, [recorded_event]})
-    end)
+      {:ok, _handler} = AppendingEventHandler.start_link(start_from: :origin)
 
-    Wait.until(fn ->
-      assert AppendingEventHandler.received_events() == events
-      assert pluck(AppendingEventHandler.received_metadata(), :stream_version) == [1, 2]
-    end)
-	end
+      {:ok, 2} = EventStore.append_to_stream(stream_uuid, 1, Commanded.Event.Mapper.map_to_event_data(new_events, UUID.uuid4(), UUID.uuid4(), %{}))
+
+      wait_for_event MoneyDeposited
+
+      Wait.until(fn ->
+        assert AppendingEventHandler.received_events() == initial_events ++ new_events
+
+        received_metadata = AppendingEventHandler.received_metadata()
+
+        assert pluck(received_metadata, :event_number) == [1, 2]
+        assert pluck(received_metadata, :stream_version) == [1, 2]
+
+        Enum.each(received_metadata, fn metadata ->
+          assert Map.get(metadata, :stream_id) == stream_uuid
+          assert %NaiveDateTime{} = Map.get(metadata, :created_at)
+        end)
+      end)
+  	end
+
+  	test "should ignore already seen events" do
+      {:ok, handler} = AppendingEventHandler.start_link()
+
+      events = [
+        %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
+        %MoneyDeposited{amount: 50, balance: 1_050}
+      ]
+      recorded_events = EventFactory.map_to_recorded_events(events)
+
+      Wait.until(fn ->
+        assert AppendingEventHandler.subscribed?()
+      end)
+
+      # send each event twice to simulate duplicate receives
+      Enum.each(recorded_events, fn recorded_event ->
+        send(handler, {:events, [recorded_event]})
+        send(handler, {:events, [recorded_event]})
+      end)
+
+      Wait.until(fn ->
+        assert AppendingEventHandler.received_events() == events
+        assert pluck(AppendingEventHandler.received_metadata(), :stream_version) == [1, 2]
+      end)
+  	end
+  end
 
   describe "event handler name" do
     test "should parse string" do

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -1,0 +1,69 @@
+defmodule Commanded.Event.HandlerInitTest do
+  use Commanded.StorageCase
+
+  import Mox
+
+  alias Commanded.Event.InitHandler
+  alias Commanded.Helpers.ProcessHelper
+  alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
+
+  setup do
+    reply_to = self()
+    {:ok, agent} = Agent.start_link(fn -> reply_to end, name: {:global, InitHandler})
+
+    on_exit(fn ->
+      ProcessHelper.shutdown(agent)
+    end)
+  end
+
+  describe "event handler `init/0` callback" do
+    setup do
+      {:ok, handler} = InitHandler.start_link()
+
+      on_exit(fn ->
+        ProcessHelper.shutdown(handler)
+      end)
+
+      [handler: handler]
+    end
+
+    test "should be called", %{handler: handler} do
+      assert_receive {:init, ^handler}
+    end
+  end
+
+  describe "event handler `init/0` callback after subscribed" do
+    setup do
+      set_mox_global()
+
+      # use mock event store adapter
+      default_event_store_adapter = Application.get_env(:commanded, :event_store_adapter)
+      :ok = Application.put_env(:commanded, :event_store_adapter, MockEventStore)
+
+      expect(MockEventStore, :subscribe_to_all_streams, fn _handler_name, handler, _subscribe_from ->
+        {:ok, handler}
+      end)
+
+      {:ok, handler} = InitHandler.start_link()
+
+      on_exit(fn ->
+        Application.put_env(:commanded, :event_store_adapter, default_event_store_adapter)
+        ProcessHelper.shutdown(handler)
+      end)
+
+      [handler: handler]
+    end
+
+    test "should be called after subscription subscribed", %{handler: handler} do
+      refute_receive {:init, ^handler}
+
+      simulate_subscribed(handler)
+
+      assert_receive {:init, ^handler}
+    end
+
+    defp simulate_subscribed(handler) do
+      send(handler, {:subscribed, handler})
+    end
+  end
+end

--- a/test/event/support/appending_event_handler.ex
+++ b/test/event/support/appending_event_handler.ex
@@ -16,6 +16,14 @@ defmodule Commanded.Event.AppendingEventHandler do
     end)
   end
 
+  def subscribed? do
+    try do
+      Agent.get(@agent_name, fn _ -> true end)
+    catch
+      :exit, _reason -> false
+    end
+  end
+
   def received_events do
     try do
       Agent.get(@agent_name, fn %{events: events} -> events end)

--- a/test/event/support/init/init_handler.ex
+++ b/test/event/support/init/init_handler.ex
@@ -1,0 +1,13 @@
+defmodule Commanded.Event.InitHandler do
+  use Commanded.Event.Handler, name: __MODULE__
+
+  def init do
+    send(reply_to(), {:init, self()})
+    
+    :ok
+  end
+
+  defp reply_to do
+    Agent.get({:global, __MODULE__}, fn reply_to -> reply_to end)
+  end
+end

--- a/test/event_store_adapter/subscription_test.exs
+++ b/test/event_store_adapter/subscription_test.exs
@@ -3,9 +3,9 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
 
   alias Commanded.EventStore
   alias Commanded.EventStore.EventData
-  alias Commanded.Helpers.{ProcessHelper,Wait}
+  alias Commanded.Helpers.{ProcessHelper, Wait}
 
-  defmodule BankAccountOpened, do: defstruct [:account_number, :initial_balance]
+  defmodule(BankAccountOpened, do: defstruct([:account_number, :initial_balance]))
 
   defmodule Subscriber do
     use GenServer
@@ -13,40 +13,41 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
     alias Commanded.EventStore
 
     defmodule State do
-      defstruct [
-        received_events: [],
-        subscription: nil,
-      ]
+      defstruct received_events: [],
+                subscribed?: false,
+                subscription: nil
     end
 
     alias Subscriber.State
 
-    def start_link do
-      GenServer.start_link(__MODULE__, %State{})
-    end
+    def start_link, do: GenServer.start_link(__MODULE__, %State{})
 
     def init(%State{} = state) do
       {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
 
-      state = %State{state |
-        subscription: subscription,
-      }
-
-      {:ok, state}
+      {:ok, %State{state | subscription: subscription}}
     end
 
-    def received_events(subscriber) do
-      GenServer.call(subscriber, :received_events)
+    def subscribed?(subscriber), do: GenServer.call(subscriber, :subscribed?)
+
+    def received_events(subscriber), do: GenServer.call(subscriber, :received_events)
+
+    def handle_call(:subscribed?, _from, %State{subscribed?: subscribed?} = state) do
+      {:reply, subscribed?, state}
     end
 
     def handle_call(:received_events, _from, %State{received_events: received_events} = state) do
       {:reply, received_events, state}
     end
 
-    def handle_info({:events, events}, %State{received_events: received_events, subscription: subscription} = state) do
-      state = %State{state |
-        received_events: Enum.concat(received_events, events),
-      }
+    def handle_info({:subscribed, subscription}, %State{subscription: subscription} = state) do
+      {:noreply, %State{state | subscribed?: true}}
+    end
+
+    def handle_info({:events, events}, %State{} = state) do
+      %State{received_events: received_events, subscription: subscription} = state
+
+      state = %State{state | received_events: Enum.concat(received_events, events)}
 
       EventStore.ack_event(subscription, List.last(events))
 
@@ -55,10 +56,16 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
   end
 
   describe "subscribe to all streams" do
+    test "should receive `:subscribed` message once subscribed" do
+      {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
+
+      assert_receive {:subscribed, ^subscription}
+    end
+
     test "should receive events appended to any stream" do
       {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
 
-      wait_for_event_store()
+      assert_receive {:subscribed, ^subscription}
 
       {:ok, 1} = EventStore.append_to_stream("stream1", 0, build_events(1))
       {:ok, 2} = EventStore.append_to_stream("stream2", 0, build_events(2))
@@ -75,17 +82,12 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       {:ok, 1} = EventStore.append_to_stream("stream1", 0, build_events(1))
       {:ok, 2} = EventStore.append_to_stream("stream2", 0, build_events(2))
 
-      wait_for_event_store()
-
       {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :current)
 
-      wait_for_event_store()
-
+      assert_receive {:subscribed, ^subscription}
       refute_receive({:events, _events})
 
       {:ok, 3} = EventStore.append_to_stream("stream3", 0, build_events(3))
-
-      wait_for_event_store()
 
       assert_receive_events(subscription, 3, from: 4)
 
@@ -94,7 +96,9 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
 
     test "should prevent duplicate subscriptions" do
       {:ok, _subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
-      assert {:error, :subscription_already_exists} == EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
+
+      assert {:error, :subscription_already_exists} ==
+               EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
     end
   end
 
@@ -105,7 +109,7 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
 
       {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
 
-      wait_for_event_store()
+      assert_receive {:subscribed, ^subscription}
 
       assert_receive_events(subscription, 1, from: 1)
       assert_receive_events(subscription, 2, from: 2)
@@ -113,7 +117,6 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       {:ok, 3} = EventStore.append_to_stream("stream3", 0, build_events(3))
 
       assert_receive_events(subscription, 3, from: 4)
-
       refute_receive({:events, _events})
     end
   end
@@ -122,15 +125,13 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
     test "should not receive further events appended to any stream" do
       {:ok, subscription} = EventStore.subscribe_to_all_streams("subscriber", self(), :origin)
 
-      {:ok, 1} = EventStore.append_to_stream("stream1", 0, build_events(1))
+      assert_receive {:subscribed, ^subscription}
 
-      wait_for_event_store()
+      {:ok, 1} = EventStore.append_to_stream("stream1", 0, build_events(1))
 
       assert_receive_events(subscription, 1, from: 1)
 
       :ok = EventStore.unsubscribe_from_all_streams("subscriber")
-
-      wait_for_event_store()
 
       {:ok, 2} = EventStore.append_to_stream("stream2", 0, build_events(2))
       {:ok, 3} = EventStore.append_to_stream("stream3", 0, build_events(3))
@@ -147,6 +148,7 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       {:ok, subscriber} = Subscriber.start_link()
 
       wait_until(fn ->
+        assert Subscriber.subscribed?(subscriber)
         received_events = Subscriber.received_events(subscriber)
         assert length(received_events) == 3
       end)
@@ -155,7 +157,6 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       :timer.sleep(event_store_wait(200))
 
       ProcessHelper.shutdown(subscriber)
-      wait_for_event_store()
 
       {:ok, subscriber} = Subscriber.start_link()
 
@@ -165,6 +166,7 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       {:ok, 1} = EventStore.append_to_stream("stream3", 0, build_events(1))
 
       wait_until(fn ->
+        assert Subscriber.subscribed?(subscriber)
         received_events = Subscriber.received_events(subscriber)
         assert length(received_events) == 1
       end)
@@ -189,15 +191,24 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
     EventStore.ack_event(subscription, List.last(received_events))
 
     case expected_count - length(received_events) do
-      0 -> :ok
-      remaining when remaining > 0 -> assert_receive_events(subscription, remaining, from: from_event_number + length(received_events))
-      remaining when remaining < 0 -> flunk("Received #{remaining} more event(s) than expected")
+      0 ->
+        :ok
+
+      remaining when remaining > 0 ->
+        assert_receive_events(
+          subscription,
+          remaining,
+          from: from_event_number + length(received_events)
+        )
+
+      remaining when remaining < 0 ->
+        flunk("Received #{remaining} more event(s) than expected")
     end
   end
 
   defp build_event(account_number) do
     %EventData{
-      correlation_id: UUID.uuid4,
+      correlation_id: UUID.uuid4(),
       event_type: "Elixir.Commanded.EventStore.Adapter.SubscriptionTest.BankAccountOpened",
       data: %BankAccountOpened{account_number: account_number, initial_balance: 1_000},
       metadata: %{}
@@ -208,12 +219,5 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
     for account_number <- 1..count, do: build_event(account_number)
   end
 
-  defp wait_for_event_store do
-    case event_store_wait() do
-      nil -> :ok
-      wait -> :timer.sleep(wait)
-    end
-  end
-
-  defp event_store_wait(default \\ nil), do: Application.get_env(:commanded, :event_store_wait, default)
+  defp event_store_wait(default), do: Application.get_env(:commanded, :event_store_wait, default)
 end

--- a/test/example_domain/bank_account/account_balance_handler.ex
+++ b/test/example_domain/bank_account/account_balance_handler.ex
@@ -1,11 +1,12 @@
 defmodule Commanded.ExampleDomain.BankAccount.AccountBalanceHandler do
   @moduledoc false
+
   use Commanded.Event.Handler, name: __MODULE__
 
   alias Commanded.ExampleDomain.BankAccount.Events.{
     BankAccountOpened,
     MoneyDeposited,
-    MoneyWithdrawn,
+    MoneyWithdrawn
   }
 
   @agent_name {:global, __MODULE__}
@@ -28,12 +29,21 @@ defmodule Commanded.ExampleDomain.BankAccount.AccountBalanceHandler do
     Agent.update(@agent_name, fn _ -> balance end)
   end
 
+  def subscribed? do
+    try do
+      Agent.get(@agent_name, fn _ -> true end)
+    catch
+      :exit, _reason -> false
+    end
+  end
+
   def current_balance do
     try do
       Agent.get(@agent_name, fn balance -> balance end)
     catch
       # catch agent not started exits, return `nil` balance
-      :exit, _reason -> nil
+      :exit, _reason ->
+        nil
     end
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(Commanded.EventStore.Adapters.Mock, for: Commanded.EventStore)


### PR DESCRIPTION
Expect event store adapters to send a `{subscribed, subscription}` message once successfully subscribed.

This is used to defer initialisation for event handlers, such as calling the `init/0` callback, and process routers. One benefit of deferring `init/0` is that it will only run once, irrespective of how many nodes are running your app and the event handler.