### PR TITLE
Fixed dialyzer warning generated by "use Commanded.Commands.Router"

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -448,7 +448,7 @@ defmodule Commanded.Commands.Router do
       def dispatch(command, _opts), do: unregistered_command(command)
 
       defp unregistered_command(command) do
-        Logger.error(fn -> "attempted to dispatch an unregistered command: #{inspect command}" end)
+        _ = Logger.error(fn -> "attempted to dispatch an unregistered command: #{inspect command}" end)
         {:error, :unregistered_command}
       end
     end


### PR DESCRIPTION
Code generated by `use Commanded.Commands.Router` was causing following dialyzer warning:
`lib/my_app/router.ex:1: Expression produces a value of type 'ok' | {'error',_}, but this value is unmatched`