### PR TITLE
Process manager event handling timeout

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -298,11 +298,11 @@ defmodule Commanded.Event.Handler do
   def parse_name(_module, name), do: inspect(name)
 
   @doc false
-  def start_opts(module, module_opts, local_opts) do
+  def start_opts(module, module_opts, local_opts, additional_allowed_opts \\ []) do
     {valid, invalid} =
       module_opts
       |> Keyword.merge(local_opts)
-      |> Keyword.split([:consistency, :start_from])
+      |> Keyword.split([:consistency, :start_from] ++ additional_allowed_opts)
 
     if Enum.any?(invalid) do
       raise "#{inspect(module)} specifies invalid options: #{inspect(Keyword.keys(invalid))}"

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -235,7 +235,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
           Commanded.Event.Handler.start_opts(
             __MODULE__,
             Keyword.drop(@opts, [:name, :router]),
-            opts
+            opts,
+            [:event_timeout]
           )
 
         Commanded.ProcessManagers.ProcessRouter.start_link(@name, __MODULE__, @router, opts)

--- a/test/process_managers/process_manager_timeout_test.exs
+++ b/test/process_managers/process_manager_timeout_test.exs
@@ -1,0 +1,45 @@
+defmodule Commanded.ProcessManagers.ProcessManagerTimeoutTest do
+  use Commanded.StorageCase
+
+  alias Commanded.ProcessManagers.ProcessRouter
+  alias Commanded.ProcessManagers.{ExampleRouter, ExampleProcessManager}
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Pause, Start}
+
+  test "should not timeout and shutdown process manager by default" do
+    aggregate_uuid = UUID.uuid4()
+
+    {:ok, process_router} = ExampleProcessManager.start_link()
+    router_ref = Process.monitor(process_router)
+
+    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+    process_instance = ProcessRouter.process_instance(process_router, aggregate_uuid)
+    instance_ref = Process.monitor(process_instance)
+
+    :ok = ExampleRouter.dispatch(%Pause{aggregate_uuid: aggregate_uuid})
+
+    # Should not shutdown process manager or instance
+    refute_receive {:DOWN, ^router_ref, _, _, _}
+    refute_receive {:DOWN, ^instance_ref, _, _, _}
+  end
+
+  test "should timeout and shutdown process manager when `event_timeout` configured" do
+    aggregate_uuid = UUID.uuid4()
+
+    {:ok, process_router} = ExampleProcessManager.start_link(event_timeout: 10)
+    router_ref = Process.monitor(process_router)
+
+    Process.unlink(process_router)
+
+    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+    process_instance = ProcessRouter.process_instance(process_router, aggregate_uuid)
+    instance_ref = Process.monitor(process_instance)
+
+    :ok = ExampleRouter.dispatch(%Pause{aggregate_uuid: aggregate_uuid})
+
+    # Should shutdown process manager and instance
+    assert_receive {:DOWN, ^router_ref, _, _, :event_timeout}
+    assert_receive {:DOWN, ^instance_ref, _, _, :shutdown}
+  end
+end

--- a/test/process_managers/support/example_aggregate.ex
+++ b/test/process_managers/support/example_aggregate.ex
@@ -9,6 +9,7 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
   defmodule Commands do
     defmodule(Start, do: defstruct([:aggregate_uuid]))
     defmodule(Publish, do: defstruct([:aggregate_uuid, :interesting, :uninteresting]))
+    defmodule(Pause, do: defstruct([:aggregate_uuid]))
     defmodule(Stop, do: defstruct([:aggregate_uuid]))
     defmodule(Error, do: defstruct([:aggregate_uuid]))
     defmodule(Raise, do: defstruct([:aggregate_uuid]))
@@ -19,6 +20,7 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
     defmodule(Interested, do: defstruct([:aggregate_uuid, :index]))
     defmodule(Uninterested, do: defstruct([:aggregate_uuid, :index]))
     defmodule(Stopped, do: defstruct([:aggregate_uuid]))
+    defmodule(Paused, do: defstruct([:aggregate_uuid]))
     defmodule(Errored, do: defstruct([:aggregate_uuid]))
     defmodule(Raised, do: defstruct([:aggregate_uuid]))
   end
@@ -32,6 +34,10 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
       publish_interesting(aggregate_uuid, interesting, 1),
       publish_uninteresting(aggregate_uuid, uninteresting, 1)
     )
+  end
+
+  def pause(%ExampleAggregate{uuid: aggregate_uuid}) do
+    %Events.Paused{aggregate_uuid: aggregate_uuid}
   end
 
   def stop(%ExampleAggregate{uuid: aggregate_uuid}) do
@@ -69,6 +75,9 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
 
   def apply(%ExampleAggregate{items: items} = state, %Events.Interested{index: index}),
     do: %ExampleAggregate{state | items: items ++ [index]}
+
+  def apply(%ExampleAggregate{} = state, %Events.Paused{}),
+    do: %ExampleAggregate{state | state: :paused}
 
   def apply(%ExampleAggregate{} = state, %Events.Errored{}),
     do: %ExampleAggregate{state | state: :errored}

--- a/test/process_managers/support/example_command_handler.ex
+++ b/test/process_managers/support/example_command_handler.ex
@@ -6,6 +6,7 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
 
   alias Commanded.ProcessManagers.ExampleAggregate.Commands.{
     Error,
+    Pause,
     Publish,
     Raise,
     Start,
@@ -20,6 +21,9 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
 
     ExampleAggregate.publish(aggregate, interesting, uninteresting)
   end
+
+  def handle(%ExampleAggregate{} = aggregate, %Pause{}),
+    do: ExampleAggregate.pause(aggregate)
 
   def handle(%ExampleAggregate{} = aggregate, %Stop{}),
     do: ExampleAggregate.stop(aggregate)

--- a/test/process_managers/support/example_process_manager.ex
+++ b/test/process_managers/support/example_process_manager.ex
@@ -1,11 +1,13 @@
 defmodule Commanded.ProcessManagers.ExampleProcessManager do
   @moduledoc false
+
   alias Commanded.ProcessManagers.{ExampleProcessManager, ExampleRouter}
   alias Commanded.ProcessManagers.ExampleAggregate.Commands.Stop
 
   alias Commanded.ProcessManagers.ExampleAggregate.Events.{
     Errored,
     Interested,
+    Paused,
     Raised,
     Started,
     Stopped
@@ -19,12 +21,18 @@ defmodule Commanded.ProcessManagers.ExampleProcessManager do
 
   def interested?(%Started{aggregate_uuid: aggregate_uuid}), do: {:start, aggregate_uuid}
   def interested?(%Interested{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
+  def interested?(%Paused{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
   def interested?(%Errored{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
   def interested?(%Raised{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
   def interested?(%Stopped{aggregate_uuid: aggregate_uuid}), do: {:stop, aggregate_uuid}
 
   def handle(%ExampleProcessManager{}, %Interested{index: 10, aggregate_uuid: aggregate_uuid}) do
     %Stop{aggregate_uuid: aggregate_uuid}
+  end
+
+  # Simulate a "stuck" process
+  def handle(%ExampleProcessManager{}, %Paused{}) do
+    :timer.sleep(:infinity)
   end
 
   def handle(%ExampleProcessManager{}, %Errored{}), do: {:error, :failed}

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -3,9 +3,17 @@ defmodule Commanded.ProcessManagers.ExampleRouter do
   use Commanded.Commands.Router
 
   alias Commanded.ProcessManagers.{ExampleAggregate, ExampleCommandHandler}
-  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Error, Publish, Raise, Start, Stop}
 
-  dispatch [Error, Publish, Raise, Start, Stop],
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{
+    Error,
+    Pause,
+    Publish,
+    Raise,
+    Start,
+    Stop
+  }
+
+  dispatch [Error, Pause, Publish, Raise, Start, Stop],
     to: ExampleCommandHandler,
     aggregate: ExampleAggregate,
     identity: :aggregate_uuid

--- a/test/process_managers/support/resume/resume_process_manager.ex
+++ b/test/process_managers/support/resume/resume_process_manager.ex
@@ -4,11 +4,9 @@ defmodule Commanded.ProcessManagers.ResumeProcessManager do
     name: "resume-process-manager",
     router: ResumeRouter
 
-  defstruct [
-    status_history: []
-  ]
+  defstruct status_history: []
 
-  alias Commanded.ProcessManagers.ResumeAggregate.Events.{ProcessStarted,ProcessResumed}
+  alias Commanded.ProcessManagers.ResumeAggregate.Events.{ProcessStarted, ProcessResumed}
   alias Commanded.ProcessManagers.ResumeProcessManager
 
   def interested?(%ProcessStarted{process_uuid: process_uuid}), do: {:start, process_uuid}
@@ -17,17 +15,19 @@ defmodule Commanded.ProcessManagers.ResumeProcessManager do
   def handle(%ResumeProcessManager{}, %ProcessStarted{}), do: []
   def handle(%ResumeProcessManager{}, %ProcessResumed{}), do: []
 
-  ## state mutators
+  # State mutators
 
-  def apply(%ResumeProcessManager{status_history: status_history} = process, %ProcessStarted{status: status}) do
-    %ResumeProcessManager{process |
-      status_history: status_history ++ [status]
-    }
+  def apply(%ResumeProcessManager{} = process, %ProcessStarted{} = event) do
+    %ResumeProcessManager{status_history: status_history} = process
+    %ProcessStarted{status: status} = event
+
+    %ResumeProcessManager{process | status_history: status_history ++ [status]}
   end
 
-  def apply(%ResumeProcessManager{status_history: status_history} = process, %ProcessResumed{status: status}) do
-    %ResumeProcessManager{process |
-      status_history: status_history ++ [status]
-    }
+  def apply(%ResumeProcessManager{} = process, %ProcessResumed{} = event) do
+    %ResumeProcessManager{status_history: status_history} = process
+    %ProcessResumed{status: status} = event
+
+    %ResumeProcessManager{process | status_history: status_history ++ [status]}
   end
 end


### PR DESCRIPTION
You can configure a timeout for event handling to ensure that events are processed in a timely manner without getting stuck.

An `event_timeout` option, defined in milliseconds, may be provided when using the `Commanded.ProcessManagers.ProcessManager` macro at compile time:

```elixir
defmodule TransferMoneyProcessManager do
  use Commanded.ProcessManagers.ProcessManager,
    name: "TransferMoneyProcessManager",
    router: BankRouter,
    event_timeout: :timer.minutes(10)
end
```

Or may be configured when starting a process manager:

```elixir
{:ok, _pid} = TransferMoneyProcessManager.start_link(event_timeout: :timer.hours(1))
```
After the timeout has elapsed, indicating the process manager has not processed an event within the configured period, the process manager is stopped. The process manager will be restarted if supervised and will retry the event, this should help resolve transient problems.