### PR TITLE
Adding recorded_event to predicate_fn in wait_for_event

### DIFF
--- a/lib/commanded/assertions/event_assertions.ex
+++ b/lib/commanded/assertions/event_assertions.ex
@@ -162,7 +162,8 @@ defmodule Commanded.Assertions.EventAssertions do
     expected_event =
       Enum.find(received_events, fn received_event ->
         case received_event.event_type do
-          ^expected_type -> apply(predicate_fn, [received_event.data])
+          ^expected_type when is_function(predicate_fn, 2) -> apply(predicate_fn, [received_event.data, received_event])
+          ^expected_type when is_function(predicate_fn, 1) -> apply(predicate_fn, [received_event.data])
           _ -> false
         end
       end)

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -93,7 +93,7 @@ defmodule Commanded.Event.HandleEventTest do
 
       :ok = EventStore.append_to_stream(stream_uuid, 1, to_event_data(new_events))
 
-      wait_for_event(MoneyDeposited)
+      wait_for_event(MoneyDeposited, fn event, recorded_event -> event.amount == 50 and recorded_event.event_number == 2 end)
 
       Wait.until(fn ->
         assert AppendingEventHandler.received_events() == new_events


### PR DESCRIPTION
Adding second optional parameter to the predicate_fn which now receive the recorded_event as second param, containing all the informations about the event.


## Why

I needed to be sure that an event was produce before another one, and I needed to check some metadata too.

```elixir
wait_for_event(
  MoneyDeposited,
  fn event, recorded_event ->
    event.amount == 50 and recorded_event.event_number == 2
  end
)
```


Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>