### PR TITLE
Aggregate subscribes to its own events

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -146,7 +146,7 @@ defmodule Commanded.Aggregates.Aggregate do
   def handle_cast(:subscribe_to_events, %Aggregate{} = state) do
     %Aggregate{aggregate_uuid: aggregate_uuid} = state
 
-    :ok = EventStore.subscribe(aggregate_uuid, self())
+    :ok = EventStore.subscribe(aggregate_uuid)
 
     {:noreply, state}
   end
@@ -254,7 +254,7 @@ defmodule Commanded.Aggregates.Aggregate do
         # ignore events already applied to aggregate state
         state
 
-      unexpected_version ->
+      _unexpected_version ->
         Logger.debug(fn ->
           describe(state) <> " received an unexpected event: #{inspect(event)}"
         end)

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -496,7 +496,13 @@ defmodule Commanded.Event.Handler do
     %Handler{state | last_seen_event: event_number}
   end
 
-  defp ack_event(event, %Handler{consistency: consistency, handler_name: handler_name, subscription: subscription}) do
+  defp ack_event(event, %Handler{} = state) do
+    %Handler{
+      consistency: consistency,
+      handler_name: handler_name,
+      subscription: subscription
+    } = state
+
     :ok = EventStore.ack_event(subscription, event)
     :ok = Subscriptions.ack_event(handler_name, consistency, event)
   end

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -70,8 +70,8 @@ defmodule Commanded.EventStore.Adapters.InMemory do
   end
 
   @impl Commanded.EventStore
-  def subscribe(stream_uuid, subscriber) do
-    GenServer.call(__MODULE__, {:subscribe, stream_uuid, subscriber})
+  def subscribe(stream_uuid) do
+    GenServer.call(__MODULE__, {:subscribe, stream_uuid, self()})
   end
 
   @impl Commanded.EventStore

--- a/lib/commanded/event_store/event_store.ex
+++ b/lib/commanded/event_store/event_store.ex
@@ -33,6 +33,16 @@ defmodule Commanded.EventStore do
     | {:error, reason}
 
   @doc """
+  Create a transient subscription to a single event stream.
+
+  The event store will publish any events appended to the given stream to the
+  `subscriber` process as an `{:events, events}` message.
+
+  The subscriber does not need to acknowledge receipt of the events.
+  """
+  @callback subscribe(stream_uuid, subscriber :: pid) :: :ok | {:error, reason}
+
+  @doc """
   Create a persistent subscription to all event streams.
 
   The event store will remember the subscribers last acknowledged event.
@@ -96,6 +106,14 @@ defmodule Commanded.EventStore do
   def stream_forward(stream_uuid, start_version \\ 0, read_batch_size \\ 1_000)
   def stream_forward(stream_uuid, start_version, read_batch_size) do
     event_store_adapter().stream_forward(stream_uuid, start_version, read_batch_size)
+  end
+
+  @doc """
+  Create a transient subscription to a single event stream.
+  """
+  @spec subscribe(stream_uuid, subscriber :: pid) :: :ok | {:error, reason}
+  def subscribe(stream_uuid, subscriber) do
+    event_store_adapter().subscribe(stream_uuid, subscriber)
   end
 
   @doc """

--- a/lib/commanded/event_store/event_store.ex
+++ b/lib/commanded/event_store/event_store.ex
@@ -40,7 +40,7 @@ defmodule Commanded.EventStore do
 
   The subscriber does not need to acknowledge receipt of the events.
   """
-  @callback subscribe(stream_uuid, subscriber :: pid) :: :ok | {:error, reason}
+  @callback subscribe(stream_uuid) :: :ok | {:error, reason}
 
   @doc """
   Create a persistent subscription to all event streams.
@@ -111,9 +111,9 @@ defmodule Commanded.EventStore do
   @doc """
   Create a transient subscription to a single event stream.
   """
-  @spec subscribe(stream_uuid, subscriber :: pid) :: :ok | {:error, reason}
-  def subscribe(stream_uuid, subscriber) do
-    event_store_adapter().subscribe(stream_uuid, subscriber)
+  @spec subscribe(stream_uuid) :: :ok | {:error, reason}
+  def subscribe(stream_uuid) do
+    event_store_adapter().subscribe(stream_uuid)
   end
 
   @doc """

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -1,0 +1,139 @@
+defmodule Commanded.Aggregates.AggregateConcurrencyTest do
+  use Commanded.MockEventStoreCase
+
+  alias Commanded.Aggregates.{Aggregate, ExecutionContext}
+  alias Commanded.EventStore.RecordedEvent
+  alias Commanded.ExampleDomain.{BankAccount, OpenAccountHandler, DepositMoneyHandler}
+  alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount, DepositMoney}
+  alias Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited
+
+  setup do
+    expect(MockEventStore, :subscribe_to_all_streams, fn _handler_name, handler, _subscribe_from ->
+      {:ok, handler}
+    end)
+
+    expect(MockEventStore, :subscribe, fn _aggregate_uuid, _subscriber -> :ok end)
+
+    :ok
+  end
+
+  describe "concurrency error" do
+    setup [
+      :open_account
+    ]
+
+    test "should retry command", context do
+      %{account_number: account_number} = context
+
+      command = %DepositMoney{
+        account_number: account_number,
+        transfer_uuid: UUID.uuid4(),
+        amount: 100
+      }
+
+      context = %ExecutionContext{
+        command: command,
+        handler: DepositMoneyHandler,
+        function: :handle,
+        retry_attempts: 5
+      }
+
+      # fail to append once
+      expect(MockEventStore, :append_to_stream, fn ^account_number, 1, _event_data ->
+        {:error, :wrong_expected_version}
+      end)
+
+      # return "missing" event
+      expect(MockEventStore, :stream_forward, fn ^account_number, 2, _batch_size ->
+        [
+          %RecordedEvent{
+            event_id: UUID.uuid4(),
+            event_number: 2,
+            stream_id: account_number,
+            stream_version: 2,
+            event_type: "Elixir.Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited",
+            data: %MoneyDeposited{
+              account_number: account_number,
+              transfer_uuid: UUID.uuid4(),
+              amount: 500,
+              balance: 1_500
+            },
+            metadata: %{}
+          }
+        ]
+      end)
+
+      # succeed on second attempt
+      expect(MockEventStore, :append_to_stream, fn ^account_number, 2, event_data ->
+        {:ok, 2 + length(event_data)}
+      end)
+
+      assert {:ok, 3, _events} = Aggregate.execute(BankAccount, account_number, context)
+
+      assert Aggregate.aggregate_version(BankAccount, account_number) == 3
+
+      assert Aggregate.aggregate_state(BankAccount, account_number) == %BankAccount{
+               account_number: account_number,
+               balance: 1_600,
+               state: :active
+             }
+    end
+
+    test "should error after too many attempts", context do
+      %{account_number: account_number} = context
+
+      # fail to append to stream
+      expect(MockEventStore, :append_to_stream, 6, fn ^account_number, 1, _event_data ->
+        {:error, :wrong_expected_version}
+      end)
+
+      expect(MockEventStore, :stream_forward, 6, fn ^account_number, 2, _batch_size -> [] end)
+
+      command = %DepositMoney{
+        account_number: account_number,
+        transfer_uuid: UUID.uuid4(),
+        amount: 100
+      }
+
+      context = %ExecutionContext{
+        command: command,
+        handler: DepositMoneyHandler,
+        function: :handle,
+        retry_attempts: 5
+      }
+
+      assert {:error, :too_many_attempts} =
+               Aggregate.execute(BankAccount, account_number, context)
+    end
+
+    defp open_account(_context) do
+      account_number = UUID.uuid4()
+
+      expect(MockEventStore, :stream_forward, fn ^account_number, 1, _batch_size ->
+        []
+      end)
+
+      expect(MockEventStore, :append_to_stream, fn ^account_number, 0, event_data ->
+        {:ok, length(event_data)}
+      end)
+
+      {:ok, ^account_number} =
+        Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, account_number)
+
+      command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
+
+      context = %ExecutionContext{
+        command: command,
+        handler: OpenAccountHandler,
+        function: :handle,
+        retry_attempts: 1
+      }
+
+      {:ok, 1, _events} = Aggregate.execute(BankAccount, account_number, context)
+
+      [
+        account_number: account_number
+      ]
+    end
+  end
+end

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -12,7 +12,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
       {:ok, handler}
     end)
 
-    expect(MockEventStore, :subscribe, fn _aggregate_uuid, _subscriber -> :ok end)
+    expect(MockEventStore, :subscribe, fn _aggregate_uuid -> :ok end)
 
     :ok
   end

--- a/test/aggregates/aggregate_subscription_test.exs
+++ b/test/aggregates/aggregate_subscription_test.exs
@@ -1,0 +1,65 @@
+defmodule Commanded.Aggregates.AggregateSubscriptionTest do
+  use Commanded.StorageCase
+
+  alias Commanded.Aggregates.{Aggregate, ExecutionContext}
+  alias Commanded.Aggregates.Supervisor, as: AggregateSupervisor
+  alias Commanded.EventStore
+  alias Commanded.ExampleDomain.{BankAccount, OpenAccountHandler}
+  alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited
+
+  describe "append event directly to aggregate stream" do
+    setup [
+      :open_account,
+      :append_event_to_stream
+    ]
+
+    test "should notify aggregate and mutate its state", context do
+      %{account_number: account_number} = context
+
+      assert Aggregate.aggregate_version(BankAccount, account_number) == 2
+
+      assert Aggregate.aggregate_state(BankAccount, account_number) == %BankAccount{
+               account_number: account_number,
+               balance: 1_500,
+               state: :active
+             }
+    end
+
+    defp open_account(_context) do
+      account_number = UUID.uuid4()
+
+      {:ok, ^account_number} = AggregateSupervisor.open_aggregate(BankAccount, account_number)
+
+      context = %ExecutionContext{
+        command: %OpenAccount{account_number: account_number, initial_balance: 1_000},
+        handler: OpenAccountHandler,
+        function: :handle,
+        retry_attempts: 1
+      }
+
+      {:ok, 1, _events} = Aggregate.execute(BankAccount, account_number, context)
+
+      [
+        account_number: account_number
+      ]
+    end
+
+    # Write an event to the aggregate's stream, bypassing the aggregate process
+    defp append_event_to_stream(%{account_number: account_number}) do
+      event = %Commanded.EventStore.EventData{
+        event_type: "Elixir.Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited",
+        data: %MoneyDeposited{
+          account_number: account_number,
+          transfer_uuid: UUID.uuid4(),
+          amount: 500,
+          balance: 1_500
+        }
+      }
+
+      {:ok, _} = EventStore.append_to_stream(account_number, 1, [event])
+
+      :ok
+    end
+  end
+end

--- a/test/event_store_adapter/subscription_test.exs
+++ b/test/event_store_adapter/subscription_test.exs
@@ -59,7 +59,7 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
     test "should receive events appended to the stream" do
       stream_uuid = UUID.uuid4()
 
-      assert :ok = EventStore.subscribe(stream_uuid, self())
+      assert :ok = EventStore.subscribe(stream_uuid)
 
       {:ok, 1} = EventStore.append_to_stream(stream_uuid, 0, build_events(1))
 
@@ -86,7 +86,7 @@ defmodule Commanded.EventStore.Adapter.SubscriptionTest do
       stream_uuid = UUID.uuid4()
       another_stream_uuid = UUID.uuid4()
 
-      assert :ok = EventStore.subscribe(stream_uuid, self())
+      assert :ok = EventStore.subscribe(stream_uuid)
 
       {:ok, 1} = EventStore.append_to_stream(another_stream_uuid, 0, build_events(1))
       {:ok, 3} = EventStore.append_to_stream(another_stream_uuid, 1, build_events(2))

--- a/test/helpers/storage_case.ex
+++ b/test/helpers/storage_case.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.StorageCase do
   @moduledoc false
+  
   use ExUnit.CaseTemplate
 
   require Logger

--- a/test/process_managers/support/multi/todo_process_manager.ex
+++ b/test/process_managers/support/multi/todo_process_manager.ex
@@ -26,5 +26,5 @@ defmodule Commanded.ProcessManagers.TodoProcessManager do
     %TodoProcessManager{state | todo_uuid: todo_uuid}
   end
 
-  def apply(%TodoProcessManager{} = state, event), do: state
+  def apply(%TodoProcessManager{} = state, _event), do: state
 end

--- a/test/support/mock_event_store_case.ex
+++ b/test/support/mock_event_store_case.ex
@@ -1,0 +1,35 @@
+defmodule Commanded.MockEventStoreCase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  import Mox
+
+  alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
+  
+  using do
+    quote do
+      import Mox
+
+      alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
+    end
+  end
+
+  setup do
+    set_mox_global()
+
+    default_event_store_adapter = Application.get_env(:commanded, :event_store_adapter)
+
+    # use mock event store adapter
+    :ok = Application.put_env(:commanded, :event_store_adapter, MockEventStore)
+
+    Application.ensure_all_started(:commanded)
+
+    on_exit(fn ->
+      Application.put_env(:commanded, :event_store_adapter, default_event_store_adapter)
+      Application.stop(:commanded)
+    end)
+
+    :ok
+  end
+end


### PR DESCRIPTION
Each aggregate instance will subscribe to its own events to catch any events appended to an aggregate's stream that were _not_ persisted via the aggregate instance process.

This might happen when events are directly appended to the stream using the configured event store, or when Commanded is run on multiple nodes but they're not connected together to form a cluster.

This pull request will require the two event store adapters be updated as the `Commanded.EventStore` behaviour has been extended to support single stream transient subscriptions. 