### PR TITLE
Support process manager routing to multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support distributed dispatch consistency ([#135](https://github.com/commanded/commanded/pull/135)).
 - Defer event handler and process router init until after subscribed ([#138](https://github.com/commanded/commanded/pull/138)).
 - Replace aggregate lifespan `after_command/1` callback with `after_event/1` ([#139](https://github.com/commanded/commanded/issues/139)).
+Support process manager routing to multiple instances ([#141](https://github.com/commanded/commanded/pull/141)).
 
 ### Breaking changes
 

--- a/guides/Process Managers.md
+++ b/guides/Process Managers.md
@@ -13,6 +13,8 @@ The `interested?/1` function is used to indicate which events the process manage
 - `{:stop, process_uuid}` - stop an existing process manager, shutdown its process, and delete its persisted state.
 - `false` - ignore the event.
 
+You can return a list of process identifiers when a single domain event must be handled by multiple process instances.
+
 ## `handle/2`
 
 A `handle/2` function can be defined for each `:start` and `:continue` tagged event previously specified. It receives the process manager's state and the event to be handled. It must return the commands to be dispatched. This may be none, a single command, or many commands.

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -404,10 +404,9 @@ defmodule Commanded.Event.Handler do
         {:stop, reason, state}
     end
   end
-
+  
   defp subscribe_to_all_streams(%Handler{} = state) do
     %Handler{
-      consistency: consistency,
       handler_name: handler_name,
       subscribe_from: subscribe_from
     } = state

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -116,7 +116,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   @type domain_event :: struct
   @type command :: struct
   @type process_manager :: struct
-  @type process_uuid :: String.t
+  @type process_uuid :: String.t() | [String.t()]
   @type consistency :: :eventual | :strong
 
   @doc """
@@ -131,6 +131,9 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   - `{:stop, process_uuid}` - stop an existing process manager, shutdown its
     process, and delete its persisted state.
   - `false` - ignore the event.
+
+  You can return a list of process identifiers when a single domain event must
+  be handled by multiple process instances.
   """
   @callback interested?(domain_event) :: {:start, process_uuid}
     | {:continue, process_uuid}

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -234,9 +234,19 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     })
   end
 
-  defp delete_state(%ProcessManagerInstance{} = state), do: EventStore.delete_snapshot(process_state_uuid(state))
+  defp delete_state(%ProcessManagerInstance{} = state),
+    do: EventStore.delete_snapshot(process_state_uuid(state))
 
-  defp ack_event(%RecordedEvent{} = event, process_router), do: ProcessRouter.ack_event(process_router, event)
+  defp ack_event(%RecordedEvent{} = event, process_router) do
+    ProcessRouter.ack_event(process_router, event, self())
+  end
 
-  defp process_state_uuid(%ProcessManagerInstance{process_manager_name: process_manager_name, process_uuid: process_uuid}), do: "#{process_manager_name}-#{process_uuid}"
+  defp process_state_uuid(%ProcessManagerInstance{} = state) do
+    %ProcessManagerInstance{
+      process_manager_name: process_manager_name,
+      process_uuid: process_uuid
+    } = state
+
+    "#{process_manager_name}-#{process_uuid}"
+  end
 end

--- a/test/process_managers/multi_routing_test.exs
+++ b/test/process_managers/multi_routing_test.exs
@@ -1,0 +1,58 @@
+defmodule Commanded.ProcessManager.MultiRoutingTest do
+  use Commanded.StorageCase
+
+  import Commanded.Assertions.EventAssertions
+
+  alias Commanded.ProcessManagers.ProcessRouter
+  alias Commanded.ProcessManagers.{TodoProcessManager, TodoRouter}
+  alias Commanded.ProcessManagers.Todo.Commands.CreateTodo
+  alias Commanded.ProcessManagers.Todo.Events.TodoDone
+  alias Commanded.ProcessManagers.TodoList.Commands.{CreateList, MarkAllDone}
+  alias Commanded.ProcessManagers.TodoList.Events.ListAllDone
+
+  test "should create process instance for each identifier returned by `interested?/2`" do
+    {:ok, pm} = TodoProcessManager.start_link()
+
+    todo1_uuid = create_todo()
+    todo2_uuid = create_todo()
+    todo3_uuid = create_todo()
+
+    list_uuid = create_list_of_todos([todo1_uuid, todo2_uuid, todo3_uuid])
+
+    # mark list done should mark individual TODOs as done via process manager
+    :ok = TodoRouter.dispatch(%MarkAllDone{list_uuid: list_uuid})
+
+    assert_receive_event(ListAllDone, fn done -> done.list_uuid == list_uuid end)
+
+    assert_receive_event(TodoDone, fn done -> done.todo_uuid == todo1_uuid end, fn done ->
+      assert done.todo_uuid == todo1_uuid
+    end)
+
+    assert_receive_event(TodoDone, fn done -> done.todo_uuid == todo2_uuid end, fn done ->
+      assert done.todo_uuid == todo2_uuid
+    end)
+
+    assert_receive_event(TodoDone, fn done -> done.todo_uuid == todo3_uuid end, fn done ->
+      assert done.todo_uuid == todo3_uuid
+    end)
+
+    instances = ProcessRouter.process_instances(pm)
+    assert length(instances) == 3
+  end
+
+  defp create_todo do
+    todo_uuid = UUID.uuid4()
+
+    :ok = TodoRouter.dispatch(%CreateTodo{todo_uuid: todo_uuid})
+
+    todo_uuid
+  end
+
+  defp create_list_of_todos(todo_uuids) do
+    list_uuid = UUID.uuid4()
+
+    :ok = TodoRouter.dispatch(%CreateList{list_uuid: list_uuid, todo_uuids: todo_uuids})
+
+    list_uuid
+  end
+end

--- a/test/process_managers/process_manager_error_handling_state_test.exs
+++ b/test/process_managers/process_manager_error_handling_state_test.exs
@@ -7,7 +7,6 @@ defmodule Commanded.ProcessManager.ProcessManagerErrorHandlingStateTest do
   }
   alias Commanded.ProcessManagers.ErrorAggregate.Commands.StartProcess
 
-  @tag :bamorim
   test "should receive the aggregate state in the context" do
     process_uuid = UUID.uuid4()
     command = %StartProcess{

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -29,7 +29,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
     :ok = ProcessManagerInstance.process_event(process_manager, event, self())
 
     # should send ack to process router after processing event
-    assert_receive({:"$gen_cast", {:ack_event, ^event}}, 1_000)
+    assert_receive({:"$gen_cast", {:ack_event, ^event, _instance}}, 1_000)
 
     ProcessHelper.shutdown(process_manager)
   end

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -67,10 +67,7 @@ defmodule Commanded.ProcessManagers.ProcessRouterProcessPendingEventsTest do
       assert event.aggregate_uuid == aggregate_uuid
     end
 
-    events =
-      aggregate_uuid
-      |> EventStore.stream_forward()
-      |> Enum.to_list()
+    events = aggregate_uuid |> EventStore.stream_forward() |> Enum.to_list()
 
     assert pluck(events, :data) == [
       %Started{aggregate_uuid: aggregate_uuid},

--- a/test/process_managers/support/multi/todo.ex
+++ b/test/process_managers/support/multi/todo.ex
@@ -1,0 +1,33 @@
+defmodule Commanded.ProcessManagers.Todo do
+  @moduledoc false
+
+  defstruct status: nil
+
+  defmodule Commands do
+    defmodule(CreateTodo, do: defstruct([:todo_uuid]))
+    defmodule(MarkDone, do: defstruct([:todo_uuid]))
+  end
+
+  defmodule Events do
+    defmodule(TodoCreated, do: defstruct([:todo_uuid]))
+    defmodule(TodoDone, do: defstruct([:todo_uuid]))
+  end
+
+  alias Commanded.ProcessManagers.Todo
+  alias Commanded.ProcessManagers.Todo.Commands.{CreateTodo, MarkDone}
+  alias Commanded.ProcessManagers.Todo.Events.{TodoCreated, TodoDone}
+
+  def execute(%Todo{}, %CreateTodo{todo_uuid: todo_uuid}) do
+    %TodoCreated{todo_uuid: todo_uuid}
+  end
+
+  def execute(%Todo{}, %MarkDone{todo_uuid: todo_uuid}) do
+    %TodoDone{todo_uuid: todo_uuid}
+  end
+
+  # state mutatators
+
+  def apply(%Todo{} = state, %TodoCreated{}), do: %Todo{state | status: :pending}
+
+  def apply(%Todo{} = state, %TodoDone{}), do: %Todo{state | status: :done}
+end

--- a/test/process_managers/support/multi/todo_list.ex
+++ b/test/process_managers/support/multi/todo_list.ex
@@ -1,0 +1,32 @@
+defmodule Commanded.ProcessManagers.TodoList do
+  @moduledoc false
+
+  defstruct todo_uuids: []
+
+  defmodule Commands do
+    defmodule(CreateList, do: defstruct([:list_uuid, :todo_uuids]))
+    defmodule(MarkAllDone, do: defstruct([:list_uuid]))
+  end
+
+  defmodule Events do
+    defmodule(TodoListCreated, do: defstruct([:list_uuid, :todo_uuids]))
+    defmodule(ListAllDone, do: defstruct([:list_uuid, :todo_uuids]))
+  end
+
+  alias Commanded.ProcessManagers.TodoList
+  alias Commanded.ProcessManagers.TodoList.Commands.{CreateList, MarkAllDone}
+  alias Commanded.ProcessManagers.TodoList.Events.{TodoListCreated, ListAllDone}
+
+  def execute(%TodoList{}, %CreateList{list_uuid: list_uuid, todo_uuids: todo_uuids}) do
+    %TodoListCreated{list_uuid: list_uuid, todo_uuids: todo_uuids}
+  end
+
+  def execute(%TodoList{todo_uuids: todo_uuids}, %MarkAllDone{list_uuid: list_uuid}) do
+    %ListAllDone{list_uuid: list_uuid, todo_uuids: todo_uuids}
+  end
+
+  def apply(%TodoList{} = state, %TodoListCreated{todo_uuids: todo_uuids}),
+    do: %TodoList{state | todo_uuids: todo_uuids}
+
+  def apply(%TodoList{} = state, event), do: state
+end

--- a/test/process_managers/support/multi/todo_process_manager.ex
+++ b/test/process_managers/support/multi/todo_process_manager.ex
@@ -1,0 +1,30 @@
+defmodule Commanded.ProcessManagers.TodoProcessManager do
+  @moduledoc false
+
+  alias Commanded.ProcessManagers.{TodoRouter, TodoProcessManager}
+
+  use Commanded.ProcessManagers.ProcessManager,
+    name: __MODULE__,
+    router: TodoRouter
+
+  defstruct [:todo_uuid]
+
+  alias Commanded.ProcessManagers.Todo.Events.TodoCreated
+  alias Commanded.ProcessManagers.TodoList.Events.ListAllDone
+  alias Commanded.ProcessManagers.Todo.Commands.MarkDone
+
+  def interested?(%TodoCreated{todo_uuid: todo_uuid}), do: {:start, todo_uuid}
+  def interested?(%ListAllDone{todo_uuids: todo_uuids}), do: {:continue, todo_uuids}
+
+  def handle(%TodoProcessManager{}, %TodoCreated{}), do: []
+
+  def handle(%TodoProcessManager{todo_uuid: todo_uuid}, %ListAllDone{}) do
+    %MarkDone{todo_uuid: todo_uuid}
+  end
+
+  def apply(%TodoProcessManager{} = state, %TodoCreated{todo_uuid: todo_uuid}) do
+    %TodoProcessManager{state | todo_uuid: todo_uuid}
+  end
+
+  def apply(%TodoProcessManager{} = state, event), do: state
+end

--- a/test/process_managers/support/multi/todo_router.ex
+++ b/test/process_managers/support/multi/todo_router.ex
@@ -1,0 +1,15 @@
+defmodule Commanded.ProcessManagers.TodoRouter do
+  @moduledoc false
+
+  use Commanded.Commands.Router
+
+  alias Commanded.ProcessManagers.{Todo, TodoList}
+  alias Commanded.ProcessManagers.Todo.Commands.{CreateTodo, MarkDone}
+  alias Commanded.ProcessManagers.TodoList.Commands.{CreateList, MarkAllDone}
+
+  identify Todo, by: :todo_uuid
+  identify TodoList, by: :list_uuid
+
+  dispatch [CreateTodo, MarkDone], to: Todo
+  dispatch [CreateList, MarkAllDone], to: TodoList
+end


### PR DESCRIPTION
Allow a process manager's `interested?/2` callback to return a list of process identities to handle an event.