### PR TITLE
Local PubSub: Replace noop Registry.match with Registry.lookup

### DIFF
--- a/lib/commanded/pubsub/local_pubsub.ex
+++ b/lib/commanded/pubsub/local_pubsub.ex
@@ -76,6 +76,6 @@ defmodule Commanded.PubSub.LocalPubSub do
   @spec list(String.t()) :: [{term, pid}]
   @impl Commanded.PubSub
   def list(topic) when is_binary(topic) do
-    Registry.match(LocalPubSub.Tracker, topic, :_) |> Enum.map(fn {pid, key} -> {key, pid} end)
+    Registry.lookup(LocalPubSub.Tracker, topic) |> Enum.map(fn {pid, key} -> {key, pid} end)
   end
 end


### PR DESCRIPTION
Simple change, since the `Registry.match` does not do anything in its match term, we might as well `Registry.lookup` :-)