### PR TITLE
Ability to globally override include_execution_result and include_aggregate_version

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -145,14 +145,13 @@ defmodule Commanded.Commands.Router do
           Commanded.Middleware.ConsistencyGuarantee,
         ],
         consistency: Application.get_env(:commanded, :default_consistency, :eventual),
+        include_aggregate_version: Application.get_env(:commanded, :include_aggregate_version, false),
+        include_execution_result: Application.get_env(:commanded, :incldue_execution_result, false),
         dispatch_timeout: 5_000,
         lifespan: Commanded.Aggregates.DefaultLifespan,
         metadata: %{},
         retry_attempts: 10
       ]
-
-      @include_aggregate_version false
-      @include_execution_result false
     end
   end
 
@@ -392,8 +391,8 @@ defmodule Commanded.Commands.Router do
         consistency = Keyword.get(opts, :consistency) || unquote(consistency) || @default[:consistency]
         metadata = Keyword.get(opts, :metadata) || @default[:metadata]
         timeout = Keyword.get(opts, :timeout) || unquote(timeout) || @default[:dispatch_timeout]
-        include_aggregate_version = Keyword.get(opts, :include_aggregate_version) || @include_aggregate_version
-        include_execution_result = Keyword.get(opts, :include_execution_result) || @include_execution_result
+        include_aggregate_version = Keyword.get(opts, :include_aggregate_version) || @default[:include_aggregate_version]
+        include_execution_result = Keyword.get(opts, :include_execution_result) || @default[:include_execution_result]
         lifespan = Keyword.get(opts, :lifespan) || unquote(lifespan) || @default[:lifespan]
         retry_attempts = Keyword.get(opts, :retry_attempts) || @default[:retry_attempts]
 


### PR DESCRIPTION


We want to enforce consistent return values in our entire app.
`:include_execution_result` looks exactly like what we want, and
currently fixes two problems for us, so we want to enforce it globally.

I did a similar change to what my colleague zamith already did
previously for another option. however, unlike his case, I didn't find
a good way to test this. Would love to get any input on that front