### PR TITLE
Allows for a default consistency to be set via the env

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -125,7 +125,7 @@ defmodule Commanded.Commands.Router do
           Commanded.Middleware.ExtractAggregateIdentity,
           Commanded.Middleware.ConsistencyGuarantee,
         ],
-        consistency: :eventual,
+        consistency: Application.get_env(:commanded, :default_consistency, :eventual),
         dispatch_timeout: 5_000,
         lifespan: Commanded.Aggregates.DefaultLifespan,
         metadata: %{},

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -327,7 +327,7 @@ defmodule Commanded.Event.Handler do
     handler = %Handler{
       handler_name: handler_name,
       handler_module: handler_module,
-      consistency: opts[:consistency] || :eventual,
+      consistency: opts[:consistency] || Application.get_env(:commanded, :default_consistency, :eventual),
       subscribe_from: opts[:start_from] || :origin,
     }
 

--- a/test/event/handler_config_test.exs
+++ b/test/event/handler_config_test.exs
@@ -12,6 +12,17 @@ defmodule Commanded.Event.HandlerConfigTest do
     assert_config handler, [consistency: :eventual, start_from: :origin]
   end
 
+  describe "global config change to default consistency" do
+    test "should default to `:eventual` consistency and start from `:origin`" do
+      Mix.Config.persist(commanded: [default_consistency: :strong])
+      {:ok, handler} = DefaultConfigHandler.start_link()
+
+      assert_config handler, [consistency: :strong, start_from: :origin]
+
+      Mix.Config.persist(commanded: [default_consistency: :eventual])
+    end
+  end
+
   defmodule ExampleHandler do
     use Commanded.Event.Handler,
       name: __MODULE__,


### PR DESCRIPTION
Why:

* In some situations, particularly when testing, we'll want to have
  strong consistency, but that might not be true for the same operation
  in a different environment. So, it would be very helpful to be able to
  switch between types of consistency per environment.

This change addresses the need by:

* Changing the default from being straight up `:eventual` but instead to
  search on the env first and only if nothing is found, then it will
  choose `:eventual`

PS: You'll notice that there are no test for the router change. That is because it is set in a module attribute, which being a compile time evaluated property means I cannot affect from the spec. The only way I could think of testing it, would be to create a new environment just for that purpose, which might be an overkill. What do you think?