### PR TITLE
Aggregates should shutdown after errors

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -187,6 +187,9 @@ defmodule Commanded.Aggregates.Aggregate do
         {:ok, _stream_version, events} ->
           aggregate_lifespan_timeout(context, events)
 
+        {:error, _} ->
+          :stop
+
         _reply ->
           :infinity
       end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -128,9 +128,10 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
     end
 
     test "should shutdown after error", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+      ib = "clearly invalid"
+
       {:error, :invalid_initial_balance} =
-        BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: "clearly
-          invalid"})
+        BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: ib})
 
       assert_receive {:DOWN, ^ref, :process, _, :normal}
     end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -126,6 +126,14 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
 
       refute_receive {:DOWN, ^ref, :process, ^pid, _}
     end
+
+    test "should shutdown after error", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+      {:error, :invalid_initial_balance} =
+        BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: "clearly
+          invalid"})
+
+      assert_receive {:DOWN, ^ref, :process, _, :normal}
+    end
   end
 
   describe "deprecated `after_command/1` callback" do

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -33,6 +33,13 @@ defmodule Commanded.ExampleDomain.BankAccount do
 
   def open_account(%BankAccount{state: nil}, %OpenAccount{
         account_number: account_number,
+        initial_balance: "clearly invalid"
+      }) do
+    {:error, :invalid_initial_balance}
+  end
+
+  def open_account(%BankAccount{state: nil}, %OpenAccount{
+        account_number: account_number,
         initial_balance: initial_balance
       })
       when is_number(initial_balance) and initial_balance > 0 do


### PR DESCRIPTION
Previously, the lifespan was being set to :infinity when executing a
command returned {:error, any}.