### PR TITLE
export Commanded.Commands.Router macros in .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,9 +1,14 @@
+locals_without_parens = [
+  dispatch: 2,
+  identify: 2,
+  middleware: 1
+]
+
 [
   inputs: [
     "lib/*/{lib,test}/**/*.{ex,exs}",
     "lib/*/mix.exs"
   ],
-  locals_without_parens: [
-    dispatch: 2
-  ]
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]


### PR DESCRIPTION
This will allow to add `import_deps: [:commanded]` to `.formatter.exs` in projects using commanded (instead of adding every macro to locals_without_parent manually)