### PR TITLE
add assert_correlated test helper

### DIFF
--- a/lib/commanded/assertions/event_assertions.ex
+++ b/lib/commanded/assertions/event_assertions.ex
@@ -41,6 +41,19 @@ defmodule Commanded.Assertions.EventAssertions do
     end)
   end
 
+  @doc """
+  Assert that events matching their respective predicates have a matching correlation id.
+  Useful when there is a chain of events that is connected through event handlers.
+
+  ## Examples
+
+      id_one = 1
+      id_two = 2
+      assert_correlated(
+        BankAccountOpened, fn opened -> opened.id == id_one end,
+        InitialAmountDeposited, fn deposited -> deposited.id == id_two end
+      )
+  """
   def assert_correlated(event_type_a, predicate_a, event_type_b, predicate_b) do
     assert_receive_event(event_type_a, predicate_a, fn(event_b, metadata_a) ->
       assert_receive_event(event_type_b, predicate_b, fn(event_b, metadata_b) ->

--- a/lib/commanded/assertions/event_assertions.ex
+++ b/lib/commanded/assertions/event_assertions.ex
@@ -41,6 +41,15 @@ defmodule Commanded.Assertions.EventAssertions do
     end)
   end
 
+  def assert_correlated(event_type_a, predicate_a, event_type_b, predicate_b) do
+    assert_receive_event(event_type_a, predicate_a, fn(event_b, metadata_a) ->
+      assert_receive_event(event_type_b, predicate_b, fn(event_b, metadata_b) ->
+        assert metadata_a.correlation_id == metadata_b.correlation_id
+      end)
+    end)
+  end
+
+
   @doc """
   Assert that an event of the given event type is published. Verify that event using the assertion function.
 
@@ -72,7 +81,7 @@ defmodule Commanded.Assertions.EventAssertions do
     unless Code.ensure_compiled?(event_type) do
       raise ExUnit.AssertionError, "event_type #{inspect(event_type)} not found"
     end
-    
+
     with_subscription(fn subscription ->
       do_assert_receive(subscription, event_type, predicate_fn, assertion_fn)
     end)
@@ -111,7 +120,13 @@ defmodule Commanded.Assertions.EventAssertions do
 
     case expected_event do
       nil -> do_assert_receive(subscription, event_type, predicate_fn, assertion_fn)
-      received_event -> apply(assertion_fn, [received_event.data])
+      received_event ->
+        if is_function(assertion_fn, 1) do
+          apply(assertion_fn, [received_event.data])
+        else
+          {data, all_metadata} = Map.split(received_event, [:data])
+          apply(assertion_fn, [data, all_metadata])
+        end
     end
   end
 


### PR DESCRIPTION
Like other helpers, can be brought in with `import Commanded.Assertions.EventAssertions`.

This assertion ensures that:
1. Both events, each matching their respective predicates, are received
2. Both events share the same correlation id

Usage sample follows.

Note that in this example I am using the same identifier to identify the two events out of convenience. 

```elixir
identifier = UUID.uuid4()
assert_correlated(
  EventTypeA, &(&1.identifier_a == identifier),
  EventTypeB, &(&1.identifier_b == identifier)
)
```