### PR TITLE
Fix snapshot recording

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -379,7 +379,7 @@ defmodule Commanded.Aggregates.Aggregate do
   defp snapshot_valid?(%SnapshotData{metadata: metadata}, %Aggregate{
          snapshot_module_version: expected_version
        }) do
-    Map.get(metadata, "snapshot_version", 1) == expected_version
+    Map.get(metadata, "snapshot_module_version", 1) == expected_version
   end
 
   # take a snapshot now?
@@ -400,7 +400,8 @@ defmodule Commanded.Aggregates.Aggregate do
       aggregate_module: _aggregate_module,
       aggregate_uuid: aggregate_uuid,
       aggregate_version: aggregate_version,
-      aggregate_state: aggregate_state
+      aggregate_state: aggregate_state,
+      snapshot_module_version: snapshot_module_version
     } = state
 
     Logger.debug(fn -> describe(state) <> " recording snapshot" end)
@@ -410,7 +411,7 @@ defmodule Commanded.Aggregates.Aggregate do
       source_version: aggregate_version,
       source_type: TypeProvider.to_string(aggregate_state),
       data: aggregate_state,
-      metadata: %{"snapshot_version" => aggregate_version}
+      metadata: %{"snapshot_module_version" => snapshot_module_version}
     }
 
     :ok = EventStore.record_snapshot(snapshot)

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -92,7 +92,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
            items: Enum.to_list(1..10),
            last_index: 10
          },
-         metadata: %{"snapshot_version" => 10},
+         metadata: %{"snapshot_module_version" => 1},
        }
     end
 
@@ -112,7 +112,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
            items: Enum.to_list(1..11),
            last_index: 11
          },
-         metadata: %{"snapshot_version" => 11},
+         metadata: %{"snapshot_module_version" => 1},
        }
     end
 
@@ -141,7 +141,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
            items: Enum.to_list(1..21),
            last_index: 21
          },
-         metadata: %{"snapshot_version" => 21},
+         metadata: %{"snapshot_module_version" => 1},
        }
     end
   end


### PR DESCRIPTION
## Issue

Aggregate is not properly populated from snapshots

## Reason

`snapshot_valid?` compares `aggregate.snapshot_module_version` with `snapshot.metadata["snapshot_version"]`, but when snapshot is recorded `aggregate.aggregate_version` is saved to new snapshot metadata instead of `aggregate.snapshot_module_version`. If I understand everything correctly `:aggregate_version` changes for every event while `:snapshot_module_version` should be changed by programmer inside config.exs file only when needed.

## How to prove this

* Create simple agent `Agent.start_link(fn -> 0 end, name: :foo)`
* Add `Agent.update(:foo, & (&1 + 1))` to every `apply/2` inside aggregate
* Dispatch a command
* `Agent.get(:foo, & &1)` will always return number equal to all events count

## Fix

* Changed value used to create new snapshot metadata to `:snapshot_module_version`
* Changed snapshot metadata field name to force snapshot recreation (this should be backward compatible and prevent any possible side effects)

## Things to consider

This probably require some additional tests to prevent regressions. Unfortunately, it's my first day with this library and I don't have enough time to learn its internals.