### PR TITLE
Command dispatch consistency using explicit handler names 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next release
+
+- Command dispatch consistency using explicit handler names ([#161](https://github.com/commanded/commanded/pull/161)).
+
 ## v0.16.0-rc.0
 
 - Support composite command routers ([#111](https://github.com/commanded/commanded/pull/111)).

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -174,15 +174,14 @@ In Commanded, the available options during command dispatch are:
     :ok = BankRouter.dispatch(command, consistency: :strong)
     ```
 
-  Dispatching a command using `:strong` consistency but without any strongly consistent event handlers configured will have no effect.
+    Dispatching a command using `:strong` consistency but without any strongly consistent event handlers configured will have no effect.
 
-  - Provide an explicit list of event handler names, containing only those handlers you'd like to wait for. No other handlers will be awaited on, regardless of their own configured consistency setting.
+  - Provide an explicit list of event handler and process manager modules (or their configured names), containing only those handlers you'd like to wait for. No other handlers will be awaited on, regardless of their own configured consistency setting.
 
-    ```elixir      
+    ```elixir
+    :ok = BankRouter.dispatch(command, consistency: [ExampleHandler, AnotherHandler])
     :ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
     ```
-
-    You should use the `name/0` function provided by the event handler macro, such as `ExampleHandler.name()`, to use the correct name.
 
     Note you cannot opt-in to strong consistency for a handler that has been configured as eventually consistent.
 

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -154,22 +154,45 @@ end
 
 ### Command dispatch consistency guarantee
 
-You can choose the consistency guarantee provided by a command dispatch using the `consistency` option:
-
-```elixir
-:ok = BankRouter.dispatch(command, consistency: :strong)
-```
-
-The available options are `:eventual` (default) and `:strong`.
+You can choose the consistency guarantee when dispatching a command.
 
 - *Strong consistency* offers up-to-date data but at the cost of high latency.
 - *Eventual consistency* offers low latency but read model queries may reply with stale data since they may not have processed the persisted events.
 
-When dispatching a command using `consistency: :strong` the dispatch will block until all of the strongly consistent event handlers and process managers have handled all events created by the command. This guarantees that when you receive the `:ok` response from dispatch your strongly consistent read models will have been updated and can safely be queried. Strong consistency helps to alleviate problems and workarounds you would otherwise encounter when dealing with eventual consistency in your own application.
+In Commanded, the available options during command dispatch are:
 
-Use `:strong` consistency when you want to query a read model immediately after dispatching a command. You *must* also configure the event handler to use `:strong` consistency. Dispatching a command using `:strong` consistency but without any strongly consistent event handlers configured will have no effect.
+  - `:eventual` (default) - don't block command dispatch and don't wait for any event handlers, regardless of their own consistency configuration.
 
-Using `:eventual` consistency, or omitting the `consistency` option, will cause the command dispatch to immediately return without waiting for any event handlers. The handlers run independently and asynchronously in the background, therefore you will need to deal with potentially stale read model data.
+    ```elixir
+    :ok = BankRouter.dispatch(command)
+    :ok = BankRouter.dispatch(command, consistency: :eventual)
+    ```
+
+  - `:strong` - block command dispatch until all strongly consistent event handlers and process managers have successfully processed all events created by the command.
+
+    ```elixir
+    :ok = BankRouter.dispatch(command, consistency: :strong)
+    ```
+
+  Dispatching a command using `:strong` consistency but without any strongly consistent event handlers configured will have no effect.
+
+  - Provide an explicit list of event handler names, containing only those handlers you'd like to wait for. No other handlers will be awaited on, regardless of their own configured consistency setting.
+
+    ```elixir      
+    :ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
+    ```
+
+    You should use the `name/0` function provided by the event handler macro, such as `ExampleHandler.name()`, to use the correct name.
+
+    Note you cannot opt-in to strong consistency for a handler that has been configured as eventually consistent.
+
+#### Which consistency guarantee should I use?
+
+When dispatching a command using `consistency: :strong` the dispatch will block until all of the strongly consistent event handlers and process managers have handled all events created by the command. This guarantees that when you receive the `:ok` response from dispatch, your strongly consistent read models will have been updated and can safely be queried.
+
+Strong consistency helps to alleviate problems and workarounds you would otherwise encounter when dealing with eventual consistency in your own application. Use `:strong` consistency when you want to query a read model immediately after dispatching a command. You *must* also configure the event handler to use `:strong` consistency.
+
+Using `:eventual` consistency, or omitting the `consistency` option, will cause the command dispatch to immediately return without waiting for any event handlers or process managers. The handlers run independently, and asynchronously, in the background, therefore you will need to deal with potentially stale read model data.
 
 #### Configure default consistency
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -138,8 +138,11 @@ defmodule Commanded.Commands.Dispatcher do
               metadata: pipeline.metadata,
             }
           }
-        %{include_aggregate_version: true} -> {:ok, pipeline.assigns.aggregate_version}
-        _ -> :ok
+        %{include_aggregate_version: true} ->
+          {:ok, pipeline.assigns.aggregate_version}
+          
+        _ ->
+          :ok
       end
 
     Pipeline.respond(pipeline, response)

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -68,17 +68,32 @@ defmodule Commanded.Commands.Router do
 
   ## Consistency
 
-  You can choose to dispatch commands using either `:eventual` or `:strong`
-  consistency:
+  You can choose the consistency guarantee when dispatching a command. The
+  available options are:
 
-      :ok = BankRouter.dispatch(command, consistency: :strong)
+    - `:eventual` (default) - don't block command dispatch while waiting for
+      event handlers
 
-  Using `:strong` consistency will block command dispatch until all strongly
-  consistent event handlers and process managers have successfully process all
-  events created by the command.
+        :ok = BankRouter.dispatch(command)
+        :ok = BankRouter.dispatch(command, consistency: :eventual)
 
-  Use this when you have event handlers that update read models you need to
-  query immediately after dispatching the command.
+    - `:strong` - block command dispatch until all strongly
+      consistent event handlers and process managers have successfully processed
+      all events created by the command.
+
+      Use this when you have event handlers that update read models you need to
+      query immediately after dispatching the command.
+
+        :ok = BankRouter.dispatch(command, consistency: :strong)
+
+    - Provide an explicit list of event handler names, containing only those
+      handlers you'd like to wait for. No other handlers will be awaited on,
+      regardless of their own configured consistency setting.
+
+        :ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
+
+      Note you cannot opt-in to strong consistency for a handler that has been
+      configured as eventually consistent.
 
   ## Aggregate version
 

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -86,11 +86,15 @@ defmodule Commanded.Commands.Router do
 
         :ok = BankRouter.dispatch(command, consistency: :strong)
 
-    - Provide an explicit list of event handler names, containing only those
-      handlers you'd like to wait for. No other handlers will be awaited on,
-      regardless of their own configured consistency setting.
+    - Provide an explicit list of event handler and process manager modules (or
+      their configured names), containing only those handlers you'd like to wait
+      for. No other handlers will be awaited on, regardless of their own
+      configured consistency setting.
 
-        :ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
+      ```elixir
+      :ok = BankRouter.dispatch(command, consistency: [ExampleHandler, AnotherHandler])
+      :ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
+      ```
 
       Note you cannot opt-in to strong consistency for a handler that has been
       configured as eventually consistent.

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -274,6 +274,8 @@ defmodule Commanded.Event.Handler do
         Supervisor.child_spec(default, [])
       end
 
+      def name, do: @name
+
       @doc false
       def init, do: :ok
 
@@ -404,7 +406,7 @@ defmodule Commanded.Event.Handler do
         {:stop, reason, state}
     end
   end
-  
+
   defp subscribe_to_all_streams(%Handler{} = state) do
     %Handler{
       handler_name: handler_name,

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -274,7 +274,8 @@ defmodule Commanded.Event.Handler do
         Supervisor.child_spec(default, [])
       end
 
-      def name, do: @name
+      @doc false
+      def __name__, do: @name
 
       @doc false
       def init, do: :ok

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -246,6 +246,9 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
         Supervisor.child_spec(default, [])
       end
+
+      @doc false
+      def __name__, do: @name
     end
   end
 

--- a/lib/commanded/subscriptions.ex
+++ b/lib/commanded/subscriptions.ex
@@ -29,8 +29,12 @@ defmodule Commanded.Subscriptions do
   handler.
   """
   def ack_event(name, consistency, event)
+
   def ack_event(_name, :eventual, _event), do: :ok
-  def ack_event(name, :strong, %RecordedEvent{stream_id: stream_id, stream_version: stream_version}) do
+
+  def ack_event(name, :strong, %RecordedEvent{} = event) do
+    %RecordedEvent{stream_id: stream_id, stream_version: stream_version} = event
+
     PubSub.broadcast(@ack_topic, {:ack_event, name, stream_id, stream_version})
   end
 
@@ -45,24 +49,24 @@ defmodule Commanded.Subscriptions do
   @doc """
   Have all the registered handlers processed the given event?
   """
-  def handled?(stream_uuid, stream_version, consistency \\ :strong, exclude \\ [])
-  def handled?(stream_uuid, stream_version, consistency, exclude) do
-    GenServer.call(__MODULE__, {:handled?, stream_uuid, stream_version, consistency, MapSet.new(exclude)})
+  def handled?(stream_uuid, stream_version, opts \\ []) do
+    GenServer.call(__MODULE__, {:handled?, stream_uuid, stream_version, opts})
   end
 
   @doc """
   Wait until all strongly consistent event store subscriptions have received
   and successfully handled the given event, by stream identity and version.
 
+  Options:
+
+    - `:consistency` - override the default consistency (`:strong`), by
+      providing an explicit list of handler modules, or their configured names,
+      to wait for.
+    - `:exclude` - a PID, or list of PIDs, to exclude from waiting.
+
   Returns `:ok` on success, or `{:error, :timeout}` on failure due to timeout.
   """
-  def wait_for(stream_uuid, stream_version, opts \\ [], timeout \\ default_consistency_timeout())
-  def wait_for(stream_uuid, stream_version, opts, timeout) do
-    consistency = Keyword.get(opts, :consistency, :strong)
-    exclusions = opts |> Keyword.get(:exclude, []) |> List.wrap() |> MapSet.new()
-
-    opts = [consistency: consistency, exclusions: exclusions]
-
+  def wait_for(stream_uuid, stream_version, opts \\ [], timeout \\ default_consistency_timeout()) do
     :ok = GenServer.call(__MODULE__, {:subscribe, stream_uuid, stream_version, opts, self()})
 
     receive do
@@ -88,18 +92,21 @@ defmodule Commanded.Subscriptions do
     {:reply, :ok, initial_state()}
   end
 
-  def handle_call({:handled?, stream_uuid, stream_version, consistency, exclude}, _from, %Subscriptions{} = state) do
+  def handle_call({:handled?, stream_uuid, stream_version, opts}, _from, %Subscriptions{} = state) do
+    {consistency, exclude} = parse_opts(opts)
+
     reply = handled_by_all?(stream_uuid, stream_version, consistency, exclude, state)
 
     {:reply, reply, state}
   end
 
   def handle_call({:subscribe, stream_uuid, stream_version, opts, pid}, _from, %Subscriptions{} = state) do
-    [consistency: consistency, exclusions: exclusions] = opts
+    {consistency, exclude} = parse_opts(opts)
+
     %Subscriptions{subscribers: subscribers} = state
 
     state =
-      case handled_by_all?(stream_uuid, stream_version, consistency, exclusions, state) do
+      case handled_by_all?(stream_uuid, stream_version, consistency, exclude, state) do
         true ->
           # immediately notify subscriber since all handlers have already
           # processed the requested event
@@ -112,7 +119,7 @@ defmodule Commanded.Subscriptions do
           # processed by all handlers
           Process.monitor(pid)
 
-          subscription = {pid, stream_uuid, stream_version, consistency, exclusions}
+          subscription = {pid, stream_uuid, stream_version, consistency, exclude}
 
           %Subscriptions{state | subscribers: [subscription | subscribers]}
       end
@@ -201,7 +208,7 @@ defmodule Commanded.Subscriptions do
     end)
   end
 
-  # notify any subscribers waiting on a given stream if it is at the expected version
+  # Notify any subscribers waiting on a given stream if it is at the expected version
   defp notify_subscribers(stream_uuid, %Subscriptions{subscribers: subscribers} = state) do
     Enum.reduce(subscribers, subscribers, fn
       ({pid, ^stream_uuid, expected_stream_version, consistency, exclude} = subscriber, subscribers) ->
@@ -209,7 +216,7 @@ defmodule Commanded.Subscriptions do
           true ->
             notify_subscriber(pid, stream_uuid, expected_stream_version)
 
-            # remove subscriber
+            # Remove subscriber
             subscribers -- [subscriber]
 
           false ->
@@ -224,12 +231,12 @@ defmodule Commanded.Subscriptions do
     send(pid, {:ok, stream_uuid, stream_version})
   end
 
-  # send an info message to the process to purge expired stream ack's
+  # Send an info message to the process to purge expired stream ack's
   defp schedule_purge_streams(ttl \\ default_ttl()) do
     Process.send_after(self(), {:purge_expired_streams, ttl}, ttl)
   end
 
-  # delete subscription ack's that are older than the configured ttl
+  # Delete subscription ack's that are older than the configured ttl
   defp purge_expired_streams(ttl, %Subscriptions{streams_table: streams_table, started_at: started_at}) do
     stale_epoch = monotonic_time() - started_at - (ttl / 1_000)
 
@@ -237,6 +244,34 @@ defmodule Commanded.Subscriptions do
     |> :ets.select([{{:"$1", :"$2", :"$3"}, [{:"=<", :"$3", stale_epoch}], [:"$1"]}])
     |> Enum.each(&:ets.delete(streams_table, &1))
   end
+
+  defp parse_opts(opts) do
+    consistency = opts |> Keyword.get(:consistency, :strong) |> parse_consistency()
+    exclude = opts |> Keyword.get(:exclude, []) |> parse_exclude()
+
+    {consistency, exclude}
+  end
+
+  defp parse_consistency(consistency) when consistency in [:eventual, :strong], do: consistency
+  defp parse_consistency(consistency) when is_list(consistency) do
+    Enum.map(consistency, fn
+      name when is_bitstring(name) ->
+        name
+
+      module when is_atom(module) ->
+        if function_exported?(module, :__name__, 0) do
+          apply(module, :__name__, [])
+        else
+          raise "Expected module #{module} to contain a public `__name__/0` function"
+        end
+
+      invalid ->
+        raise "Invalid consistency: #{inspect invalid}"
+    end)
+  end
+  defp parse_consistency(invalid), do: raise "Invalid consistency: #{inspect invalid}"
+
+  defp parse_exclude(exclude), do: exclude |> List.wrap() |> MapSet.new()
 
   defp monotonic_time, do: System.monotonic_time(:seconds)
 

--- a/test/commands/dispatch_consistency_test.exs
+++ b/test/commands/dispatch_consistency_test.exs
@@ -69,7 +69,7 @@ defmodule Commanded.Commands.DispatchConsistencyTest do
 
     test "should only wait for opt-in strongly consistent event handler to handle event" do
       command = %ConsistencyCommand{uuid: UUID.uuid4(), delay: 100}
-      opts = [consistency: [OptionalStronglyConsistentEventHandler.name()]]
+      opts = [consistency: [OptionalStronglyConsistentEventHandler]]
 
       assert :ok = ConsistencyRouter.dispatch(command, opts)
     end

--- a/test/commands/support/consistency/optional_strongly_consistent_handler.ex
+++ b/test/commands/support/consistency/optional_strongly_consistent_handler.ex
@@ -1,0 +1,31 @@
+defmodule Commanded.Commands.OptionalStronglyConsistentEventHandler do
+  use Commanded.Event.Handler,
+    name: "OptionalStronglyConsistentEventHandler",
+    consistency: :strong
+
+  alias Commanded.Commands.{
+    ConsistencyAggregateRoot,
+    ConsistencyRouter
+  }
+
+  alias ConsistencyAggregateRoot.{
+    ConsistencyCommand,
+    ConsistencyEvent,
+    DispatchRequestedEvent
+  }
+
+  def handle(%ConsistencyEvent{delay: delay}, _metadata) do
+    :timer.sleep(round(delay / 4))
+    :ok
+  end
+
+  # handle event by dispatching a command
+  def handle(%DispatchRequestedEvent{uuid: uuid, delay: delay}, _metadata) do
+    :timer.sleep(round(delay / 4))
+
+    ConsistencyRouter.dispatch(
+      %ConsistencyCommand{uuid: uuid, delay: delay},
+      consistency: :strong
+    )
+  end
+end

--- a/test/commands/support/consistency/optional_strongly_consistent_handler.ex
+++ b/test/commands/support/consistency/optional_strongly_consistent_handler.ex
@@ -15,13 +15,13 @@ defmodule Commanded.Commands.OptionalStronglyConsistentEventHandler do
   }
 
   def handle(%ConsistencyEvent{delay: delay}, _metadata) do
-    :timer.sleep(round(delay / 4))
+    :timer.sleep(round(delay / 10))
     :ok
   end
 
   # handle event by dispatching a command
   def handle(%DispatchRequestedEvent{uuid: uuid, delay: delay}, _metadata) do
-    :timer.sleep(round(delay / 4))
+    :timer.sleep(round(delay / 10))
 
     ConsistencyRouter.dispatch(
       %ConsistencyCommand{uuid: uuid, delay: delay},

--- a/test/event/event_handler_macro_test.exs
+++ b/test/event/event_handler_macro_test.exs
@@ -33,4 +33,8 @@ defmodule Commanded.Event.EventHandlerMacroTest do
       assert AccountBalanceHandler.current_balance == 1_050
     end)
   end
+
+  test "should provide handler name function" do
+    assert AccountBalanceHandler.name() == "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler"
+  end
 end

--- a/test/event/event_handler_macro_test.exs
+++ b/test/event/event_handler_macro_test.exs
@@ -2,14 +2,14 @@ defmodule Commanded.Event.EventHandlerMacroTest do
   use Commanded.StorageCase
 
   alias Commanded.Event.IgnoredEvent
-  alias Commanded.Helpers.{EventFactory,ProcessHelper,Wait}
-  alias Commanded.ExampleDomain.BankAccount.Events.{BankAccountOpened,MoneyDeposited}
+  alias Commanded.Helpers.{EventFactory, ProcessHelper, Wait}
+  alias Commanded.ExampleDomain.BankAccount.Events.{BankAccountOpened, MoneyDeposited}
   alias Commanded.ExampleDomain.BankAccount.AccountBalanceHandler
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       ProcessHelper.shutdown(AccountBalanceHandler)
-    end
+    end)
   end
 
   test "should handle published events" do
@@ -23,18 +23,19 @@ defmodule Commanded.Event.EventHandlerMacroTest do
       [
         %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000},
         %MoneyDeposited{amount: 50, balance: 1_050},
-        %IgnoredEvent{name: "ignored"},
+        %IgnoredEvent{name: "ignored"}
       ]
       |> EventFactory.map_to_recorded_events()
 
     send(handler, {:events, recorded_events})
 
     Wait.until(fn ->
-      assert AccountBalanceHandler.current_balance == 1_050
+      assert AccountBalanceHandler.current_balance() == 1_050
     end)
   end
 
-  test "should provide handler name function" do
-    assert AccountBalanceHandler.name() == "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler"
+  test "should provide `__name__/0` function" do
+    assert AccountBalanceHandler.__name__() ==
+             "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler"
   end
 end

--- a/test/subscriptions/subscriptions_test.exs
+++ b/test/subscriptions/subscriptions_test.exs
@@ -45,7 +45,7 @@ defmodule Commanded.SubscriptionsTest do
       :ok = Subscriptions.register("handler1", :strong)
 
       # current process should not block handler
-      assert Subscriptions.handled?("stream1", 1, [self()])
+      assert Subscriptions.handled?("stream1", 1, exclude: [self()])
     end
   end
 
@@ -138,9 +138,9 @@ defmodule Commanded.SubscriptionsTest do
       :ok = Subscriptions.ack_event("handler2", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 2})
 
       refute Subscriptions.handled?("stream1", 2)
-      assert Subscriptions.handled?("stream1", 2, ["handler1", "handler2"])
-      refute Subscriptions.handled?("stream1", 2, ["handler1", "handler2", "handler3"])
-      assert Subscriptions.handled?("stream1", 2, ["handler1", "handler2", "handler4"])
+      assert Subscriptions.handled?("stream1", 2, consistency: ["handler1", "handler2"])
+      refute Subscriptions.handled?("stream1", 2, consistency: ["handler1", "handler2", "handler3"])
+      assert Subscriptions.handled?("stream1", 2, consistency: ["handler1", "handler2", "handler4"])
 
       assert :ok == Subscriptions.wait_for("stream1", 2, consistency: ["handler1", "handler2"])
       assert {:error, :timeout} == Subscriptions.wait_for("stream1", 2, [consistency: ["handler1", "handler2", "handler3"]], 100)

--- a/test/subscriptions/subscriptions_test.exs
+++ b/test/subscriptions/subscriptions_test.exs
@@ -66,7 +66,7 @@ defmodule Commanded.SubscriptionsTest do
     test "should immediately succeed when excluding handler process" do
       :ok = Subscriptions.register("handler", :strong)
 
-      assert :ok == Subscriptions.wait_for("stream1", 2, [self()])
+      assert :ok == Subscriptions.wait_for("stream1", 2, exclude: [self()])
     end
 
     test "should succeed when waited event is ack'd" do
@@ -116,6 +116,34 @@ defmodule Commanded.SubscriptionsTest do
       :ok = Subscriptions.ack_event("handler", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 4})
 
       assert Subscriptions.handled?("stream1", 2)
+    end
+
+    test "should allow per-handler consistency" do
+      :ok = Subscriptions.register("handler1", :strong)
+      :ok = Subscriptions.register("handler2", :strong)
+
+      :ok = Subscriptions.ack_event("handler1", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 2})
+
+      refute Subscriptions.handled?("stream1", 2)
+      assert :ok == Subscriptions.wait_for("stream1", 2, consistency: ["handler1"])
+    end
+
+    test "should wait for each configured handler consistency" do
+      :ok = Subscriptions.register("handler1", :strong)
+      :ok = Subscriptions.register("handler2", :strong)
+      :ok = Subscriptions.register("handler3", :strong)
+      :ok = Subscriptions.register("handler3", :eventual)
+
+      :ok = Subscriptions.ack_event("handler1", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 2})
+      :ok = Subscriptions.ack_event("handler2", :strong, %RecordedEvent{stream_id: "stream1", stream_version: 2})
+
+      refute Subscriptions.handled?("stream1", 2)
+      assert Subscriptions.handled?("stream1", 2, ["handler1", "handler2"])
+      refute Subscriptions.handled?("stream1", 2, ["handler1", "handler2", "handler3"])
+      assert Subscriptions.handled?("stream1", 2, ["handler1", "handler2", "handler4"])
+
+      assert :ok == Subscriptions.wait_for("stream1", 2, consistency: ["handler1", "handler2"])
+      assert {:error, :timeout} == Subscriptions.wait_for("stream1", 2, [consistency: ["handler1", "handler2", "handler3"]], 100)
     end
   end
 


### PR DESCRIPTION
Provide an explicit list of event handler and process manager modules, or their configured names, containing only those handlers you'd like to wait for during command dispatch. No other handlers will be awaited on, regardless of their own configured consistency setting.

```elixir
:ok = BankRouter.dispatch(command, consistency: [ExampleHandler, AnotherHandler])
:ok = BankRouter.dispatch(command, consistency: ["ExampleHandler", "AnotherHandler"])
```

Note you cannot opt-in to strong consistency for a handler that has been configured as eventually consistent.
