### PR TITLE
Added Additions to the wiki section to test setup

### DIFF
--- a/guides/Testing.md
+++ b/guides/Testing.md
@@ -6,6 +6,25 @@ When using ES/CQRS, events are first-class citizens. It's critical to be able to
 
 Please refer to the [Testing your application](https://github.com/commanded/commanded/wiki/Testing-your-application) page on the Wiki for help with configuring your test environment.
 
+### Additions to the wiki:
+
+#### 1. Remember projection_versions when truncating tables
+If you rely on your read projections in your tests, remember to truncate the projection_versions table in your truncate_readstore_tables function. Otherwise, your projector will ignore everything but the first projection. 
+
+```elixir
+defp truncate_readstore_tables do
+    """
+    TRUNCATE TABLE
+      table1,
+      table2,
+      table3,
+      projection_versions    <---- REMEBER THIS LINE
+    RESTART IDENTITY
+    CASCADE;
+    """
+  end
+```
+
 ## Asserting that an event is published
 
 Often you'll want to make sure a given event is published. Commanded provides `assert_receive_event/2` and `assert_receive_event/3` functions in the `Commanded.Assertions.EventAssertions` module to help with this.


### PR DESCRIPTION
@slashdotdash feel free to add the essence of this to the wiki if you prefer that. 
The solution dawned on me when I was looking through Conduit and how it's storage.ex file was setup.