### PR TITLE
Add Assertion to ListAllDone event

### DIFF
--- a/test/process_managers/multi_routing_test.exs
+++ b/test/process_managers/multi_routing_test.exs
@@ -22,7 +22,7 @@ defmodule Commanded.ProcessManager.MultiRoutingTest do
     # mark list done should mark individual TODOs as done via process manager
     :ok = TodoRouter.dispatch(%MarkAllDone{list_uuid: list_uuid})
 
-    assert_receive_event(ListAllDone, fn done -> done.list_uuid == list_uuid end)
+    assert_receive_event(ListAllDone, fn done -> assert done.list_uuid == list_uuid end)
 
     assert_receive_event(TodoDone, fn done -> done.todo_uuid == todo1_uuid end, fn done ->
       assert done.todo_uuid == todo1_uuid


### PR DESCRIPTION
assert_receive_event is missing an assert, so the check for list_uuid never fails.

When learning Commanded, I used this example as a template, then later realised none of my tests were failing and I needed to assert inside function.