### PR TITLE
Remove unnecessary else

### DIFF
--- a/lib/commanded/snapshotting.ex
+++ b/lib/commanded/snapshotting.ex
@@ -27,8 +27,6 @@ defmodule Commanded.Snapshotting do
          {:ok, snapshot} <- EventStore.read_snapshot(source_uuid),
          :ok <- validate_snapshot(snapshotting, snapshot) do
       {:ok, snapshot}
-    else
-      {:error, error} -> {:error, error}
     end
   end
 


### PR DESCRIPTION
With the error being returned without any changes, you do not need the else, only if you want to be explicit