### PR TITLE
Replace aggregate lifespan `after_command/1` callback with `after_event/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Event handler `error/3` callback ([#133](https://github.com/commanded/commanded/pull/133)).
 - Support distributed dispatch consistency ([#135](https://github.com/commanded/commanded/pull/135)).
 - Defer event handler and process router init until after subscribed ([#138](https://github.com/commanded/commanded/pull/138)).
+- Replace aggregate lifespan `after_command/1` callback with `after_event/1` ([#139](https://github.com/commanded/commanded/issues/139)).
+
+### Breaking changes
+
+- The `Commanded.Aggregates.AggregateLifespan` behaviour has been changed from `after_command/1` to `after_event/1`. You will need to update your own lifespan modules to use events instead of commands to shutdown an aggregate process after an inactivity timeout.
 
 ## v0.15.1
 

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -268,12 +268,15 @@ You should always use string keys in your metadata map; atom keys will be conver
 
 By default an aggregate instance process will run indefinitely once started. You can control this by implementing the `Commanded.Aggregates.AggregateLifespan` behaviour in a module.
 
+Define a module that implements the `Commanded.Aggregates.AggregateLifespan` behaviour:
+
 ```elixir
 defmodule BankAccountLifespan do
   @behaviour Commanded.Aggregates.AggregateLifespan
 
-  def after_command(%OpenAccount{}), do: :infinity
-  def after_command(%CloseAccount{}), do: 0
+  def after_event(%BankAccountOpened{}), do: :infinity
+  def after_event(%MoneyDeposited{}), do: 60_000
+  def after_event(%BankAccountClosed{}), do: :stop
 end
 ```
 
@@ -290,11 +293,11 @@ defmodule BankRouter do
 end
 ```
 
-The timeout is specified in milliseconds, after which time the aggregate process will be stopped if no other messages are received.
+The inactivity timeout is specified in milliseconds, after which time the aggregate process will be stopped if no other messages are received.
+
+Return `:stop` to immediately shutdown the aggregate process. Return `:infinity` to prevent the aggregate instance from shutting down.
 
 You can also return `:hibernate` and the process is hibernated, it will continue its loop once a message is in its message queue. Hibernating an aggregate causes garbage collection and minimises the memory used by the process. Hibernating should not be used aggressively as too much time could be spent garbage collecting.
-
-Return `:infinity` to keep the aggregate instance process running indefinitely.
 
 ## Middleware
 

--- a/lib/commanded/aggregates/aggregate_lifespan.ex
+++ b/lib/commanded/aggregates/aggregate_lifespan.ex
@@ -1,23 +1,62 @@
 defmodule Commanded.Aggregates.AggregateLifespan do
   @moduledoc """
-  The `Commanded.Aggregates.AggregateLifespan` behaviour is used to control an aggregate lifespan.
+  The `Commanded.Aggregates.AggregateLifespan` behaviour is used to control an
+  aggregate lifespan.
 
   By default an aggregate instance process will run indefinitely once started.
-  You can control this by implementing the `Commanded.Aggregates.AggregateLifespan` behaviour in a module.
+  You can control this by implementing the
+  `Commanded.Aggregates.AggregateLifespan` behaviour in a module and configuring
+  it in your router.
 
-  The `c:after_command/1` function is called after each command executes.
-  The returned timeout value is used to shutdown the aggregate process if no other messages are recevied.
+  After a command successfully executes, and creates at least one domain event,
+  the `c:after_event/1` function is called passing the last created event. The
+  returned inactivity timeout value is used to shutdown the aggregate process if
+  no other messages are received.
 
-  Return `:infinity` to prevent the aggregate instance from shutting down.
+  ## Supported return values
+
+    - Non-negative integer - specify an inactivity timeout, in millisconds.
+    - `:infinity` - prevent the aggregate instance from shutting down.
+    - `:hibernate` - send the process into hibernation.
+    - `:stop` - immediately shutdown the aggregate process.
+
+  ### Hibernation
+
+  A hibernated process will continue its loop once a message is in its message
+  queue. Hibernating an aggregate causes garbage collection and minimises the
+  memory used by the process. Hibernating should not be used aggressively as too
+  much time could be spent garbage collecting.
+
+  ## Example
+
+  Define a module that implements the `Commanded.Aggregates.AggregateLifespan`
+  behaviour:
+
+      defmodule BankAccountLifespan do
+        @behaviour Commanded.Aggregates.AggregateLifespan
+
+        def after_event(%BankAccountOpened{}), do: :infinity
+        def after_event(%MoneyDeposited{}), do: 60_000
+        def after_event(%BankAccountClosed{}), do: :stop
+      end
+
+  Then specify the module as the `lifespan` option when registering
+  the applicable commands in your router:
+
+      defmodule BankRouter do
+        use Commanded.Commands.Router
+
+        dispatch [OpenAccount, CloseAccount],
+          to: BankAccount,
+          lifespan: BankAccountLifespan,
+          identity: :account_number
+      end
+
   """
-
-  @type command :: struct()
-  @type timeout_or_action :: timeout() | :infinity | :hibernate
 
   @doc """
-  After specified timeout aggregate process will be stoped.
-
-  Timeout begins at start of processing a command.
+  Aggregate process will be stopped after specified inactivity timeout unless
+  `:infinity`, `:hibernate`, or `:stop` are returned.
   """
-  @callback after_command(command) :: timeout_or_action
+  @callback after_event(event :: struct()) :: timeout() | :hibernate | :stop
 end

--- a/lib/commanded/aggregates/default_lifespan.ex
+++ b/lib/commanded/aggregates/default_lifespan.ex
@@ -1,14 +1,16 @@
 defmodule Commanded.Aggregates.DefaultLifespan do
   @moduledoc """
-  The default implementation of the `Commanded.Aggregates.AggregateLifespan` behaviour.
+  The default implementation of the `Commanded.Aggregates.AggregateLifespan`
+  behaviour.
 
-  It will ensure that an aggregate instance process runs indefinitely once started.
+  It will ensure that an aggregate instance process runs indefinitely once
+  started.
   """
 
   @behaviour Commanded.Aggregates.AggregateLifespan
 
   @doc """
-  Aggregate will run indefinitely once started
+  Aggregate will run indefinitely once started.
   """
-  def after_command(_command), do: :infinity
+  def after_event(_event), do: :infinity
 end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -3,18 +3,22 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
 
   alias Commanded.Aggregates.BankRouter
   alias Commanded.ExampleDomain.BankAccount
+
   alias Commanded.ExampleDomain.BankAccount.Commands.{
+    CloseAccount,
     OpenAccount,
     DepositMoney,
-    WithdrawMoney,
+    WithdrawMoney
   }
+
   alias Commanded.Registration
 
   describe "aggregate started" do
     setup do
-      aggregate_uuid = UUID.uuid4
+      aggregate_uuid = UUID.uuid4()
 
-      {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, aggregate_uuid)
+      {:ok, ^aggregate_uuid} =
+        Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, aggregate_uuid)
 
       pid = Registration.whereis_name({BankAccount, aggregate_uuid})
       ref = Process.monitor(pid)
@@ -25,22 +29,64 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
     test "should shutdown after timeout", %{aggregate_uuid: aggregate_uuid, ref: ref} do
       :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
 
-      assert_receive {:DOWN, ^ref, :process, _, :normal}, 10
+      assert_receive {:DOWN, ^ref, :process, _, :normal}
     end
 
-    test "should not shutdown if next command executed", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+    test "should not shutdown if another command executed", %{
+      aggregate_uuid: aggregate_uuid,
+      ref: ref
+    } do
       :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
       :ok = BankRouter.dispatch(%DepositMoney{account_number: aggregate_uuid, amount: 10})
 
       refute_receive {:DOWN, ^ref, :process, _, :normal}, 10
-      assert_receive {:DOWN, ^ref, :process, _, :normal}, 30
+      assert_receive {:DOWN, ^ref, :process, _, :normal}
     end
 
-    test "should use default lifespan when it's not specified'", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+    test "should use default lifespan when it's not specified'", %{
+      aggregate_uuid: aggregate_uuid,
+      ref: ref
+    } do
       :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
       :ok = BankRouter.dispatch(%WithdrawMoney{account_number: aggregate_uuid, amount: 10})
 
       refute_receive {:DOWN, ^ref, :process, _, :normal}, 30
+    end
+
+    test "should stop process when requested" , %{
+      aggregate_uuid: aggregate_uuid,
+      ref: ref
+    } do
+      :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
+      :ok = BankRouter.dispatch(%CloseAccount{account_number: aggregate_uuid})
+
+      assert_receive {:DOWN, ^ref, :process, _, :normal}
+    end
+  end
+
+  describe "deprecated `after_command/1` callback" do
+    test "should fail to compile when missing `after_event/1` function" do
+      assert_raise ArgumentError, "Aggregate lifespan `BankAccountLifespan` does not define a callback function: `after_event/1`", fn ->
+        Code.eval_string """
+          alias Commanded.ExampleDomain.BankAccount
+          alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount, DepositMoney}
+
+          defmodule BankAccountLifespan do
+            def after_command(%OpenAccount{}), do: 5
+            def after_command(%DepositMoney{}), do: 20
+            def after_command(_), do: :infinity
+          end
+
+          defmodule BankRouter do
+            use Commanded.Commands.Router
+
+            dispatch [OpenAccount],
+              to: BankAccount,
+              lifespan: BankAccountLifespan,
+              identity: :account_number
+          end
+        """
+      end
     end
   end
 end

--- a/test/aggregates/support/bank_account_lifespan.ex
+++ b/test/aggregates/support/bank_account_lifespan.ex
@@ -1,13 +1,16 @@
 defmodule Commanded.Aggregates.BankAccountLifespan do
   @moduledoc false
+
   @behaviour Commanded.Aggregates.AggregateLifespan
 
-  alias Commanded.ExampleDomain.BankAccount.Commands.{
-    OpenAccount,
-    DepositMoney,
+  alias Commanded.ExampleDomain.BankAccount.Events.{
+    BankAccountClosed,
+    BankAccountOpened,
+    MoneyDeposited
   }
 
-  def after_command(%OpenAccount{}), do: 5
-  def after_command(%DepositMoney{}), do: 20
-  def after_command(_), do: :infinity
+  def after_event(%BankAccountOpened{}), do: 5
+  def after_event(%MoneyDeposited{}), do: 20
+  def after_event(%BankAccountClosed{}), do: :stop
+  def after_event(_event), do: :infinity
 end

--- a/test/aggregates/support/bank_router.ex
+++ b/test/aggregates/support/bank_router.ex
@@ -3,16 +3,19 @@ defmodule Commanded.Aggregates.BankRouter do
   use Commanded.Commands.Router
 
   alias Commanded.Aggregates.BankAccountLifespan
+
   alias Commanded.ExampleDomain.{
     BankAccount,
     OpenAccountHandler,
     DepositMoneyHandler,
-    WithdrawMoneyHandler,
+    WithdrawMoneyHandler
   }
+
   alias BankAccount.Commands.{
-    OpenAccount,
+    CloseAccount,
     DepositMoney,
-    WithdrawMoney,
+    OpenAccount,
+    WithdrawMoney
   }
 
   dispatch OpenAccount,
@@ -30,5 +33,11 @@ defmodule Commanded.Aggregates.BankRouter do
   dispatch WithdrawMoney,
     to: WithdrawMoneyHandler,
     aggregate: BankAccount,
+    identity: :account_number
+
+  dispatch CloseAccount,
+    to: OpenAccountHandler,
+    aggregate: BankAccount,
+    lifespan: BankAccountLifespan,
     identity: :account_number
 end

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -123,7 +123,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should prevent duplicate registrations for a command" do
-    assert_raise RuntimeError, "duplicate command registration for: Commanded.ExampleDomain.BankAccount.Commands.OpenAccount", fn ->
+    assert_raise ArgumentError, "Command `Commanded.ExampleDomain.BankAccount.Commands.OpenAccount` has already been registered in router `DuplicateRouter`", fn ->
       Code.eval_string """
         alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
@@ -143,7 +143,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should prevent registration for a command handler without a `handle/2` function" do
-    assert_raise RuntimeError, "command handler InvalidHandler does not define a function: handle/2", fn ->
+    assert_raise ArgumentError, "Command handler `InvalidHandler` does not define a `handle/2` function", fn ->
       Code.eval_string """
         alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount

--- a/test/example_domain/bank_account/open_account_handler.ex
+++ b/test/example_domain/bank_account/open_account_handler.ex
@@ -1,17 +1,16 @@
 defmodule Commanded.ExampleDomain.OpenAccountHandler do
   @moduledoc false
+
   alias Commanded.ExampleDomain.BankAccount
-  alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount,CloseAccount}
+  alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount, CloseAccount}
 
   @behaviour Commanded.Commands.Handler
 
   def handle(%BankAccount{} = aggregate, %OpenAccount{} = open_account) do
-    aggregate
-    |> BankAccount.open_account(open_account)
+    BankAccount.open_account(aggregate, open_account)
   end
 
   def handle(%BankAccount{} = aggregate, %CloseAccount{} = close_account) do
-    aggregate
-    |> BankAccount.close_account(close_account)
+    BankAccount.close_account(aggregate, close_account)
   end
 end


### PR DESCRIPTION
An aggregate process lifespan should be controlled by the domain events it creates, not the commands, since a command may be rejected or ignored.

The events created by an aggregate are returned when executing a command so it should be straightforward to call an after_event/1 callback and pass it the last domain event.

#### Supported return values

- Non-negative integer - specify an inactivity timeout, in millisconds.
- `:infinity` - prevent the aggregate instance from shutting down.
- `:hibernate` - send the process into hibernation.
- `:stop` - immediately shutdown the aggregate process.

Closes #126.