### PR TITLE
Fix subscribe/1 '@spec'

### DIFF
--- a/lib/commanded/pubsub.ex
+++ b/lib/commanded/pubsub.ex
@@ -11,7 +11,7 @@ defmodule Commanded.PubSub do
   @doc """
   Subscribes the caller to the PubSub adapter's topic.
   """
-  @callback subscribe(atom) :: :ok | {:error, term}
+  @callback subscribe(String.t() | atom) :: :ok | {:error, term}
 
   @doc """
   Broadcasts message on given topic.

--- a/lib/commanded/pubsub/phoenix_pubsub.ex
+++ b/lib/commanded/pubsub/phoenix_pubsub.ex
@@ -84,7 +84,7 @@ if Code.ensure_loaded?(Phoenix.PubSub) do
     @doc """
     Subscribes the caller to the topic.
     """
-    @spec subscribe(atom) :: :ok | {:error, term}
+    @spec subscribe(String.t()) :: :ok | {:error, term}
     @impl Commanded.PubSub
     def subscribe(topic) when is_binary(topic) do
       Phoenix.PubSub.subscribe(__MODULE__, topic)


### PR DESCRIPTION
There are places where `subscribe/1` `@ spec` is expecting string and not just atom