### PR TITLE
Expands AggregateLifespan to include after_command/1 and after_error/1 

### DIFF
--- a/lib/commanded/aggregates/default_lifespan.ex
+++ b/lib/commanded/aggregates/default_lifespan.ex
@@ -13,4 +13,6 @@ defmodule Commanded.Aggregates.DefaultLifespan do
   Aggregate will run indefinitely once started.
   """
   def after_event(_event), do: :infinity
+  def after_command(_event), do: :infinity
+  def after_error(_event), do: :infinity
 end

--- a/test/aggregates/support/bank_account_lifespan.ex
+++ b/test/aggregates/support/bank_account_lifespan.ex
@@ -9,6 +9,13 @@ defmodule Commanded.Aggregates.BankAccountLifespan do
     MoneyDeposited
   }
 
+  alias Commanded.ExampleDomain.BankAccount.Commands.CloseAccount
+
+  def after_command(%CloseAccount{}), do: :stop
+  def after_command(_), do: 10
+
+  def after_error(:invalid_initial_balance), do: 30
+
   def after_event(%BankAccountOpened{}), do: 25
   def after_event(%MoneyDeposited{}), do: 50
   def after_event(%BankAccountClosed{}), do: :stop

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -31,6 +31,10 @@ defmodule Commanded.ExampleDomain.BankAccount do
     BankAccountClosed
   }
 
+  def open_account(%BankAccount{state: nil}, %OpenAccount{initial_balance: "clearly invalid"}) do
+    {:error, :invalid_initial_balance}
+  end
+
   def open_account(%BankAccount{state: nil}, %OpenAccount{
         account_number: account_number,
         initial_balance: initial_balance
@@ -81,6 +85,10 @@ defmodule Commanded.ExampleDomain.BankAccount do
           balance: balance
         }
     end
+  end
+
+  def close_account(%BankAccount{state: :closed}, %CloseAccount{}) do
+    []
   end
 
   def close_account(%BankAccount{state: :active}, %CloseAccount{account_number: account_number}) do


### PR DESCRIPTION
Previously, aggregates would not shut down if one or more events were
not returned after command execution. This change defines callbacks to
handle cases where an error or a [] is returned.