### PR TITLE
Process manager and event handler error & exception handling

### DIFF
--- a/guides/Events.md
+++ b/guides/Events.md
@@ -86,7 +86,7 @@ end
 
 ### `error/3` callback
 
-You can define an `error/3` callback function to handle any errors returned from your event handler's `handle/2` functions. The `error/3` function is passed the actual error (e.g. `{:error, :failure}`), the failed event, and a failure context.
+You can define an `error/3` callback function to handle any exceptions or errors returned from your event handler's `handle/2` functions. The `error/3` function is passed the actual error (e.g. `{:error, :failure}`), the failed event, and a failure context.
 
 Use pattern matching on the error and/or failed event to explicitly handle certain errors or events. You can choose to retry, skip, or stop the event handler after an error.
 
@@ -103,7 +103,7 @@ defmodule ExampleHandler do
   alias Commanded.Event.FailureContext
 
   def handle(%AnEvent{}, _metadata) do
-    # simulate event handling failure
+    # Simulate event handling failure
     {:error, :failed}
   end
 
@@ -112,13 +112,13 @@ defmodule ExampleHandler do
 
     case Map.get(context, :failures) do
       too_many when too_many >= 3 ->
-        # skip bad event after third failure
+        # Skip bad event after third failure
         Logger.warn(fn -> "Skipping bad event, too many failures: " <> inspect(event) end)
 
         :skip
 
       _ ->
-        # retry event, failure count is included in context map
+        # Retry event, failure count is included in context map
         {:retry, context}
     end
   end

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -33,8 +33,12 @@ defmodule Commanded.ProcessManagers.ProcessManager do
           # ...
         end
 
+        def error({:error, failure}, %ExampleEvent{}, _failure_context) do
+          # Retry, skip, ignore, or stop process manager on error handling event
+        end
+
         def error({:error, failure}, %ExampleCommand{}, _failure_context) do
-          # retry, skip, ignore, or stop process manager on error dispatching command
+          # Retry, skip, ignore, or stop process manager on error dispatching command
         end
       end
 
@@ -44,19 +48,20 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
   # Error handling
 
-  You can define an `c:error/3` callback function to handle any errors returned
-  by commands dispatched from your process manager. The function is passed the
-  command dispatch error (e.g. `{:error, :failure}`), the failed command, and a
-  failure context. See `Commanded.ProcessManagers.FailureContext` for details.
+  You can define an `c:error/3` callback function to handle any errors or
+  exceptions during event handling or returned by commands dispatched from your
+  process manager. The function is passed the error (e.g. `{:error, :failure}`),
+  the failed event or command, and a failure context.
+  See `Commanded.ProcessManagers.FailureContext` for details.
 
-  Use pattern matching on the error and/or failed command to explicitly handle
-  certain errors or commands. You can choose to retry, skip, ignore, or stop the
-  process manager after a command dispatch error.
+  Use pattern matching on the error and/or failed event/command to explicitly
+  handle certain errors, events, or commands. You can choose to retry, skip,
+  ignore, or stop the process manager after a command dispatch error.
 
   The default behaviour, if you don't provide an `c:error/3` callback, is to
   stop the process manager using the exact error reason returned from the
-  command dispatch. You should supervise your process managers to ensure they
-  are restarted on error.
+  event handler function or command dispatch. You should supervise your
+  process managers to ensure they are restarted on error.
 
   ## Example
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -1,41 +1,46 @@
 defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @moduledoc false
+
   use GenServer
 
   require Logger
 
-  alias Commanded.ProcessManagers.{
-    ProcessRouter,
-    ProcessManagerInstance,
-    FailureContext,
-  }
+  alias Commanded.ProcessManagers.{ProcessRouter, ProcessManagerInstance, FailureContext}
   alias Commanded.EventStore
-  alias Commanded.EventStore.{
-    RecordedEvent,
-    SnapshotData,
-  }
+  alias Commanded.EventStore.{RecordedEvent, SnapshotData}
 
   defstruct [
-    command_dispatcher: nil,
-    process_manager_name: nil,
-    process_manager_module: nil,
-    process_uuid: nil,
-    process_state: nil,
-    last_seen_event: nil,
+    :command_dispatcher,
+    :process_router,
+    :process_manager_name,
+    :process_manager_module,
+    :process_uuid,
+    :process_state,
+    :last_seen_event
   ]
 
-  def start_link(command_dispatcher, process_manager_name, process_manager_module, process_uuid) do
-    GenServer.start_link(__MODULE__, %ProcessManagerInstance{
+  def start_link(
+        command_dispatcher,
+        process_router,
+        process_manager_name,
+        process_manager_module,
+        process_uuid
+      ) do
+    state = %ProcessManagerInstance{
       command_dispatcher: command_dispatcher,
+      process_router: process_router,
       process_manager_name: process_manager_name,
       process_manager_module: process_manager_module,
       process_uuid: process_uuid,
-      process_state: struct(process_manager_module),
-    })
+      process_state: struct(process_manager_module)
+    }
+
+    GenServer.start_link(__MODULE__, state)
   end
 
   def init(%ProcessManagerInstance{} = state) do
     GenServer.cast(self(), :fetch_state)
+
     {:ok, state}
   end
 
@@ -49,8 +54,8 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @doc """
   Handle the given event by delegating to the process manager module
   """
-  def process_event(process_manager, %RecordedEvent{} = event, process_router) do
-    GenServer.cast(process_manager, {:process_event, event, process_router})
+  def process_event(process_manager, %RecordedEvent{} = event) do
+    GenServer.cast(process_manager, {:process_event, event})
   end
 
   @doc """
@@ -78,12 +83,16 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc false
-  def handle_call(:process_state, _from, %ProcessManagerInstance{process_state: process_state} = state) do
+  def handle_call(:process_state, _from, %ProcessManagerInstance{} = state) do
+    %ProcessManagerInstance{process_state: process_state} = state
+
     {:reply, process_state, state}
   end
 
   @doc false
-  def handle_call(:new?, _from, %ProcessManagerInstance{last_seen_event: last_seen_event} = state) do
+  def handle_call(:new?, _from, %ProcessManagerInstance{} = state) do
+    %ProcessManagerInstance{last_seen_event: last_seen_event} = state
+
     {:reply, is_nil(last_seen_event), state}
   end
 
@@ -91,15 +100,18 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   Attempt to fetch intial process state from snapshot storage
   """
   def handle_cast(:fetch_state, %ProcessManagerInstance{} = state) do
-    state = case EventStore.read_snapshot(process_state_uuid(state)) do
-      {:ok, snapshot} ->
-        %ProcessManagerInstance{state |
-          process_state: snapshot.data,
-          last_seen_event: snapshot.source_version,
-        }
+    state =
+      case EventStore.read_snapshot(process_state_uuid(state)) do
+        {:ok, snapshot} ->
+          %ProcessManagerInstance{
+            state
+            | process_state: snapshot.data,
+              last_seen_event: snapshot.source_version
+          }
 
-      {:error, :snapshot_not_found} -> state
-    end
+        {:error, :snapshot_not_found} ->
+          state
+      end
 
     {:noreply, state}
   end
@@ -107,48 +119,61 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @doc """
   Handle the given event, using the process manager module, against the current process state
   """
-  def handle_cast({:process_event, %RecordedEvent{} = event, process_router}, %ProcessManagerInstance{} = state) do
+  def handle_cast({:process_event, event}, %ProcessManagerInstance{} = state) do
     case event_already_seen?(event, state) do
-      true -> process_seen_event(event, process_router, state)
-      false -> process_unseen_event(event, process_router, state)
+      true -> process_seen_event(event, state)
+      false -> process_unseen_event(event, state)
     end
   end
 
   defp event_already_seen?(
-    %RecordedEvent{event_number: event_number},
-    %ProcessManagerInstance{last_seen_event: last_seen_event})
-  do
+         %RecordedEvent{event_number: event_number},
+         %ProcessManagerInstance{last_seen_event: last_seen_event}
+       ) do
     not is_nil(last_seen_event) and event_number <= last_seen_event
   end
 
-  defp process_seen_event(event = %RecordedEvent{}, process_router, state) do
-    # already seen event, so just ack
-    :ok = ack_event(event, process_router)
+  # Already seen event, so just ack
+  defp process_seen_event(event, state) do
+    :ok = ack_event(event, state)
 
     {:noreply, state}
   end
 
-  defp process_unseen_event(%RecordedEvent{correlation_id: correlation_id, event_id: event_id, event_number: event_number} = event, process_router, %ProcessManagerInstance{} = state) do
-    case handle_event(event, state) do
-      {:error, reason} ->
-        Logger.error(fn -> describe(state) <> " failed to handle event #{inspect event_number} due to: #{inspect reason}" end)
+  defp process_unseen_event(event, state, context \\ %{}) do
+    %RecordedEvent{
+      correlation_id: correlation_id,
+      event_id: event_id,
+      event_number: event_number
+    } = event
 
-	      {:stop, reason, state}
+    case handle_event(event, state) do
+      {:error, error} ->
+        Logger.error(fn ->
+          describe(state) <>
+            " failed to handle event #{inspect(event_number)} due to: #{inspect(error)}"
+        end)
+
+        handle_event_error({:error, error}, event, state, context)
+
+      {:stop, _error, _state} = reply ->
+        reply
 
       commands ->
-        # copy event id, as causation id, and correlation id from handled event
+        # Copy event id, as causation id, and correlation id from handled event.
         opts = [causation_id: event_id, correlation_id: correlation_id]
 
         with :ok <- commands |> List.wrap() |> dispatch_commands(opts, state, event) do
           process_state = mutate_state(event, state)
 
-          state = %ProcessManagerInstance{state |
-            process_state: process_state,
-            last_seen_event: event_number,
+          state = %ProcessManagerInstance{
+            state
+            | process_state: process_state,
+              last_seen_event: event_number
           }
 
-          :ok = persist_state(state, event_number)
-          :ok = ack_event(event, process_router)
+          :ok = persist_state(event_number, state)
+          :ok = ack_event(event, state)
 
           {:noreply, state}
         else
@@ -158,41 +183,118 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     end
   end
 
-  # process instance is given the event and returns applicable commands (may be none, one or many)
-  defp handle_event(%RecordedEvent{data: data}, %ProcessManagerInstance{process_manager_module: process_manager_module, process_state: process_state}) do
-    process_manager_module.handle(process_state, data)
+  # Process instance is given the event and returns applicable commands
+  # (may be none, one or many).
+  defp handle_event(%RecordedEvent{} = event, %ProcessManagerInstance{} = state) do
+    %RecordedEvent{data: data} = event
+
+    %ProcessManagerInstance{
+      process_manager_module: process_manager_module,
+      process_state: process_state
+    } = state
+
+    try do
+      process_manager_module.handle(process_state, data)
+    rescue
+      e ->
+        {:error, e}
+    end
+  end
+
+  defp handle_event_error(error, failed_event, state, context) do
+    %RecordedEvent{data: data} = failed_event
+    %ProcessManagerInstance{process_manager_module: process_manager_module} = state
+
+    failure_context = %FailureContext{
+      pending_commands: [],
+      process_manager_state: state,
+      last_event: failed_event,
+      context: context
+    }
+
+    case process_manager_module.error(error, data, failure_context) do
+      {:retry, context} when is_map(context) ->
+        # Retry the failed event
+        Logger.info(fn -> describe(state) <> " is retrying failed event" end)
+
+        process_unseen_event(failed_event, state, context)
+
+      {:retry, delay, context} when is_map(context) and is_integer(delay) and delay >= 0 ->
+        # Retry the failed event after waiting for the given delay, in milliseconds
+        Logger.info(fn ->
+          describe(state) <> " is retrying failed event after #{inspect(delay)}ms"
+        end)
+
+        :timer.sleep(delay)
+
+        process_unseen_event(failed_event, state, context)
+
+      :skip ->
+        # Skip the failed event by confirming receipt
+        Logger.info(fn -> describe(state) <> " is skipping event" end)
+
+        :ok = ack_event(failed_event, state)
+
+        {:noreply, state}
+
+      {:stop, error} ->
+        # Stop the process manager instance
+        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(error)}" end)
+
+        {:stop, error, state}
+
+      invalid ->
+        Logger.warn(fn ->
+          describe(state) <> " returned an invalid error reponse: #{inspect(invalid)}"
+        end)
+
+        # Stop process manager with original error
+        {:stop, error, state}
+    end
   end
 
   # update the process instance's state by applying the event
-  defp mutate_state(%RecordedEvent{data: data}, %ProcessManagerInstance{process_manager_module: process_manager_module, process_state: process_state}) do
+  defp mutate_state(%RecordedEvent{data: data}, %ProcessManagerInstance{
+         process_manager_module: process_manager_module,
+         process_state: process_state
+       }) do
     process_manager_module.apply(process_state, data)
   end
 
   defp dispatch_commands(commands, opts, state, last_event, context \\ %{})
   defp dispatch_commands([], _opts, _state, _last_event, _context), do: :ok
+
   defp dispatch_commands([command | pending_commands], opts, state, last_event, context) do
-    Logger.debug(fn -> describe(state) <> " attempting to dispatch command: #{inspect command}" end)
+    Logger.debug(fn ->
+      describe(state) <> " attempting to dispatch command: #{inspect(command)}"
+    end)
 
     case state.command_dispatcher.dispatch(command, opts) do
       :ok ->
         dispatch_commands(pending_commands, opts, state, last_event)
 
       error ->
-        Logger.warn(fn -> describe(state) <> " failed to dispatch command #{inspect command} due to: #{inspect error}" end)
+        Logger.warn(fn ->
+          describe(state) <>
+            " failed to dispatch command #{inspect(command)} due to: #{inspect(error)}"
+        end)
 
-        dispatch_failure(error, command, pending_commands, opts, state, last_event, context)
+        failure_context = %FailureContext{
+          pending_commands: pending_commands,
+          process_manager_state: mutate_state(last_event, state),
+          last_event: last_event,
+          context: context
+        }
+
+        dispatch_failure(error, command, opts, state, failure_context)
     end
   end
 
-  defp dispatch_failure(error, failed_command, pending_commands, opts, state, last_event, context) do
-    failure_context = %FailureContext{
-      pending_commands: pending_commands,
-      process_manager_state: mutate_state(last_event, state),
-      last_event: last_event,
-      context: context
-    }
+  defp dispatch_failure(error, failed_command, opts, state, failure_context) do
+    %ProcessManagerInstance{process_manager_module: process_manager_module} = state
+    %FailureContext{pending_commands: pending_commands, last_event: last_event} = failure_context
 
-    case state.process_manager_module.error(error, failed_command, failure_context) do
+    case process_manager_module.error(error, failed_command, failure_context) do
       {:continue, commands, context} when is_list(commands) ->
         # continue dispatching the given commands
         Logger.info(fn -> describe(state) <> " is continuing with modified command(s)" end)
@@ -207,7 +309,9 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       {:retry, delay, context} when is_integer(delay) ->
         # retry the failed command after waiting for the given delay, in milliseconds
-        Logger.info(fn -> describe(state) <> " is retrying failed command after #{inspect delay}ms" end)
+        Logger.info(fn ->
+          describe(state) <> " is retrying failed command after #{inspect(delay)}ms"
+        end)
 
         :timer.sleep(delay)
 
@@ -215,7 +319,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       {:skip, :discard_pending} ->
         # skip the failed command and discard any pending commands
-        Logger.info(fn -> describe(state) <> " is skipping event and #{length(pending_commands)} pending command(s)" end)
+        Logger.info(fn ->
+          describe(state) <>
+            " is skipping event and #{length(pending_commands)} pending command(s)"
+        end)
 
         :ok
 
@@ -227,29 +334,36 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       {:stop, reason} = reply ->
         # stop process manager
-        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect reason}" end)
+        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(reason)}" end)
 
         reply
     end
   end
 
-  defp describe(%ProcessManagerInstance{process_manager_module: process_manager_module}) do
-    inspect(process_manager_module)
-  end
+  defp describe(%ProcessManagerInstance{process_manager_module: process_manager_module}),
+    do: inspect(process_manager_module)
 
-  defp persist_state(%ProcessManagerInstance{process_manager_module: process_manager_module, process_state: process_state} = state, source_version) do
+  defp persist_state(source_version, %ProcessManagerInstance{} = state) do
+    %ProcessManagerInstance{
+      process_manager_module: process_manager_module,
+      process_state: process_state
+    } = state
+
     EventStore.record_snapshot(%SnapshotData{
       source_uuid: process_state_uuid(state),
       source_version: source_version,
       source_type: Atom.to_string(process_manager_module),
-      data: process_state,
+      data: process_state
     })
   end
 
-  defp delete_state(%ProcessManagerInstance{} = state),
-    do: EventStore.delete_snapshot(process_state_uuid(state))
+  defp delete_state(%ProcessManagerInstance{} = state) do
+    EventStore.delete_snapshot(process_state_uuid(state))
+  end
 
-  defp ack_event(%RecordedEvent{} = event, process_router) do
+  defp ack_event(%RecordedEvent{} = event, %ProcessManagerInstance{} = state) do
+    %ProcessManagerInstance{process_router: process_router} = state
+
     ProcessRouter.ack_event(process_router, event, self())
   end
 

--- a/lib/commanded/process_managers/supervisor.ex
+++ b/lib/commanded/process_managers/supervisor.ex
@@ -1,21 +1,38 @@
 defmodule Commanded.ProcessManagers.Supervisor do
   @moduledoc false
+
   use Supervisor
+
   require Logger
 
-  def start_link(command_dispatcher) do
-    Supervisor.start_link(__MODULE__, command_dispatcher)
+  def start_link(command_dispatcher, process_router) do
+    Supervisor.start_link(__MODULE__, [command_dispatcher, process_router])
   end
 
-  def start_process_manager(supervisor, process_manager_name, process_manager_module, process_uuid) do
-    Logger.debug(fn -> "Starting process manager process for `#{process_manager_module}` with uuid #{process_uuid}" end)
+  def start_process_manager(
+        supervisor,
+        process_manager_name,
+        process_manager_module,
+        process_uuid
+      ) do
+    Logger.debug(fn ->
+      "Starting process manager process for `#{process_manager_module}` with uuid #{process_uuid}"
+    end)
 
-    Supervisor.start_child(supervisor, [process_manager_name, process_manager_module, process_uuid])
+    Supervisor.start_child(supervisor, [
+      process_manager_name,
+      process_manager_module,
+      process_uuid
+    ])
   end
 
-  def init(command_dispatcher) do
+  def init([command_dispatcher, process_router]) do
     children = [
-      worker(Commanded.ProcessManagers.ProcessManagerInstance, [command_dispatcher], restart: :temporary),
+      worker(
+        Commanded.ProcessManagers.ProcessManagerInstance,
+        [command_dispatcher, process_router],
+        restart: :temporary
+      )
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/test/aggregates/support/example_aggregate.ex
+++ b/test/aggregates/support/example_aggregate.ex
@@ -1,21 +1,19 @@
 defmodule Commanded.Aggregates.ExampleAggregate do
   @moduledoc false
-  defstruct [
-    items: [],
-    last_index: 0,
-  ]
+  defstruct items: [],
+            last_index: 0
 
   defmodule Commands do
-    defmodule AppendItems, do: defstruct [count: 0]
-    defmodule NoOp, do: defstruct [count: 0]
+    defmodule(AppendItems, do: defstruct(count: 0))
+    defmodule(NoOp, do: defstruct(count: 0))
   end
 
   defmodule Events do
-    defmodule ItemAppended, do: defstruct [:index]
+    defmodule(ItemAppended, do: defstruct([:index]))
   end
 
   alias Commanded.Aggregates.ExampleAggregate
-  alias Commands.{AppendItems,NoOp}
+  alias Commands.{AppendItems, NoOp}
   alias Events.ItemAppended
 
   def append_items(%ExampleAggregate{last_index: last_index}, count) do
@@ -26,12 +24,9 @@ defmodule Commanded.Aggregates.ExampleAggregate do
 
   def noop(%ExampleAggregate{}, %NoOp{}), do: []
 
-  # state mutatators
+  # State mutators
 
   def apply(%ExampleAggregate{items: items} = state, %ItemAppended{index: index}) do
-    %ExampleAggregate{state |
-      items: items ++ [index],
-      last_index: index,
-    }
+    %ExampleAggregate{state | items: items ++ [index], last_index: index}
   end
 end

--- a/test/aggregates/support/multi_bank_account.ex
+++ b/test/aggregates/support/multi_bank_account.ex
@@ -1,56 +1,50 @@
 defmodule Commanded.Aggregate.Multi.BankAccount do
-  defstruct [
-    account_number: nil,
-    balance: 0,
-    state: nil,
-  ]
+  defstruct account_number: nil,
+            balance: 0,
+            state: nil
 
   alias Commanded.Aggregate.Multi
   alias Commanded.Aggregate.Multi.BankAccount
 
   defmodule Commands do
-    defmodule OpenAccount,        do: defstruct [:account_number, :initial_balance]
-    defmodule WithdrawMoney,      do: defstruct [:account_number, :transfer_uuid, :amount]
+    defmodule(OpenAccount, do: defstruct([:account_number, :initial_balance]))
+    defmodule(WithdrawMoney, do: defstruct([:account_number, :transfer_uuid, :amount]))
   end
 
   defmodule Events do
-    defmodule BankAccountOpened,  do: defstruct [:account_number, :balance]
-    defmodule MoneyWithdrawn,     do: defstruct [:account_number, :transfer_uuid, :amount, :balance]
+    defmodule(BankAccountOpened, do: defstruct([:account_number, :balance]))
+    defmodule(MoneyWithdrawn, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
   end
 
-  alias Commands.{OpenAccount,WithdrawMoney}
-  alias Events.{BankAccountOpened,MoneyWithdrawn}
+  alias Commands.{OpenAccount, WithdrawMoney}
+  alias Events.{BankAccountOpened, MoneyWithdrawn}
 
   def execute(
-    %BankAccount{state: nil},
-    %OpenAccount{account_number: account_number, initial_balance: initial_balance})
-    when is_number(initial_balance) and initial_balance > 0
-  do
+        %BankAccount{state: nil},
+        %OpenAccount{account_number: account_number, initial_balance: initial_balance}
+      )
+      when is_number(initial_balance) and initial_balance > 0 do
     %BankAccountOpened{account_number: account_number, balance: initial_balance}
   end
 
   def execute(
-    %BankAccount{state: :active} = account,
-    %WithdrawMoney{amount: amount})
-    when is_number(amount) and amount > 0
-  do
+        %BankAccount{state: :active} = account,
+        %WithdrawMoney{amount: amount}
+      )
+      when is_number(amount) and amount > 0 do
     account
     |> Multi.new()
     |> Multi.execute(&withdraw_money(&1, amount))
     |> Multi.execute(&check_balance/1)
   end
 
-  # state mutatators
+  # State mutators
 
   def apply(
-    %BankAccount{} = state,
-    %BankAccountOpened{account_number: account_number, balance: balance})
-  do
-    %BankAccount{state |
-      account_number: account_number,
-      balance: balance,
-      state: :active,
-    }
+        %BankAccount{} = state,
+        %BankAccountOpened{account_number: account_number, balance: balance}
+      ) do
+    %BankAccount{state | account_number: account_number, balance: balance, state: :active}
   end
 
   def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}),
@@ -67,9 +61,9 @@ defmodule Commanded.Aggregate.Multi.BankAccount do
   end
 
   defp check_balance(%BankAccount{balance: balance})
-    when balance < 0
-  do
+       when balance < 0 do
     {:error, :insufficient_funds_available}
   end
+
   defp check_balance(%BankAccount{}), do: []
 end

--- a/test/aggregates/support/snapshot_aggregate.ex
+++ b/test/aggregates/support/snapshot_aggregate.ex
@@ -2,15 +2,15 @@ defmodule Commanded.Aggregates.SnapshotAggregate do
   @moduledoc false
   defstruct [
     :name,
-    :date,
+    :date
   ]
 
   defmodule Commands do
-    defmodule Create, do: defstruct [:name, :date]
+    defmodule(Create, do: defstruct([:name, :date]))
   end
 
   defmodule Events do
-    defmodule Created, do: defstruct [:name, :date]
+    defmodule(Created, do: defstruct([:name, :date]))
   end
 
   alias Commanded.Aggregates.SnapshotAggregate
@@ -18,22 +18,19 @@ defmodule Commanded.Aggregates.SnapshotAggregate do
   alias Events.Created
 
   def execute(
-    %SnapshotAggregate{name: nil},
-    %Create{name: name, date: date})
-  do
+        %SnapshotAggregate{name: nil},
+        %Create{name: name, date: date}
+      ) do
     %Created{name: name, date: date}
   end
 
-  # state mutatators
+  # State mutators
 
   def apply(
-    %SnapshotAggregate{} = state,
-    %Created{name: name, date: date})
-  do
-    %SnapshotAggregate{state |
-      name: name,
-      date: date
-    }
+        %SnapshotAggregate{} = state,
+        %Created{name: name, date: date}
+      ) do
+    %SnapshotAggregate{state | name: name, date: date}
   end
 end
 
@@ -44,8 +41,6 @@ defimpl Commanded.Serialization.JsonDecoder, for: SnapshotAggregate do
   Parse the date included in the aggregate state
   """
   def decode(%SnapshotAggregate{date: date} = state) do
-    %SnapshotAggregate{state |
-      date: NaiveDateTime.from_iso8601!(date)
-    }
+    %SnapshotAggregate{state | date: NaiveDateTime.from_iso8601!(date)}
   end
 end

--- a/test/event/event_handler_error_handling_test.exs
+++ b/test/event/event_handler_error_handling_test.exs
@@ -12,11 +12,13 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     [
       handler: handler,
       ref: Process.monitor(handler),
-      uuid: UUID.uuid4(),
+      uuid: UUID.uuid4()
     ]
   end
 
-  test "should stop event handler on error by default", %{handler: handler, ref: ref, uuid: uuid} do
+  test "should stop event handler on error by default", context do
+    %{handler: handler, ref: ref, uuid: uuid} = context
+
     :ok = ErrorRouter.dispatch(%RaiseError{uuid: uuid, strategy: "default", reply_to: reply_to()})
 
     assert_receive {:error, :stopping}
@@ -25,7 +27,9 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     refute Process.alive?(handler)
   end
 
-  test "should stop event handler when invalid error response returned", %{handler: handler, ref: ref, uuid: uuid} do
+  test "should stop event handler when invalid error response returned", context do
+    %{handler: handler, ref: ref, uuid: uuid} = context
+
     :ok = ErrorRouter.dispatch(%RaiseError{uuid: uuid, strategy: "invalid", reply_to: reply_to()})
 
     assert_receive {:error, :invalid}
@@ -34,7 +38,9 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     refute Process.alive?(handler)
   end
 
-  test "should retry event handler on error", %{handler: handler, ref: ref, uuid: uuid} do
+  test "should retry event handler on error", context do
+    %{handler: handler, ref: ref, uuid: uuid} = context
+
     :ok = ErrorRouter.dispatch(%RaiseError{uuid: uuid, strategy: "retry", reply_to: reply_to()})
 
     assert_receive {:error, :failed, %{failures: 1}}
@@ -45,8 +51,12 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     refute Process.alive?(handler)
   end
 
-  test "should retry event handler after delay on error", %{handler: handler, ref: ref, uuid: uuid} do
-    :ok = ErrorRouter.dispatch(%RaiseError{uuid: uuid, strategy: "retry", delay: 10, reply_to: reply_to()})
+  test "should retry event handler after delay on error", context do
+    %{handler: handler, ref: ref, uuid: uuid} = context
+
+    command = %RaiseError{uuid: uuid, strategy: "retry", delay: 10, reply_to: reply_to()}
+
+    :ok = ErrorRouter.dispatch(command)
 
     assert_receive {:error, :failed, %{failures: 1, delay: 10}}
     assert_receive {:error, :failed, %{failures: 2, delay: 10}}
@@ -56,7 +66,9 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     refute Process.alive?(handler)
   end
 
-  test "should skip event on error", %{handler: handler, ref: ref, uuid: uuid} do
+  test "should skip event on error", context do
+    %{handler: handler, ref: ref, uuid: uuid} = context
+
     :ok = ErrorRouter.dispatch(%RaiseError{uuid: uuid, strategy: "skip", reply_to: reply_to()})
 
     assert_receive {:error, :skipping}

--- a/test/event/support/error/error_aggregate.ex
+++ b/test/event/support/error/error_aggregate.ex
@@ -5,20 +5,26 @@ defmodule Commanded.Event.ErrorAggregate do
 
   defmodule Commands do
     defmodule(RaiseError, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
+    defmodule(RaiseException, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
   end
 
   defmodule Events do
     defmodule(ErrorEvent, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
+    defmodule(ExceptionEvent, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
   end
 
   alias Commanded.Event.ErrorAggregate
-  alias Commands.RaiseError
-  alias Events.ErrorEvent
+  alias Commands.{RaiseError, RaiseException}
+  alias Events.{ErrorEvent, ExceptionEvent}
 
-  def execute(%ErrorAggregate{}, %RaiseError{} = raise_error) do
-    struct(ErrorEvent, Map.from_struct(raise_error))
+  def execute(%ErrorAggregate{}, %RaiseError{} = command) do
+    struct(ErrorEvent, Map.from_struct(command))
   end
 
-  def apply(%ErrorAggregate{} = aggregate, %ErrorEvent{uuid: uuid}),
-    do: %ErrorAggregate{aggregate | uuid: uuid}
+  def execute(%ErrorAggregate{}, %RaiseException{} = command) do
+    struct(ExceptionEvent, Map.from_struct(command))
+  end
+
+  def apply(%ErrorAggregate{} = aggregate, _event),
+    do: aggregate
 end

--- a/test/event/support/error/error_event_handler.ex
+++ b/test/event/support/error/error_event_handler.ex
@@ -4,59 +4,79 @@ defmodule Commanded.Event.ErrorEventHandler do
   use Commanded.Event.Handler, name: __MODULE__
 
   alias Commanded.Event.FailureContext
-  alias Commanded.Event.ErrorAggregate.Events.ErrorEvent
+  alias Commanded.Event.ErrorAggregate.Events.{ErrorEvent, ExceptionEvent}
 
+  # Simulate event handling error reply
   def handle(%ErrorEvent{}, _metadata) do
-    # simulate event handling failure
     {:error, :failed}
   end
 
-  def error({:error, :failed}, %ErrorEvent{strategy: "retry", delay: delay} = event, %FailureContext{
-        context: context
-      }) do
+  # Simulate event handling exception
+  def handle(%ExceptionEvent{}, _metadata) do
+    raise "exception"
+  end
+
+  # Default behaviour is to stop the event handler with the given error reason
+  def error({:error, reason}, %ErrorEvent{strategy: "default"} = event, _failure_context) do
+    %ErrorEvent{reply_to: reply_to} = event
+
+    send_reply(reply_to, {:error, :stopping})
+
+    {:stop, reason}
+  end
+
+  def error({:error, :failed}, %ErrorEvent{strategy: "retry"} = event, failure_context) do
+    %ErrorEvent{delay: delay, reply_to: reply_to} = event
+    %FailureContext{context: context} = failure_context
+
     context = context |> record_failure() |> Map.put(:delay, delay)
 
     case Map.get(context, :failures) do
       too_many when too_many >= 3 ->
         # stop error handler after third failure
-        send_reply({:error, :too_many_failures, context}, event)
+        send_reply(reply_to, {:error, :too_many_failures, context})
 
         {:stop, :too_many_failures}
 
       _ ->
         # retry event, record failure count in context map
-        send_reply({:error, :failed, context}, event)
+        send_reply(reply_to, {:error, :failed, context})
 
         {:retry, context}
     end
   end
 
-  # skip event
+  # Skip event
   def error({:error, :failed}, %ErrorEvent{strategy: "skip"} = event, _failure_context) do
-    send_reply({:error, :skipping}, event)
+    %ErrorEvent{reply_to: reply_to} = event
+
+    send_reply(reply_to, {:error, :skipping})
 
     :skip
   end
 
-  # default behaviour is to stop the event handler with the given error reason
-  def error({:error, reason}, %ErrorEvent{strategy: "default"} = event, _failure_context) do
-    send_reply({:error, :stopping}, event)
-
-    {:stop, reason}
-  end
-
-  # return an invalid response
+  # Return an invalid response
   def error({:error, :failed}, %ErrorEvent{strategy: "invalid"} = event, _failure_context) do
-    send_reply({:error, :invalid}, event)
+    %ErrorEvent{reply_to: reply_to} = event
+
+    send_reply(reply_to, {:error, :invalid})
 
     :invalid
+  end
+
+  def error({:error, error}, %ExceptionEvent{strategy: "default"} = event, _failure_context) do
+    %ExceptionEvent{reply_to: reply_to} = event
+
+    send_reply(reply_to, {:exception, :stopping})
+
+    {:stop, error}
   end
 
   defp record_failure(context) do
     Map.update(context, :failures, 1, fn failures -> failures + 1 end)
   end
 
-  defp send_reply(reply, %ErrorEvent{reply_to: reply_to}) do
+  defp send_reply(reply_to, reply) do
     pid = :erlang.list_to_pid(reply_to)
 
     send(pid, reply)

--- a/test/event/support/error/error_router.ex
+++ b/test/event/support/error/error_router.ex
@@ -4,7 +4,7 @@ defmodule Commanded.Event.ErrorRouter do
   use Commanded.Commands.Router
 
   alias Commanded.Event.ErrorAggregate
-  alias Commanded.Event.ErrorAggregate.Commands.RaiseError
+  alias Commanded.Event.ErrorAggregate.Commands.{RaiseError, RaiseException}
 
-  dispatch [RaiseError], to: ErrorAggregate, identity: :uuid
+  dispatch [RaiseError, RaiseException], to: ErrorAggregate, identity: :uuid
 end

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -1,56 +1,85 @@
 defmodule Commanded.ExampleDomain.BankAccount do
   @moduledoc false
-  defstruct [
-    account_number: nil,
-    balance: 0,
-    state: nil,
-  ]
+  defstruct account_number: nil,
+            balance: 0,
+            state: nil
 
   alias Commanded.ExampleDomain.BankAccount
 
   defmodule Commands do
-    defmodule OpenAccount,        do: defstruct [:account_number, :initial_balance]
-    defmodule DepositMoney,       do: defstruct [:account_number, :transfer_uuid, :amount]
-    defmodule WithdrawMoney,      do: defstruct [:account_number, :transfer_uuid, :amount]
-    defmodule CloseAccount,       do: defstruct [:account_number]
+    defmodule(OpenAccount, do: defstruct([:account_number, :initial_balance]))
+    defmodule(DepositMoney, do: defstruct([:account_number, :transfer_uuid, :amount]))
+    defmodule(WithdrawMoney, do: defstruct([:account_number, :transfer_uuid, :amount]))
+    defmodule(CloseAccount, do: defstruct([:account_number]))
   end
 
   defmodule Events do
-    defmodule BankAccountOpened,  do: defstruct [:account_number, :initial_balance]
-    defmodule MoneyDeposited,     do: defstruct [:account_number, :transfer_uuid, :amount, :balance]
-    defmodule MoneyWithdrawn,     do: defstruct [:account_number, :transfer_uuid, :amount, :balance]
-    defmodule AccountOverdrawn,   do: defstruct [:account_number, :balance]
-    defmodule BankAccountClosed,  do: defstruct [:account_number]
+    defmodule(BankAccountOpened, do: defstruct([:account_number, :initial_balance]))
+    defmodule(MoneyDeposited, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
+    defmodule(MoneyWithdrawn, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
+    defmodule(AccountOverdrawn, do: defstruct([:account_number, :balance]))
+    defmodule(BankAccountClosed, do: defstruct([:account_number]))
   end
 
-  alias Commands.{OpenAccount,DepositMoney,WithdrawMoney,CloseAccount}
-  alias Events.{BankAccountOpened,MoneyDeposited,MoneyWithdrawn,AccountOverdrawn,BankAccountClosed}
+  alias Commands.{OpenAccount, DepositMoney, WithdrawMoney, CloseAccount}
 
-  def open_account(%BankAccount{state: nil}, %OpenAccount{account_number: account_number, initial_balance: initial_balance})
-    when is_number(initial_balance) and initial_balance > 0
-  do
+  alias Events.{
+    BankAccountOpened,
+    MoneyDeposited,
+    MoneyWithdrawn,
+    AccountOverdrawn,
+    BankAccountClosed
+  }
+
+  def open_account(%BankAccount{state: nil}, %OpenAccount{
+        account_number: account_number,
+        initial_balance: initial_balance
+      })
+      when is_number(initial_balance) and initial_balance > 0 do
     %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
   end
 
-  def deposit(%BankAccount{state: :active, balance: balance}, %DepositMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount})
-    when is_number(amount) and amount > 0
-  do
+  def deposit(%BankAccount{state: :active, balance: balance}, %DepositMoney{
+        account_number: account_number,
+        transfer_uuid: transfer_uuid,
+        amount: amount
+      })
+      when is_number(amount) and amount > 0 do
     balance = balance + amount
 
-    %MoneyDeposited{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance}
+    %MoneyDeposited{
+      account_number: account_number,
+      transfer_uuid: transfer_uuid,
+      amount: amount,
+      balance: balance
+    }
   end
 
-  def withdraw(%BankAccount{state: :active, balance: balance}, %WithdrawMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount})
-    when is_number(amount) and amount > 0
-  do
+  def withdraw(%BankAccount{state: :active, balance: balance}, %WithdrawMoney{
+        account_number: account_number,
+        transfer_uuid: transfer_uuid,
+        amount: amount
+      })
+      when is_number(amount) and amount > 0 do
     case balance - amount do
       balance when balance < 0 ->
         [
-          %MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance},
-          %AccountOverdrawn{account_number: account_number, balance: balance},
+          %MoneyWithdrawn{
+            account_number: account_number,
+            transfer_uuid: transfer_uuid,
+            amount: amount,
+            balance: balance
+          },
+          %AccountOverdrawn{account_number: account_number, balance: balance}
         ]
+
       balance ->
-        %MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance}
+        %MoneyWithdrawn{
+          account_number: account_number,
+          transfer_uuid: transfer_uuid,
+          amount: amount,
+          balance: balance
+        }
     end
   end
 
@@ -58,25 +87,24 @@ defmodule Commanded.ExampleDomain.BankAccount do
     %BankAccountClosed{account_number: account_number}
   end
 
-  # state mutatators
+  # State mutators
 
-  def apply(%BankAccount{} = state, %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}) do
-    %BankAccount{state |
-      account_number: account_number,
-      balance: initial_balance,
-      state: :active,
-    }
+  def apply(%BankAccount{} = state, %BankAccountOpened{
+        account_number: account_number,
+        initial_balance: initial_balance
+      }) do
+    %BankAccount{state | account_number: account_number, balance: initial_balance, state: :active}
   end
 
-  def apply(%BankAccount{} = state, %MoneyDeposited{balance: balance}), do: %BankAccount{state | balance: balance}
+  def apply(%BankAccount{} = state, %MoneyDeposited{balance: balance}),
+    do: %BankAccount{state | balance: balance}
 
-  def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}), do: %BankAccount{state | balance: balance}
+  def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}),
+    do: %BankAccount{state | balance: balance}
 
   def apply(%BankAccount{} = state, %AccountOverdrawn{}), do: state
 
   def apply(%BankAccount{} = state, %BankAccountClosed{}) do
-    %BankAccount{state |
-      state: :closed,
-    }
+    %BankAccount{state | state: :closed}
   end
 end

--- a/test/example_domain/money_transfer/money_transfer.ex
+++ b/test/example_domain/money_transfer/money_transfer.ex
@@ -1,41 +1,53 @@
 defmodule Commanded.ExampleDomain.MoneyTransfer do
   @moduledoc false
-  defstruct [
-    transfer_uuid: nil,
-    debit_account: nil,
-    credit_account: nil,
-    amount: 0,
-    state: nil,
-  ]
+  defstruct transfer_uuid: nil,
+            debit_account: nil,
+            credit_account: nil,
+            amount: 0,
+            state: nil
 
   alias Commanded.ExampleDomain.MoneyTransfer
 
   defmodule Commands do
-    defmodule TransferMoney, do: defstruct [transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil]
+    defmodule(TransferMoney,
+      do: defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
+    )
   end
 
   defmodule Events do
-    defmodule MoneyTransferRequested, do: defstruct [transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil]
+    defmodule(MoneyTransferRequested,
+      do: defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
+    )
   end
 
   alias Commands.{TransferMoney}
   alias Events.{MoneyTransferRequested}
 
-  def transfer_money(%MoneyTransfer{state: nil}, %TransferMoney{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount})
-    when amount > 0
-  do
-    %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}
+  def transfer_money(%MoneyTransfer{state: nil}, %TransferMoney{
+        transfer_uuid: transfer_uuid,
+        debit_account: debit_account,
+        credit_account: credit_account,
+        amount: amount
+      })
+      when amount > 0 do
+    %MoneyTransferRequested{
+      transfer_uuid: transfer_uuid,
+      debit_account: debit_account,
+      credit_account: credit_account,
+      amount: amount
+    }
   end
 
-  # state mutatators
+  # State mutators
 
   def apply(%MoneyTransfer{} = state, %MoneyTransferRequested{} = transfer_requested) do
-    %MoneyTransfer{state |
-      transfer_uuid: transfer_requested.transfer_uuid,
-      debit_account: transfer_requested.debit_account,
-      credit_account: transfer_requested.credit_account,
-      amount: transfer_requested.amount,
-      state: :requested,
+    %MoneyTransfer{
+      state
+      | transfer_uuid: transfer_requested.transfer_uuid,
+        debit_account: transfer_requested.debit_account,
+        credit_account: transfer_requested.credit_account,
+        amount: transfer_requested.amount,
+        state: :requested
     }
   end
 end

--- a/test/process_managers/process_manager_instance_exception_test.exs
+++ b/test/process_managers/process_manager_instance_exception_test.exs
@@ -1,0 +1,36 @@
+defmodule Commanded.ProcessManagers.ProcessManagerInstanceExceptionTest do
+  use Commanded.StorageCase
+
+  alias Commanded.ProcessManagers.{ExampleRouter, ExampleProcessManager}
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Error, Raise, Start}
+
+  test "should stop process router when handling event errors" do
+    aggregate_uuid = UUID.uuid4()
+
+    {:ok, process_router} = ExampleProcessManager.start_link()
+
+    Process.unlink(process_router)
+    ref = Process.monitor(process_router)
+
+    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+    :ok = ExampleRouter.dispatch(%Error{aggregate_uuid: aggregate_uuid})
+
+    # Should shutdown process
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+
+  test "should stop process router when handling event exception" do
+    aggregate_uuid = UUID.uuid4()
+
+    {:ok, process_router} = ExampleProcessManager.start_link()
+
+    Process.unlink(process_router)
+    ref = Process.monitor(process_router)
+
+    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+    :ok = ExampleRouter.dispatch(%Raise{aggregate_uuid: aggregate_uuid})
+
+    # Should shutdown process
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+end

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -15,6 +15,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
     {:ok, process_manager} =
       ProcessManagerInstance.start_link(
         NullRouter,
+        self(),
         "TransferMoneyProcessManager",
         TransferMoneyProcessManager,
         transfer_uuid
@@ -32,9 +33,9 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
       }
     }
 
-    :ok = ProcessManagerInstance.process_event(process_manager, event, self())
+    :ok = ProcessManagerInstance.process_event(process_manager, event)
 
-    # should send ack to process router after processing event
+    # Should send ack to process router after processing event
     assert_receive({:"$gen_cast", {:ack_event, ^event, _instance}}, 1_000)
 
     ProcessHelper.shutdown(process_manager)

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -6,110 +6,160 @@ defmodule Commanded.ProcessManagers.ProcessRouterProcessPendingEventsTest do
 
   alias Commanded.EventStore
   alias Commanded.Helpers.Wait
-  alias Commanded.ProcessManagers.{ExampleRouter,ExampleProcessManager,ProcessRouter,ProcessManagerInstance}
-  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Error,Publish,Start}
-  alias Commanded.ProcessManagers.ExampleAggregate.Events.{Interested,Started,Stopped,Uninterested}
+
+  alias Commanded.ProcessManagers.{
+    ExampleRouter,
+    ExampleProcessManager,
+    ProcessRouter,
+    ProcessManagerInstance
+  }
+
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Publish, Start}
+
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.{
+    Interested,
+    Started,
+    Stopped,
+    Uninterested
+  }
 
   test "should start process manager instance and successfully dispatch command" do
-    aggregate_uuid = UUID.uuid4
+    aggregate_uuid = UUID.uuid4()
 
     {:ok, process_router} = ExampleProcessManager.start_link()
 
     :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
 
     # dispatch command to publish multiple events and trigger dispatch of the stop command
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 10, uninteresting: 1})
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 10,
+        uninteresting: 1
+      })
 
-    assert_receive_event Stopped, fn event ->
+    assert_receive_event(Stopped, fn event ->
       assert event.aggregate_uuid == aggregate_uuid
-    end
+    end)
 
     events = EventStore.stream_forward(aggregate_uuid) |> Enum.to_list()
 
     assert pluck(events, :data) == [
-      %Started{aggregate_uuid: aggregate_uuid},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 1},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 2},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 3},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 4},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 5},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 6},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 7},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 8},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 9},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 10},
-      %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
-      %Stopped{aggregate_uuid: aggregate_uuid},
-    ]
+             %Started{aggregate_uuid: aggregate_uuid},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 2},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 3},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 4},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 5},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 6},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 7},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 8},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 9},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 10},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Stopped{aggregate_uuid: aggregate_uuid}
+           ]
 
-    Wait.until fn ->
+    Wait.until(fn ->
       # process instance should be stopped
-      assert ProcessRouter.process_instance(process_router, aggregate_uuid) == {:error, :process_manager_not_found}
+      assert ProcessRouter.process_instance(process_router, aggregate_uuid) ==
+               {:error, :process_manager_not_found}
 
       # process state snapshot should be deleted
-      assert EventStore.read_snapshot("example_process_manager-#{aggregate_uuid}") == {:error, :snapshot_not_found}
-    end
+      assert EventStore.read_snapshot("example_process_manager-#{aggregate_uuid}") ==
+               {:error, :snapshot_not_found}
+    end)
   end
 
   test "should ignore uninteresting events" do
-    aggregate_uuid = UUID.uuid4
+    aggregate_uuid = UUID.uuid4()
 
     {:ok, process_router} = ExampleProcessManager.start_link()
 
     :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
 
     # dispatch commands to publish a mix of interesting and uninteresting events for the process router
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 0, uninteresting: 2})
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 0, uninteresting: 2})
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 10, uninteresting: 0})
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 0,
+        uninteresting: 2
+      })
 
-    assert_receive_event Stopped, fn event ->
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 0,
+        uninteresting: 2
+      })
+
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 10,
+        uninteresting: 0
+      })
+
+    assert_receive_event(Stopped, fn event ->
       assert event.aggregate_uuid == aggregate_uuid
-    end
+    end)
 
     events = aggregate_uuid |> EventStore.stream_forward() |> Enum.to_list()
 
     assert pluck(events, :data) == [
-      %Started{aggregate_uuid: aggregate_uuid},
-      %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
-      %Uninterested{aggregate_uuid: aggregate_uuid, index: 2},
-      %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
-      %Uninterested{aggregate_uuid: aggregate_uuid, index: 2},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 1},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 2},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 3},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 4},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 5},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 6},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 7},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 8},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 9},
-      %Interested{aggregate_uuid: aggregate_uuid, index: 10},
-      %Stopped{aggregate_uuid: aggregate_uuid},
-    ]
+             %Started{aggregate_uuid: aggregate_uuid},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 2},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 2},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 2},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 3},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 4},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 5},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 6},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 7},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 8},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 9},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 10},
+             %Stopped{aggregate_uuid: aggregate_uuid}
+           ]
 
-    Wait.until fn ->
+    Wait.until(fn ->
       # process instance should be stopped
-      assert ProcessRouter.process_instance(process_router, aggregate_uuid) == {:error, :process_manager_not_found}
-    end
+      assert ProcessRouter.process_instance(process_router, aggregate_uuid) ==
+               {:error, :process_manager_not_found}
+    end)
   end
 
   test "should ignore past events when starting subscription from current" do
-    aggregate_uuid = UUID.uuid4
+    aggregate_uuid = UUID.uuid4()
 
     :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 4, uninteresting: 0})
 
-    wait_for_event Interested, fn event -> event.index == 4 end
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 4,
+        uninteresting: 0
+      })
+
+    wait_for_event(Interested, fn event -> event.index == 4 end)
 
     {:ok, process_router} = ExampleProcessManager.start_link(start_from: :current)
 
     assert ProcessRouter.process_instances(process_router) == []
 
     :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
-    :ok = ExampleRouter.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 6, uninteresting: 0})
 
-    wait_for_event Interested, fn event -> event.index == 6 end
+    :ok =
+      ExampleRouter.dispatch(%Publish{
+        aggregate_uuid: aggregate_uuid,
+        interesting: 6,
+        uninteresting: 0
+      })
+
+    wait_for_event(Interested, fn event -> event.index == 6 end)
 
     Wait.until(fn ->
       process_instance = ProcessRouter.process_instance(process_router, aggregate_uuid)
@@ -118,20 +168,5 @@ defmodule Commanded.ProcessManagers.ProcessRouterProcessPendingEventsTest do
       %{items: items} = ProcessManagerInstance.process_state(process_instance)
       assert items == [1, 2, 3, 4, 5, 6]
     end)
-  end
-
-  test "should stop process router when handling event errors" do
-    aggregate_uuid = UUID.uuid4
-
-    {:ok, process_router} = ExampleProcessManager.start_link()
-
-    Process.unlink(process_router)
-    ref = Process.monitor(process_router)
-
-    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
-    :ok = ExampleRouter.dispatch(%Error{aggregate_uuid: aggregate_uuid})
-
-    # should shutdown process
-    assert_receive {:DOWN, ^ref, _, _, _}
   end
 end

--- a/test/process_managers/support/error/context_error_handling_process_manager.ex
+++ b/test/process_managers/support/error/context_error_handling_process_manager.ex
@@ -1,16 +1,9 @@
 defmodule Commanded.ProcessManagers.StateErrorHandlingProcessManager do
   @moduledoc false
 
-  alias Commanded.ProcessManagers.{
-    StateErrorHandlingProcessManager,
-    ExampleRouter,
-  }
-  alias Commanded.ProcessManagers.ErrorAggregate.Commands.{
-    AttemptProcess,
-  }
-  alias Commanded.ProcessManagers.ErrorAggregate.Events.{
-    ProcessStarted,
-  }
+  alias Commanded.ProcessManagers.{StateErrorHandlingProcessManager, ExampleRouter}
+  alias Commanded.ProcessManagers.ErrorAggregate.Commands.AttemptProcess
+  alias Commanded.ProcessManagers.ErrorAggregate.Events.ProcessStarted
 
   use Commanded.ProcessManagers.ProcessManager,
     name: "StateErrorHandlingProcessManager",
@@ -24,13 +17,17 @@ defmodule Commanded.ProcessManagers.StateErrorHandlingProcessManager do
     %AttemptProcess{process_uuid: process_uuid}
   end
 
-  def apply(_, %ProcessStarted{reply_to: reply_to, process_uuid: process_uuid}) do
+  def apply(%StateErrorHandlingProcessManager{}, %ProcessStarted{} = event) do
+    %ProcessStarted{reply_to: reply_to, process_uuid: process_uuid} = event
+
     %StateErrorHandlingProcessManager{reply_to: reply_to, process_uuid: process_uuid}
   end
 
   def error(_, _, failure_context) do
     %{process_manager_state: %{reply_to: reply_to}} = failure_context
+
     send(:erlang.list_to_pid(reply_to), :got_from_context)
+
     {:stop, :stopping}
   end
 end

--- a/test/process_managers/support/error/error_aggregate.ex
+++ b/test/process_managers/support/error/error_aggregate.ex
@@ -3,25 +3,50 @@ defmodule Commanded.ProcessManagers.ErrorAggregate do
   defstruct [:process_uuid]
 
   defmodule Commands do
-    defmodule StartProcess, do: defstruct [:process_uuid, :strategy, :delay, :reply_to]
-    defmodule AttemptProcess, do: defstruct [:process_uuid, :strategy, :delay, :reply_to]
-    defmodule ContinueProcess, do: defstruct [:process_uuid, :reply_to]
+    defmodule(StartProcess, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
+    defmodule(RaiseError, do: defstruct([:process_uuid, :message, :reply_to]))
+    defmodule(RaiseException, do: defstruct([:process_uuid, :message, :reply_to]))
+    defmodule(AttemptProcess, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
+    defmodule(ContinueProcess, do: defstruct([:process_uuid, :reply_to]))
   end
 
   defmodule Events do
-    defmodule ProcessStarted, do: defstruct [:process_uuid, :strategy, :delay, :reply_to]
-    defmodule ProcessContinued, do: defstruct [:process_uuid, :reply_to]
+    defmodule(ProcessStarted, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
+    defmodule(ProcessContinued, do: defstruct([:process_uuid, :reply_to]))
+    defmodule(ProcessError, do: defstruct([:process_uuid, :message, :reply_to]))
+    defmodule(ProcessException, do: defstruct([:process_uuid, :message, :reply_to]))
   end
 
   alias Commanded.ProcessManagers.ErrorAggregate
-  alias Commands.{AttemptProcess,ContinueProcess,StartProcess}
-  alias Events.{ProcessContinued,ProcessStarted}
+  alias Commands.{AttemptProcess, ContinueProcess, RaiseError, RaiseException, StartProcess}
+  alias Events.{ProcessContinued, ProcessError, ProcessException, ProcessStarted}
 
-  def execute(
-    %ErrorAggregate{},
-    %StartProcess{process_uuid: process_uuid, strategy: strategy, delay: delay, reply_to: reply_to})
-  do
-    %ProcessStarted{process_uuid: process_uuid, strategy: strategy, delay: delay, reply_to: reply_to}
+  def execute(%ErrorAggregate{}, %StartProcess{} = command) do
+    %StartProcess{
+      process_uuid: process_uuid,
+      strategy: strategy,
+      delay: delay,
+      reply_to: reply_to
+    } = command
+
+    %ProcessStarted{
+      process_uuid: process_uuid,
+      strategy: strategy,
+      delay: delay,
+      reply_to: reply_to
+    }
+  end
+
+  def execute(%ErrorAggregate{}, %RaiseError{} = command) do
+    %RaiseError{process_uuid: process_uuid, message: message, reply_to: reply_to} = command
+
+    %ProcessError{process_uuid: process_uuid, message: message, reply_to: reply_to}
+  end
+
+  def execute(%ErrorAggregate{}, %RaiseException{} = command) do
+    %RaiseException{process_uuid: process_uuid, message: message, reply_to: reply_to} = command
+
+    %ProcessException{process_uuid: process_uuid, message: message, reply_to: reply_to}
   end
 
   def execute(%ErrorAggregate{}, %AttemptProcess{}),
@@ -33,5 +58,5 @@ defmodule Commanded.ProcessManagers.ErrorAggregate do
   def apply(%ErrorAggregate{} = aggregate, %ProcessStarted{process_uuid: process_uuid}),
     do: %ErrorAggregate{aggregate | process_uuid: process_uuid}
 
-  def apply(%ErrorAggregate{} = aggregate, %ProcessContinued{}), do: aggregate
+  def apply(%ErrorAggregate{} = aggregate, _event), do: aggregate
 end

--- a/test/process_managers/support/error/error_handling_process_manager.ex
+++ b/test/process_managers/support/error/error_handling_process_manager.ex
@@ -1,17 +1,14 @@
 defmodule Commanded.ProcessManagers.ErrorHandlingProcessManager do
   @moduledoc false
 
-  alias Commanded.ProcessManagers.{
-    ErrorHandlingProcessManager,
-    ErrorRouter,
-  }
-  alias Commanded.ProcessManagers.ErrorAggregate.Commands.{
-    AttemptProcess,
-    ContinueProcess,
-  }
+  alias Commanded.ProcessManagers.{ErrorHandlingProcessManager, ErrorRouter, FailureContext}
+  alias Commanded.ProcessManagers.ErrorAggregate.Commands.{AttemptProcess, ContinueProcess}
+
   alias Commanded.ProcessManagers.ErrorAggregate.Events.{
     ProcessContinued,
-    ProcessStarted,
+    ProcessError,
+    ProcessException,
+    ProcessStarted
   }
 
   use Commanded.ProcessManagers.ProcessManager,
@@ -21,75 +18,137 @@ defmodule Commanded.ProcessManagers.ErrorHandlingProcessManager do
   defstruct [:process_uuid]
 
   def interested?(%ProcessStarted{process_uuid: process_uuid}), do: {:start, process_uuid}
+  def interested?(%ProcessError{process_uuid: process_uuid}), do: {:start, process_uuid}
+  def interested?(%ProcessException{process_uuid: process_uuid}), do: {:start, process_uuid}
   def interested?(%ProcessContinued{process_uuid: process_uuid}), do: {:continue, process_uuid}
 
-  def handle(
-    %ErrorHandlingProcessManager{},
-    %ProcessStarted{process_uuid: process_uuid, strategy: strategy, delay: delay})
-  do
-    %AttemptProcess{process_uuid: process_uuid, strategy: strategy, delay: delay}
+  def handle(%ErrorHandlingProcessManager{}, %ProcessStarted{} = event) do
+    %ProcessStarted{
+      process_uuid: process_uuid,
+      reply_to: reply_to,
+      strategy: strategy,
+      delay: delay
+    } = event
+
+    %AttemptProcess{
+      process_uuid: process_uuid,
+      reply_to: reply_to,
+      strategy: strategy,
+      delay: delay
+    }
   end
 
-  def handle(%ErrorHandlingProcessManager{}, %ProcessContinued{}) do
-    reply(:process_continued)
+  # Simulate an error handling an event.
+  def handle(%ErrorHandlingProcessManager{}, %ProcessError{} = event) do
+    %ProcessError{message: message} = event
+
+    {:error, message}
+  end
+
+  # Simulate an exception handling an event.
+  def handle(%ErrorHandlingProcessManager{}, %ProcessException{} = event) do
+    %ProcessException{message: message} = event
+
+    raise message
+  end
+
+  def handle(%ErrorHandlingProcessManager{}, %ProcessContinued{} = event) do
+    %ProcessContinued{reply_to: reply_to} = event
+
+    reply(reply_to, :process_continued)
+
     []
   end
 
-  # stop after three attempts
-  def error({:error, :failed}, %AttemptProcess{strategy: "retry"}, %{context: %{attempts: attempts}} = failure_context)
-    when attempts >= 2
-  do
-    reply({:error, :too_many_attempts, record_attempt(failure_context.context)})
+  # Skip events causing errors during event handling
+  def error({:error, _error} = error, %ProcessError{} = event, _failure_context) do
+    %ProcessError{reply_to: reply_to} = event
+    reply(reply_to, error)
+
+    :skip
+  end
+
+  # Skip events causing exceptions during event handling
+  def error({:error, _error} = error, %ProcessException{} = event, _failure_context) do
+    %ProcessException{reply_to: reply_to} = event
+
+    reply(reply_to, error)
+
+    :skip
+  end
+
+  # Stop after three attempts
+  def error(
+        {:error, :failed},
+        %AttemptProcess{strategy: "retry"} = command,
+        %FailureContext{context: %{attempts: attempts}} = failure_context
+      )
+      when attempts >= 2 do
+    %AttemptProcess{reply_to: reply_to} = command
+
+    context = record_attempt(failure_context)
+    reply(reply_to, {:error, :too_many_attempts, context})
 
     {:stop, :too_many_attempts}
   end
 
-  # retry command with delay
-  def error({:error, :failed}, %AttemptProcess{strategy: "retry", delay: delay}, failure_context)
-    when is_integer(delay)
-  do
-    context = record_attempt(failure_context.context)
-    reply_failure(Map.put(context, :delay, delay))
+  # Retry command with delay
+  def error(
+        {:error, :failed},
+        %AttemptProcess{strategy: "retry", delay: delay} = command,
+        failure_context
+      )
+      when is_integer(delay) do
+    %AttemptProcess{reply_to: reply_to} = command
+
+    context = record_attempt(failure_context)
+    reply_failure(reply_to, Map.put(context, :delay, delay))
 
     {:retry, delay, context}
   end
 
-  # retry command
-  def error({:error, :failed}, %AttemptProcess{strategy: "retry"}, failure_context) do
-    context = record_attempt(failure_context.context)
-    reply_failure(context)
+  # Retry command
+  def error({:error, :failed}, %AttemptProcess{strategy: "retry"} = command, failure_context) do
+    %AttemptProcess{reply_to: reply_to} = command
+
+    context = record_attempt(failure_context)
+    reply_failure(reply_to, context)
 
     {:retry, context}
   end
 
-  # skip failed command, continue pending
-  def error({:error, :failed}, %AttemptProcess{strategy: "skip"}, failure_context) do
-    reply({:error, :failed, record_attempt(failure_context.context)})
+  # Skip failed command, continue pending
+  def error({:error, :failed}, %AttemptProcess{strategy: "skip"} = command, failure_context) do
+    %AttemptProcess{reply_to: reply_to} = command
+
+    context = record_attempt(failure_context)
+    reply(reply_to, {:error, :failed, context})
 
     {:skip, :continue_pending}
   end
 
-  # continue with modified command
-  def error({:error, :failed}, %AttemptProcess{strategy: "continue", process_uuid: process_uuid}, failure_context) do
-    context = record_attempt(failure_context.context)
-    reply({:error, :failed, context})
+  # Continue with modified command
+  def error({:error, :failed}, %AttemptProcess{strategy: "continue"} = command, failure_context) do
+    %AttemptProcess{process_uuid: process_uuid, reply_to: reply_to} = command
 
-    continue = %ContinueProcess{process_uuid: process_uuid}
+    context = record_attempt(failure_context)
+    reply(reply_to, {:error, :failed, context})
+
+    continue = %ContinueProcess{process_uuid: process_uuid, reply_to: reply_to}
 
     {:continue, [continue | failure_context.pending_commands], context}
   end
 
-  defp record_attempt(context) do
+  defp record_attempt(%FailureContext{context: context}) do
     Map.update(context, :attempts, 1, fn attempts -> attempts + 1 end)
   end
 
-  defp reply_failure(context) do
-    reply({:error, :failed, context})
+  defp reply_failure(reply_to, context) do
+    reply(reply_to, {:error, :failed, context})
   end
 
-  defp reply(message) do
-    reply_to = Agent.get({:global, ErrorHandlingProcessManager}, fn reply_to -> reply_to end)
-
-    send(reply_to, message)
+  defp reply(reply_to, message) do
+    pid = :erlang.list_to_pid(reply_to)
+    send(pid, message)
   end
 end

--- a/test/process_managers/support/error/error_router.ex
+++ b/test/process_managers/support/error/error_router.ex
@@ -1,14 +1,19 @@
 defmodule Commanded.ProcessManagers.ErrorRouter do
   @moduledoc false
+
   use Commanded.Commands.Router
 
   alias Commanded.ProcessManagers.ErrorAggregate
+
   alias Commanded.ProcessManagers.ErrorAggregate.Commands.{
-    StartProcess,
     AttemptProcess,
     ContinueProcess,
+    RaiseError,
+    RaiseException,
+    StartProcess
   }
 
-  dispatch [StartProcess,AttemptProcess,ContinueProcess],
-    to: ErrorAggregate, identity: :process_uuid
+  dispatch [AttemptProcess, ContinueProcess, RaiseError, RaiseException, StartProcess],
+    to: ErrorAggregate,
+    identity: :process_uuid
 end

--- a/test/process_managers/support/example_aggregate.ex
+++ b/test/process_managers/support/example_aggregate.ex
@@ -2,25 +2,25 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
   @moduledoc false
   alias Commanded.ProcessManagers.ExampleAggregate
 
-  defstruct [
-    uuid: nil,
-    state: nil,
-    items: [],
-  ]
+  defstruct uuid: nil,
+            state: nil,
+            items: []
 
   defmodule Commands do
-    defmodule Start, do: defstruct [:aggregate_uuid]
-    defmodule Publish, do: defstruct [:aggregate_uuid, :interesting, :uninteresting]
-    defmodule Stop, do: defstruct [:aggregate_uuid]
-    defmodule Error, do: defstruct [:aggregate_uuid]
+    defmodule(Start, do: defstruct([:aggregate_uuid]))
+    defmodule(Publish, do: defstruct([:aggregate_uuid, :interesting, :uninteresting]))
+    defmodule(Stop, do: defstruct([:aggregate_uuid]))
+    defmodule(Error, do: defstruct([:aggregate_uuid]))
+    defmodule(Raise, do: defstruct([:aggregate_uuid]))
   end
 
   defmodule Events do
-    defmodule Started, do: defstruct [:aggregate_uuid]
-    defmodule Interested, do: defstruct [:aggregate_uuid, :index]
-    defmodule Uninterested, do: defstruct [:aggregate_uuid, :index]
-    defmodule Stopped, do: defstruct [:aggregate_uuid]
-    defmodule Errored, do: defstruct [:aggregate_uuid]
+    defmodule(Started, do: defstruct([:aggregate_uuid]))
+    defmodule(Interested, do: defstruct([:aggregate_uuid, :index]))
+    defmodule(Uninterested, do: defstruct([:aggregate_uuid, :index]))
+    defmodule(Stopped, do: defstruct([:aggregate_uuid]))
+    defmodule(Errored, do: defstruct([:aggregate_uuid]))
+    defmodule(Raised, do: defstruct([:aggregate_uuid]))
   end
 
   def start(%ExampleAggregate{}, aggregate_uuid) do
@@ -42,25 +42,42 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
     %Events.Errored{aggregate_uuid: aggregate_uuid}
   end
 
+  def raise(%ExampleAggregate{uuid: aggregate_uuid}) do
+    %Events.Raised{aggregate_uuid: aggregate_uuid}
+  end
+
   defp publish_interesting(_aggregate_uuid, 0, _index), do: []
+
   defp publish_interesting(aggregate_uuid, interesting, index) do
     [
-      %Events.Interested{aggregate_uuid: aggregate_uuid, index: index},
+      %Events.Interested{aggregate_uuid: aggregate_uuid, index: index}
     ] ++ publish_interesting(aggregate_uuid, interesting - 1, index + 1)
   end
 
   defp publish_uninteresting(_aggregate_uuid, 0, _index), do: []
+
   defp publish_uninteresting(aggregate_uuid, interesting, index) do
     [
-      %Events.Uninterested{aggregate_uuid: aggregate_uuid, index: index},
+      %Events.Uninterested{aggregate_uuid: aggregate_uuid, index: index}
     ] ++ publish_uninteresting(aggregate_uuid, interesting - 1, index + 1)
   end
 
-  # state mutatators
+  # State mutators
 
-  def apply(%ExampleAggregate{} = state, %Events.Started{aggregate_uuid: aggregate_uuid}), do: %ExampleAggregate{state | uuid: aggregate_uuid, state: :started}
-  def apply(%ExampleAggregate{items: items} = state, %Events.Interested{index: index}), do: %ExampleAggregate{state | items: items ++ [index]}
-  def apply(%ExampleAggregate{} = state, %Events.Errored{}), do: %ExampleAggregate{state | state: :errored}
+  def apply(%ExampleAggregate{} = state, %Events.Started{aggregate_uuid: aggregate_uuid}),
+    do: %ExampleAggregate{state | uuid: aggregate_uuid, state: :started}
+
+  def apply(%ExampleAggregate{items: items} = state, %Events.Interested{index: index}),
+    do: %ExampleAggregate{state | items: items ++ [index]}
+
+  def apply(%ExampleAggregate{} = state, %Events.Errored{}),
+    do: %ExampleAggregate{state | state: :errored}
+
+  def apply(%ExampleAggregate{} = state, %Events.Raised{}),
+    do: %ExampleAggregate{state | state: :exception}
+
   def apply(%ExampleAggregate{} = state, %Events.Uninterested{}), do: state
-  def apply(%ExampleAggregate{} = state, %Events.Stopped{}), do: %ExampleAggregate{state | state: :stopped}
+
+  def apply(%ExampleAggregate{} = state, %Events.Stopped{}),
+    do: %ExampleAggregate{state | state: :stopped}
 end

--- a/test/process_managers/support/example_command_handler.ex
+++ b/test/process_managers/support/example_command_handler.ex
@@ -3,22 +3,30 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
   @behaviour Commanded.Commands.Handler
 
   alias Commanded.ProcessManagers.ExampleAggregate
+
   alias Commanded.ProcessManagers.ExampleAggregate.Commands.{
     Error,
     Publish,
+    Raise,
     Start,
-    Stop,
+    Stop
   }
 
   def handle(%ExampleAggregate{} = aggregate, %Start{aggregate_uuid: aggregate_uuid}),
     do: ExampleAggregate.start(aggregate, aggregate_uuid)
 
-  def handle(%ExampleAggregate{} = aggregate, %Publish{interesting: interesting, uninteresting: uninteresting}),
-    do: ExampleAggregate.publish(aggregate, interesting, uninteresting)
+  def handle(%ExampleAggregate{} = aggregate, %Publish{} = command) do
+    %Publish{interesting: interesting, uninteresting: uninteresting} = command
+
+    ExampleAggregate.publish(aggregate, interesting, uninteresting)
+  end
 
   def handle(%ExampleAggregate{} = aggregate, %Stop{}),
     do: ExampleAggregate.stop(aggregate)
 
   def handle(%ExampleAggregate{} = aggregate, %Error{}),
     do: ExampleAggregate.error(aggregate)
+
+  def handle(%ExampleAggregate{} = aggregate, %Raise{}),
+    do: ExampleAggregate.raise(aggregate)
 end

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -2,10 +2,10 @@ defmodule Commanded.ProcessManagers.ExampleRouter do
   @moduledoc false
   use Commanded.Commands.Router
 
-  alias Commanded.ProcessManagers.{ExampleAggregate,ExampleCommandHandler}
-  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Error,Publish,Start,Stop}
+  alias Commanded.ProcessManagers.{ExampleAggregate, ExampleCommandHandler}
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Error, Publish, Raise, Start, Stop}
 
-  dispatch [Start,Publish,Stop,Error],
+  dispatch [Error, Publish, Raise, Start, Stop],
     to: ExampleCommandHandler,
     aggregate: ExampleAggregate,
     identity: :aggregate_uuid

--- a/test/process_managers/support/multi/todo.ex
+++ b/test/process_managers/support/multi/todo.ex
@@ -25,7 +25,7 @@ defmodule Commanded.ProcessManagers.Todo do
     %TodoDone{todo_uuid: todo_uuid}
   end
 
-  # state mutatators
+  # State mutators
 
   def apply(%Todo{} = state, %TodoCreated{}), do: %Todo{state | status: :pending}
 

--- a/test/process_managers/support/resume/resume_aggregate.ex
+++ b/test/process_managers/support/resume/resume_aggregate.ex
@@ -1,31 +1,37 @@
 defmodule Commanded.ProcessManagers.ResumeAggregate do
   @moduledoc false
-  defstruct [status: nil]
+
+  defstruct [:status]
 
   defmodule Commands do
-    defmodule StartProcess, do: defstruct [process_uuid: nil, status: nil]
-    defmodule ResumeProcess, do: defstruct [process_uuid: nil, status: nil]
+    defmodule(StartProcess, do: defstruct([:process_uuid, :status]))
+    defmodule(ResumeProcess, do: defstruct([:process_uuid, :status]))
   end
 
   defmodule Events do
-    defmodule ProcessStarted, do: defstruct [process_uuid: nil, status: nil]
-    defmodule ProcessResumed, do: defstruct [process_uuid: nil, status: nil]
+    defmodule(ProcessStarted, do: defstruct([:process_uuid, :status]))
+    defmodule(ProcessResumed, do: defstruct([:process_uuid, :status]))
   end
 
   alias Commanded.ProcessManagers.ResumeAggregate
-  alias Commanded.ProcessManagers.ResumeAggregate.Commands.{StartProcess,ResumeProcess}
-  alias Commanded.ProcessManagers.ResumeAggregate.Events.{ProcessStarted,ProcessResumed}
+  alias Commanded.ProcessManagers.ResumeAggregate.Commands.{StartProcess, ResumeProcess}
+  alias Commanded.ProcessManagers.ResumeAggregate.Events.{ProcessStarted, ProcessResumed}
 
   def start_process(%ResumeAggregate{}, %StartProcess{process_uuid: process_uuid, status: status}) do
     %ProcessStarted{process_uuid: process_uuid, status: status}
   end
 
-  def resume_process(%ResumeAggregate{}, %ResumeProcess{process_uuid: process_uuid, status: status}) do
+  def resume_process(%ResumeAggregate{}, %ResumeProcess{} = command) do
+    %ResumeProcess{process_uuid: process_uuid, status: status} = command
+
     %ProcessResumed{process_uuid: process_uuid, status: status}
   end
 
-  # state mutatators
+  # State mutators
 
-  def apply(%ResumeAggregate{} = state, %ProcessStarted{status: status}), do: %ResumeAggregate{state | status: status}
-  def apply(%ResumeAggregate{} = state, %ProcessResumed{status: status}), do: %ResumeAggregate{state | status: status}
+  def apply(%ResumeAggregate{} = state, %ProcessStarted{status: status}),
+    do: %ResumeAggregate{state | status: status}
+
+  def apply(%ResumeAggregate{} = state, %ProcessResumed{status: status}),
+    do: %ResumeAggregate{state | status: status}
 end


### PR DESCRIPTION
Allow exceptions and errors during event handling to be handled by `error/3` callback functions defined in event handlers and process managers. 

This allows extra resiliency for event handling since exceptions will cause process crashes. These processes are usually supervised and get restarted by the supervisor, they will then retry the same event and likely crash again. This can cause the supervisor itself to crash and propagate further up the supervision tree, eventually causing the application to stop.

The pull request allows the user to decide how to handle problematic events by for example retyring a limited number of times or skipping the event.