### PR TITLE
Fix testing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ MIT License
   - [Single node deployment](guides/Deployment.md#single-node-deployment)
   - [Multi node cluster deployment](guides/Deployment.md#multi-node-cluster-deployment)
   - [Multi node, but not clustered deployment](guides/Deployment.md#multi-node-but-not-clustered-deployment)
-- [Testing with Commanded](guides/Testing.md)
+- [Testing with Commanded](guides/testing.md)
 - [Used in production?](#used-in-production)
 - [Example application](#example-application)
 - [Learn Commanded in 20 minutes](#learn-commanded-in-20-minutes)


### PR DESCRIPTION
The testing link in README.md linked to guides/Testing.md, which does not exist.

Small change so the link matches the file.