### PR TITLE
Remove pattern that can not occur

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -79,7 +79,6 @@ defmodule Commanded.Commands.Dispatcher do
     result =
       case Task.yield(task, timeout) || Task.shutdown(task) do
         {:ok, reply} -> reply
-        {:error, error} -> {:error, :aggregate_execution_failed, error}
         {:exit, error} -> {:error, :aggregate_execution_failed, error}
         nil -> {:error, :aggregate_execution_timeout}
       end


### PR DESCRIPTION
`Task.yield/1` and `Task.shutdown/1` do not return: `{:error, error}`, only `{:ok, term} | {:exit, term} | nil`