### PR TITLE
Set default aggregate lifespan timeout to `:infinity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug fixes
 
 - Fix snapshot recording ([#196](https://github.com/commanded/commanded/pull/196)).
+- Set default aggregate lifespan timeout to `:infinity` ([#200](https://github.com/commanded/commanded/pull/200)).
 
 ## v0.17.0
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -53,7 +53,7 @@ defmodule Commanded.Aggregates.Aggregate do
             aggregate_uuid: nil,
             aggregate_state: nil,
             aggregate_version: 0,
-            lifespan_timeout: nil,
+            lifespan_timeout: :infinity,
             snapshot_every: nil,
             snapshot_module_version: 1,
             snapshot_version: 0


### PR DESCRIPTION
To ensure the `lifespan_timeout` is always a valid timeout value that can be used for `GenServer` handle callbacks.

Fixes #199.