### PR TITLE
Moving to Jason

### DIFF
--- a/guides/Events.md
+++ b/guides/Events.md
@@ -8,6 +8,7 @@ Create a module per domain event and define the fields with `defstruct`. An even
 
 ```elixir
 defmodule BankAccountOpened do
+  @derive Jason.Encoder
   defstruct [:account_number, :initial_balance]
 end
 ```

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -10,11 +10,11 @@ Commanded can be installed from hex as follows.
     end
     ```
 
-2. Optionally add `poison` to make `Commanded.Serialization.JsonSerializer` available:
+2. Optionally add `jason` to make `Commanded.Serialization.JsonSerializer` available:
 
     ```elixir
     def deps do
-      [{:poison, "~> 3.1 or ~> 4.0"}]
+      [{:jason, "~> 1.1"}]
     end
     ```
 

--- a/guides/Serialization.md
+++ b/guides/Serialization.md
@@ -2,11 +2,11 @@
 
 JSON serialization can be used for event and snapshot data.
 
-To enable JSON serialization with the included `Commanded.Serialization.JsonSerializer` module add `poison` to your deps
+To enable JSON serialization with the included `Commanded.Serialization.JsonSerializer` module add `jason` to your deps
 
     ```elixir
     def deps do
-      [{:poison, "~> 3.1 or ~> 4.0"}]
+      [{:jason, "~> 1.1"}]
     end
     ```
 
@@ -31,21 +31,21 @@ defimpl Commanded.Serialization.JsonDecoder, for: ExampleEvent do
 end
 ```
 
-[Poison](https://github.com/devinus/poison), a pure Elixir JSON library, is used for the actual serialization. It provides an extension point if you need to manually encode your event by using the `Poison.Encoder` protocol:
+[Jason](https://hex.pm/packages/jason), a pure Elixir JSON library, is used for the actual serialization. It provides an extension point if you need to manually encode your event by using the `Jason.Encoder` protocol:
 
 ```elixir
-defimpl Poison.Encoder, for: Person do
-  def encode(%{name: name, age: age}, options) do
-    Poison.Encoder.BitString.encode("#{name} (#{age})", options)
+defimpl Jason.Encoder, for: Person do
+  def encode(%{name: name, age: age}, opts) do
+    Jason.Encode.string("#{name} (#{age})", options)
   end
 end
 ```
 
-For maximum performance, make sure you `@derive [Poison.Encoder]` for any struct you plan on encoding.
+Make sure you `@derive Jason.Encoder` for any struct you plan on encoding.
 
 ```elixir
 defmodule ExampleEvent do
-  @derive [Poison.Encoder]
+  @derive Jason.Encoder
   defstruct [:name, :date]
 end
 ```

--- a/lib/commanded/serialization/json_serializer.ex
+++ b/lib/commanded/serialization/json_serializer.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Poison) do
+if Code.ensure_loaded?(Jason) do
   defmodule Commanded.Serialization.JsonSerializer do
     @moduledoc """
     A serializer that uses the JSON format.
@@ -11,22 +11,34 @@ if Code.ensure_loaded?(Poison) do
     Serialize given term to JSON binary data.
     """
     def serialize(term) do
-      Poison.encode!(term)
+      Jason.encode!(term)
     end
 
     @doc """
     Deserialize given JSON binary data to the expected type.
     """
     def deserialize(binary, config \\ [])
-    def deserialize(binary, config) do
-      type = case Keyword.get(config, :type) do
-        nil -> nil
-        type -> TypeProvider.to_struct(type)
-      end
 
-      binary
-      |> Poison.decode!(as: type)
-      |> JsonDecoder.decode()
+    def deserialize(binary, config) do
+      type =
+        case Keyword.get(config, :type) do
+          nil -> nil
+          type -> TypeProvider.to_struct(type)
+        end
+
+      opts =
+        case Keyword.get(config, :type) do
+          nil -> %{}
+          _type -> %{keys: :atoms}
+        end
+
+      # todo this actually should be with ! since it can throw
+      res =
+        binary
+        |> Jason.decode!(opts)
+        |> JsonDecoder.decode()
+
+      if type !== nil, do: struct(type, res), else: res
     end
   end
 end

--- a/lib/commanded/serialization/json_serializer.ex
+++ b/lib/commanded/serialization/json_serializer.ex
@@ -33,6 +33,7 @@ if Code.ensure_loaded?(Jason) do
         end
 
       # todo this actually should be with ! since it can throw
+
       res =
         binary
         |> Jason.decode!(opts)

--- a/mix.exs
+++ b/mix.exs
@@ -50,13 +50,13 @@ defmodule Commanded.Mixfile do
   defp deps do
     [
       {:elixir_uuid, "~> 1.2"},
-      {:poison, "~> 3.1 or ~> 4.0", optional: true},
-
+      {:jason, "~> 1.1", optional: true},
       # Build & test tools
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},
       {:ex_doc, "~> 0.19", only: :dev},
       {:mix_test_watch, "~> 0.9", only: :dev},
       {:mox, "~> 0.4", only: :test},
+      {:apex, "~> 1.2", only: :test},
 
       # Optional dependencies
       {:phoenix_pubsub, "~> 1.1", optional: true}

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,11 @@
 %{
+  "apex": {:hex, :apex, "1.2.1", "297f5dac23fa2a32648b890a0838fce2772114010e0b9ec975cae6021cc5a092", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -236,7 +236,6 @@ defmodule Commanded.Aggregates.SnapshottingTest do
     end
   end
 
-  @tag :wip
   describe "decode snapshot data" do
     setup do
       configure_snapshotting(SnapshotAggregate, snapshot_every: 1, snapshot_version: 1)
@@ -252,7 +251,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
       # aggregate state should be decoded
       assert_aggregate_state(SnapshotAggregate, aggregate_uuid, %SnapshotAggregate{
         name: "Example",
-        date: now
+        date: NaiveDateTime.to_iso8601(now)
       })
 
       assert_aggregate_version(SnapshotAggregate, aggregate_uuid, 1)

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -236,6 +236,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
     end
   end
 
+  @tag :wip
   describe "decode snapshot data" do
     setup do
       configure_snapshotting(SnapshotAggregate, snapshot_every: 1, snapshot_version: 1)

--- a/test/aggregates/support/example_aggregate.ex
+++ b/test/aggregates/support/example_aggregate.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.Aggregates.ExampleAggregate do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct items: [],
             last_index: 0
 
@@ -9,7 +10,10 @@ defmodule Commanded.Aggregates.ExampleAggregate do
   end
 
   defmodule Events do
-    defmodule(ItemAppended, do: defstruct([:index]))
+    defmodule ItemAppended do
+      @derive Jason.Encoder
+      defstruct([:index])
+    end
   end
 
   alias Commanded.Aggregates.ExampleAggregate

--- a/test/aggregates/support/lifespan/lifespan_aggregate.ex
+++ b/test/aggregates/support/lifespan/lifespan_aggregate.ex
@@ -1,12 +1,15 @@
 defmodule Commanded.Aggregates.LifespanAggregate do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct [:uuid, :reply_to, :lifespan]
 
   defmodule Command do
+    @derive Jason.Encoder
     defstruct [:uuid, :reply_to, :action, :lifespan]
   end
 
   defmodule Event do
+    @derive Jason.Encoder
     defstruct [:uuid, :reply_to, :lifespan]
   end
 

--- a/test/aggregates/support/multi_bank_account.ex
+++ b/test/aggregates/support/multi_bank_account.ex
@@ -12,8 +12,15 @@ defmodule Commanded.Aggregate.Multi.BankAccount do
   end
 
   defmodule Events do
-    defmodule(BankAccountOpened, do: defstruct([:account_number, :balance]))
-    defmodule(MoneyWithdrawn, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
+    defmodule BankAccountOpened do
+      @derive Jason.Encoder
+      defstruct([:account_number, :balance])
+    end
+
+    defmodule MoneyWithdrawn do
+      @derive Jason.Encoder
+      defstruct([:account_number, :transfer_uuid, :amount, :balance])
+    end
   end
 
   alias Commands.{OpenAccount, WithdrawMoney}

--- a/test/aggregates/support/snapshot_aggregate.ex
+++ b/test/aggregates/support/snapshot_aggregate.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.Aggregates.SnapshotAggregate do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct [
     :name,
     :date
@@ -10,7 +11,10 @@ defmodule Commanded.Aggregates.SnapshotAggregate do
   end
 
   defmodule Events do
-    defmodule(Created, do: defstruct([:name, :date]))
+    defmodule Created do
+      @derive Jason.Encoder
+      defstruct([:name, :date])
+    end
   end
 
   alias Commanded.Aggregates.SnapshotAggregate

--- a/test/commands/custom_identity_routing_test.exs
+++ b/test/commands/custom_identity_routing_test.exs
@@ -7,6 +7,7 @@ defmodule Commanded.Commands.CustomIdentityRoutingTest do
   alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
 
   defmodule AccountNumber do
+    @derive Jason.Encoder
     defstruct [:branch, :account_number]
 
     defimpl String.Chars do
@@ -40,6 +41,7 @@ defmodule Commanded.Commands.CustomIdentityRoutingTest do
 
   describe "invalid identity" do
     defmodule InvalidIdentity do
+      @derive Jason.Encoder
       defstruct [:uuid]
     end
 

--- a/test/commands/support/consistency/consistency_aggregate_root.ex
+++ b/test/commands/support/consistency/consistency_aggregate_root.ex
@@ -1,12 +1,32 @@
 defmodule Commanded.Commands.ConsistencyAggregateRoot do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct [:delay]
 
-  defmodule ConsistencyCommand, do: defstruct [:uuid, :delay]
-  defmodule NoOpCommand, do: defstruct [:uuid]
-  defmodule RequestDispatchCommand, do: defstruct [:uuid, :delay]
-  defmodule ConsistencyEvent, do: defstruct [:uuid, :delay]
-  defmodule DispatchRequestedEvent, do: defstruct [:uuid, :delay]
+  defmodule ConsistencyCommand do
+    @derive Jason.Encoder
+    defstruct([:uuid, :delay])
+  end
+
+  defmodule NoOpCommand do
+    @derive Jason.Encoder
+    defstruct([:uuid])
+  end
+
+  defmodule RequestDispatchCommand do
+    @derive Jason.Encoder
+    defstruct([:uuid, :delay])
+  end
+
+  defmodule ConsistencyEvent do
+    @derive Jason.Encoder
+    defstruct([:uuid, :delay])
+  end
+
+  defmodule DispatchRequestedEvent do
+    @derive Jason.Encoder
+    defstruct([:uuid, :delay])
+  end
 
   alias Commanded.Commands.ConsistencyAggregateRoot
 

--- a/test/commands/support/consistency/strongly_consistent_process_manager.ex
+++ b/test/commands/support/consistency/strongly_consistent_process_manager.ex
@@ -6,6 +6,7 @@ defmodule Commanded.Commands.StronglyConsistentProcessManager do
     consistency: :strong,
     router: ConsistencyRouter
 
+  @derive Jason.Encoder
   defstruct [
     :uuid
   ]
@@ -22,7 +23,7 @@ defmodule Commanded.Commands.StronglyConsistentProcessManager do
 
   def handle(%StronglyConsistentProcessManager{}, %DispatchRequestedEvent{} = requested) do
     %DispatchRequestedEvent{uuid: uuid, delay: delay} = requested
-    
+
     %ConsistencyCommand{uuid: uuid, delay: delay}
   end
 

--- a/test/commands/support/identity/identity_aggregate.ex
+++ b/test/commands/support/identity/identity_aggregate.ex
@@ -1,9 +1,17 @@
 defmodule Commanded.Commands.IdentityAggregate do
   @moduledoc false
-  defstruct [uuid: nil]
+  @derive Jason.Encoder
+  defstruct uuid: nil
 
-  defmodule IdentityCommand, do: defstruct [:uuid]
-  defmodule IdentityEvent, do: defstruct [:uuid]
+  defmodule IdentityCommand do
+    @derive Jason.Encoder
+    defstruct([:uuid])
+  end
+
+  defmodule IdentityEvent do
+    @derive Jason.Encoder
+    defstruct([:uuid])
+  end
 
   def execute(%__MODULE__{}, %IdentityCommand{uuid: uuid}), do: %IdentityEvent{uuid: uuid}
   def apply(aggregate, _event), do: aggregate

--- a/test/commands/support/identity/identity_function_aggregate.ex
+++ b/test/commands/support/identity/identity_function_aggregate.ex
@@ -1,10 +1,20 @@
 defmodule Commanded.Commands.IdentityFunctionAggregate do
   @moduledoc false
-  defstruct [uuid: nil]
+  @derive Jason.Encoder
+  defstruct uuid: nil
 
-  defmodule IdentityFunctionCommand, do: defstruct [:uuid]
-  defmodule IdentityFunctionEvent, do: defstruct [:uuid]
+  defmodule IdentityFunctionCommand do
+    @derive Jason.Encoder
+    defstruct [:uuid]
+  end
 
-  def execute(%__MODULE__{}, %IdentityFunctionCommand{uuid: uuid}), do: %IdentityFunctionEvent{uuid: uuid}
+  defmodule IdentityFunctionEvent do
+    @derive Jason.Encoder
+    defstruct [:uuid]
+  end
+
+  def execute(%__MODULE__{}, %IdentityFunctionCommand{uuid: uuid}),
+    do: %IdentityFunctionEvent{uuid: uuid}
+
   def apply(aggregate, _event), do: aggregate
 end

--- a/test/event/event_handler_subscribe_to_stream_test.exs
+++ b/test/event/event_handler_subscribe_to_stream_test.exs
@@ -4,6 +4,7 @@ defmodule Commanded.Event.EventHandlerSubscribeToStreamTest do
   alias Commanded.EventStore
 
   defmodule AnEvent do
+    @derive Jason.Encoder
     defstruct [:stream_uuid, :reply_to]
   end
 

--- a/test/event/support/error/error_aggregate.ex
+++ b/test/event/support/error/error_aggregate.ex
@@ -9,8 +9,15 @@ defmodule Commanded.Event.ErrorAggregate do
   end
 
   defmodule Events do
-    defmodule(ErrorEvent, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
-    defmodule(ExceptionEvent, do: defstruct([:uuid, :strategy, :delay, :reply_to]))
+    defmodule ErrorEvent do
+      @derive Jason.Encoder
+      defstruct([:uuid, :strategy, :delay, :reply_to])
+    end
+
+    defmodule ExceptionEvent do
+      @derive Jason.Encoder
+      defstruct([:uuid, :strategy, :delay, :reply_to])
+    end
   end
 
   alias Commanded.Event.ErrorAggregate

--- a/test/event_store/adapters/in_memory_test.exs
+++ b/test/event_store/adapters/in_memory_test.exs
@@ -5,6 +5,7 @@ defmodule Commanded.EventStore.Adapters.InMemoryTest do
   alias Commanded.EventStore.EventData
 
   defmodule BankAccountOpened do
+    @derive Jason.Encoder
     defstruct [:account_number, :initial_balance]
   end
 

--- a/test/event_store/support/append_events_test_case.ex
+++ b/test/event_store/support/append_events_test_case.ex
@@ -8,6 +8,7 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
     alias Commanded.EventStore.EventData
 
     defmodule BankAccountOpened do
+      @derive Jason.Encoder
       defstruct [:account_number, :initial_balance]
     end
 

--- a/test/event_store/support/snapshot_test_case.ex
+++ b/test/event_store/support/snapshot_test_case.ex
@@ -6,6 +6,7 @@ defmodule Commanded.EventStore.SnapshotTestCase do
     alias Commanded.EventStore.SnapshotData
 
     defmodule BankAccountOpened do
+      @derive Jason.Encoder
       defstruct [:account_number, :initial_balance]
     end
 

--- a/test/event_store/support/subscription_test_case.ex
+++ b/test/event_store/support/subscription_test_case.ex
@@ -7,6 +7,7 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
     alias Commanded.Helpers.ProcessHelper
 
     defmodule BankAccountOpened do
+      @derive Jason.Encoder
       defstruct [:account_number, :initial_balance]
     end
 

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.ExampleDomain.BankAccount do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct account_number: nil,
             balance: 0,
             state: nil
@@ -7,18 +8,52 @@ defmodule Commanded.ExampleDomain.BankAccount do
   alias Commanded.ExampleDomain.BankAccount
 
   defmodule Commands do
-    defmodule(OpenAccount, do: defstruct([:account_number, :initial_balance]))
-    defmodule(DepositMoney, do: defstruct([:account_number, :transfer_uuid, :amount]))
-    defmodule(WithdrawMoney, do: defstruct([:account_number, :transfer_uuid, :amount]))
-    defmodule(CloseAccount, do: defstruct([:account_number]))
+    defmodule OpenAccount do
+      @derive Jason.Encoder
+      defstruct([:account_number, :initial_balance])
+    end
+
+    defmodule DepositMoney do
+      @derive Jason.Encoder
+      defstruct([:account_number, :transfer_uuid, :amount])
+    end
+
+    defmodule WithdrawMoney do
+      @derive Jason.Encoder
+      defstruct([:account_number, :transfer_uuid, :amount])
+    end
+
+    defmodule CloseAccount do
+      @derive Jason.Encoder
+      defstruct([:account_number])
+    end
   end
 
   defmodule Events do
-    defmodule(BankAccountOpened, do: defstruct([:account_number, :initial_balance]))
-    defmodule(MoneyDeposited, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
-    defmodule(MoneyWithdrawn, do: defstruct([:account_number, :transfer_uuid, :amount, :balance]))
-    defmodule(AccountOverdrawn, do: defstruct([:account_number, :balance]))
-    defmodule(BankAccountClosed, do: defstruct([:account_number]))
+    defmodule BankAccountOpened do
+      @derive Jason.Encoder
+      defstruct([:account_number, :initial_balance])
+    end
+
+    defmodule MoneyDeposited do
+      @derive Jason.Encoder
+      defstruct([:account_number, :transfer_uuid, :amount, :balance])
+    end
+
+    defmodule MoneyWithdrawn do
+      @derive Jason.Encoder
+      defstruct([:account_number, :transfer_uuid, :amount, :balance])
+    end
+
+    defmodule AccountOverdrawn do
+      @derive Jason.Encoder
+      defstruct([:account_number, :balance])
+    end
+
+    defmodule BankAccountClosed do
+      @derive Jason.Encoder
+      defstruct([:account_number])
+    end
   end
 
   alias Commands.{OpenAccount, DepositMoney, WithdrawMoney, CloseAccount}

--- a/test/example_domain/money_transfer/money_transfer.ex
+++ b/test/example_domain/money_transfer/money_transfer.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.ExampleDomain.MoneyTransfer do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct transfer_uuid: nil,
             debit_account: nil,
             credit_account: nil,
@@ -9,15 +10,17 @@ defmodule Commanded.ExampleDomain.MoneyTransfer do
   alias Commanded.ExampleDomain.MoneyTransfer
 
   defmodule Commands do
-    defmodule(TransferMoney,
-      do: defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
-    )
+    defmodule TransferMoney do
+      @derive Jason.Encoder
+      defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
+    end
   end
 
   defmodule Events do
-    defmodule(MoneyTransferRequested,
-      do: defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
-    )
+    defmodule MoneyTransferRequested do
+      @derive Jason.Encoder
+      defstruct(transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil)
+    end
   end
 
   alias Commands.{TransferMoney}

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -4,28 +4,40 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
     name: "transfer_money_process_manager",
     router: Commanded.ExampleDomain.BankRouter
 
-  defstruct [
-    transfer_uuid: nil,
-    debit_account: nil,
-    credit_account: nil,
-    amount: nil,
-    status: nil
-  ]
+  @derive Jason.Encoder
+  defstruct transfer_uuid: nil,
+            debit_account: nil,
+            credit_account: nil,
+            amount: nil,
+            status: nil
 
   alias Commanded.ExampleDomain.TransferMoneyProcessManager
   alias Commanded.ExampleDomain.MoneyTransfer.Events.{MoneyTransferRequested}
-  alias Commanded.ExampleDomain.BankAccount.Events.{MoneyDeposited,MoneyWithdrawn}
-  alias Commanded.ExampleDomain.BankAccount.Commands.{DepositMoney,WithdrawMoney}
+  alias Commanded.ExampleDomain.BankAccount.Events.{MoneyDeposited, MoneyWithdrawn}
+  alias Commanded.ExampleDomain.BankAccount.Commands.{DepositMoney, WithdrawMoney}
 
-  def interested?(%MoneyTransferRequested{transfer_uuid: transfer_uuid}), do: {:start, transfer_uuid}
+  def interested?(%MoneyTransferRequested{transfer_uuid: transfer_uuid}),
+    do: {:start, transfer_uuid}
+
   def interested?(%MoneyWithdrawn{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
   def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
 
-  def handle(%TransferMoneyProcessManager{}, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, amount: amount}) do
+  def handle(%TransferMoneyProcessManager{}, %MoneyTransferRequested{
+        transfer_uuid: transfer_uuid,
+        debit_account: debit_account,
+        amount: amount
+      }) do
     %WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
-  def handle(%TransferMoneyProcessManager{transfer_uuid: transfer_uuid, credit_account: credit_account, amount: amount}, %MoneyWithdrawn{}) do
+  def handle(
+        %TransferMoneyProcessManager{
+          transfer_uuid: transfer_uuid,
+          credit_account: credit_account,
+          amount: amount
+        },
+        %MoneyWithdrawn{}
+      ) do
     %DepositMoney{account_number: credit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
@@ -33,25 +45,27 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
 
   ## state mutators
 
-  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}) do
-    %TransferMoneyProcessManager{transfer |
-      transfer_uuid: transfer_uuid,
-      debit_account: debit_account,
-      credit_account: credit_account,
-      amount: amount,
-      status: :withdraw_money_from_debit_account
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyTransferRequested{
+        transfer_uuid: transfer_uuid,
+        debit_account: debit_account,
+        credit_account: credit_account,
+        amount: amount
+      }) do
+    %TransferMoneyProcessManager{
+      transfer
+      | transfer_uuid: transfer_uuid,
+        debit_account: debit_account,
+        credit_account: credit_account,
+        amount: amount,
+        status: :withdraw_money_from_debit_account
     }
   end
 
   def apply(%TransferMoneyProcessManager{} = transfer, %MoneyWithdrawn{}) do
-    %TransferMoneyProcessManager{transfer |
-      status: :deposit_money_in_credit_account
-    }
+    %TransferMoneyProcessManager{transfer | status: :deposit_money_in_credit_account}
   end
 
   def apply(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{}) do
-    %TransferMoneyProcessManager{transfer |
-      status: :transfer_complete
-    }
+    %TransferMoneyProcessManager{transfer | status: :transfer_complete}
   end
 end

--- a/test/helpers/commands/commands.ex
+++ b/test/helpers/commands/commands.ex
@@ -3,7 +3,7 @@ defmodule Commanded.Helpers.Commands do
 
   defmodule IncrementCount do
     @moduledoc false
-    defstruct [aggregate_uuid: nil, by: 1]
+    defstruct aggregate_uuid: nil, by: 1
   end
 
   defmodule Fail do
@@ -28,16 +28,16 @@ defmodule Commanded.Helpers.Commands do
 
   defmodule CountIncremented do
     @moduledoc false
+    @derive Jason.Encoder
     defstruct [:count]
   end
 
   defmodule CounterAggregateRoot do
     @moduledoc false
-    defstruct [count: 0]
+    defstruct count: 0
 
     def increment(%CounterAggregateRoot{count: count}, increment_by)
-      when is_integer(increment_by)
-    do
+        when is_integer(increment_by) do
       %CountIncremented{count: count + increment_by}
     end
 
@@ -63,7 +63,7 @@ defmodule Commanded.Helpers.Commands do
     end
 
     def handle(%CounterAggregateRoot{}, %Timeout{}) do
-      :timer.sleep 1_000
+      :timer.sleep(1_000)
       []
     end
 

--- a/test/process_managers/support/error/error_aggregate.ex
+++ b/test/process_managers/support/error/error_aggregate.ex
@@ -1,20 +1,55 @@
 defmodule Commanded.ProcessManagers.ErrorAggregate do
   @moduledoc false
+  @derive Jason.Encoder
   defstruct [:process_uuid]
 
   defmodule Commands do
-    defmodule(StartProcess, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
-    defmodule(RaiseError, do: defstruct([:process_uuid, :message, :reply_to]))
-    defmodule(RaiseException, do: defstruct([:process_uuid, :message, :reply_to]))
-    defmodule(AttemptProcess, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
-    defmodule(ContinueProcess, do: defstruct([:process_uuid, :reply_to]))
+    defmodule StartProcess do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :strategy, :delay, :reply_to])
+    end
+
+    defmodule RaiseError do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :message, :reply_to])
+    end
+
+    defmodule RaiseException do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :message, :reply_to])
+    end
+
+    defmodule AttemptProcess do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :strategy, :delay, :reply_to])
+    end
+
+    defmodule ContinueProcess do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :reply_to])
+    end
   end
 
   defmodule Events do
-    defmodule(ProcessStarted, do: defstruct([:process_uuid, :strategy, :delay, :reply_to]))
-    defmodule(ProcessContinued, do: defstruct([:process_uuid, :reply_to]))
-    defmodule(ProcessError, do: defstruct([:process_uuid, :message, :reply_to]))
-    defmodule(ProcessException, do: defstruct([:process_uuid, :message, :reply_to]))
+    defmodule ProcessStarted do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :strategy, :delay, :reply_to])
+    end
+
+    defmodule ProcessContinued do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :reply_to])
+    end
+
+    defmodule ProcessError do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :message, :reply_to])
+    end
+
+    defmodule ProcessException do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :message, :reply_to])
+    end
   end
 
   alias Commanded.ProcessManagers.ErrorAggregate

--- a/test/process_managers/support/error/error_handling_process_manager.ex
+++ b/test/process_managers/support/error/error_handling_process_manager.ex
@@ -15,6 +15,7 @@ defmodule Commanded.ProcessManagers.ErrorHandlingProcessManager do
     name: "ErrorHandlingProcessManager",
     router: ErrorRouter
 
+  @derive Jason.Encoder
   defstruct [:process_uuid]
 
   def interested?(%ProcessStarted{process_uuid: process_uuid}), do: {:start, process_uuid}

--- a/test/process_managers/support/example_aggregate.ex
+++ b/test/process_managers/support/example_aggregate.ex
@@ -1,7 +1,7 @@
 defmodule Commanded.ProcessManagers.ExampleAggregate do
   @moduledoc false
   alias Commanded.ProcessManagers.ExampleAggregate
-
+  @derive Jason.Encoder
   defstruct uuid: nil,
             state: nil,
             items: []
@@ -16,13 +16,40 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
   end
 
   defmodule Events do
-    defmodule(Started, do: defstruct([:aggregate_uuid]))
-    defmodule(Interested, do: defstruct([:aggregate_uuid, :index]))
-    defmodule(Uninterested, do: defstruct([:aggregate_uuid, :index]))
-    defmodule(Stopped, do: defstruct([:aggregate_uuid]))
-    defmodule(Paused, do: defstruct([:aggregate_uuid]))
-    defmodule(Errored, do: defstruct([:aggregate_uuid]))
-    defmodule(Raised, do: defstruct([:aggregate_uuid]))
+    defmodule Started do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid])
+    end
+
+    defmodule Interested do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid, :index])
+    end
+
+    defmodule Uninterested do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid, :index])
+    end
+
+    defmodule Stopped do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid])
+    end
+
+    defmodule Paused do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid])
+    end
+
+    defmodule Errored do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid])
+    end
+
+    defmodule Raised do
+      @derive Jason.Encoder
+      defstruct([:aggregate_uuid])
+    end
   end
 
   def start(%ExampleAggregate{}, aggregate_uuid) do

--- a/test/process_managers/support/example_process_manager.ex
+++ b/test/process_managers/support/example_process_manager.ex
@@ -17,6 +17,7 @@ defmodule Commanded.ProcessManagers.ExampleProcessManager do
     name: "ExampleProcessManager",
     router: ExampleRouter
 
+  @derive Jason.Encoder
   defstruct [:status, items: []]
 
   def interested?(%Started{aggregate_uuid: aggregate_uuid}), do: {:start, aggregate_uuid}

--- a/test/process_managers/support/multi/todo.ex
+++ b/test/process_managers/support/multi/todo.ex
@@ -1,16 +1,31 @@
 defmodule Commanded.ProcessManagers.Todo do
   @moduledoc false
 
+  @derive Jason.Encoder
   defstruct status: nil
 
   defmodule Commands do
-    defmodule(CreateTodo, do: defstruct([:todo_uuid]))
-    defmodule(MarkDone, do: defstruct([:todo_uuid]))
+    defmodule CreateTodo do
+      @derive Jason.Encoder
+      defstruct([:todo_uuid])
+    end
+
+    defmodule MarkDone do
+      @derive Jason.Encoder
+      defstruct([:todo_uuid])
+    end
   end
 
   defmodule Events do
-    defmodule(TodoCreated, do: defstruct([:todo_uuid]))
-    defmodule(TodoDone, do: defstruct([:todo_uuid]))
+    defmodule TodoCreated do
+      @derive Jason.Encoder
+      defstruct([:todo_uuid])
+    end
+
+    defmodule TodoDone do
+      @derive Jason.Encoder
+      defstruct([:todo_uuid])
+    end
   end
 
   alias Commanded.ProcessManagers.Todo

--- a/test/process_managers/support/multi/todo_list.ex
+++ b/test/process_managers/support/multi/todo_list.ex
@@ -1,16 +1,30 @@
 defmodule Commanded.ProcessManagers.TodoList do
   @moduledoc false
-
+  @derive Jason.Encoder
   defstruct todo_uuids: []
 
   defmodule Commands do
-    defmodule(CreateList, do: defstruct([:list_uuid, :todo_uuids]))
-    defmodule(MarkAllDone, do: defstruct([:list_uuid]))
+    defmodule CreateList do
+      @derive Jason.Encoder
+      defstruct([:list_uuid, :todo_uuids])
+    end
+
+    defmodule MarkAllDone do
+      @derive Jason.Encoder
+      defstruct([:list_uuid])
+    end
   end
 
   defmodule Events do
-    defmodule(TodoListCreated, do: defstruct([:list_uuid, :todo_uuids]))
-    defmodule(ListAllDone, do: defstruct([:list_uuid, :todo_uuids]))
+    defmodule TodoListCreated do
+      @derive Jason.Encoder
+      defstruct([:list_uuid, :todo_uuids])
+    end
+
+    defmodule ListAllDone do
+      @derive Jason.Encoder
+      defstruct([:list_uuid, :todo_uuids])
+    end
   end
 
   alias Commanded.ProcessManagers.TodoList

--- a/test/process_managers/support/multi/todo_process_manager.ex
+++ b/test/process_managers/support/multi/todo_process_manager.ex
@@ -7,6 +7,7 @@ defmodule Commanded.ProcessManagers.TodoProcessManager do
     name: __MODULE__,
     router: TodoRouter
 
+  @derive Jason.Encoder
   defstruct [:todo_uuid]
 
   alias Commanded.ProcessManagers.Todo.Events.TodoCreated

--- a/test/process_managers/support/resume/resume_aggregate.ex
+++ b/test/process_managers/support/resume/resume_aggregate.ex
@@ -9,8 +9,15 @@ defmodule Commanded.ProcessManagers.ResumeAggregate do
   end
 
   defmodule Events do
-    defmodule(ProcessStarted, do: defstruct([:process_uuid, :status]))
-    defmodule(ProcessResumed, do: defstruct([:process_uuid, :status]))
+    defmodule ProcessStarted do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :status])
+    end
+
+    defmodule ProcessResumed do
+      @derive Jason.Encoder
+      defstruct([:process_uuid, :status])
+    end
   end
 
   alias Commanded.ProcessManagers.ResumeAggregate

--- a/test/process_managers/support/resume/resume_process_manager.ex
+++ b/test/process_managers/support/resume/resume_process_manager.ex
@@ -4,6 +4,7 @@ defmodule Commanded.ProcessManagers.ResumeProcessManager do
     name: "resume-process-manager",
     router: ResumeRouter
 
+  @derive Jason.Encoder
   defstruct status_history: []
 
   alias Commanded.ProcessManagers.ResumeAggregate.Events.{ProcessStarted, ProcessResumed}

--- a/test/serialization/json_decoder_test.exs
+++ b/test/serialization/json_decoder_test.exs
@@ -1,10 +1,11 @@
 defmodule Commanded.Serialization.JsonDecoderTest do
-	use ExUnit.Case
-	doctest Commanded.Serialization.JsonDecoder
+  use ExUnit.Case
+  doctest Commanded.Serialization.JsonDecoder
 
-  alias Commanded.Serialization.{JsonSerializer,JsonDecoder}
+  alias Commanded.Serialization.{JsonSerializer, JsonDecoder}
 
   defmodule ExampleEvent do
+    @derive Jason.Encoder
     defstruct [:name, :date]
   end
 
@@ -13,13 +14,11 @@ defmodule Commanded.Serialization.JsonDecoderTest do
     Parse the date included in the event
     """
     def decode(%ExampleEvent{date: date} = event) do
-      %ExampleEvent{event |
-        date: NaiveDateTime.from_iso8601!(date)
-      }
+      %ExampleEvent{event | date: NaiveDateTime.from_iso8601!(date)}
     end
   end
 
-  @serialized_event_json "{\"name\":\"Ben\",\"date\":\"2016-09-20T20:01:02\"}"
+  @serialized_event_json "{\"date\":\"2016-09-20T20:01:02\",\"name\":\"Ben\"}"
 
   test "should serialize value to JSON" do
     event = %ExampleEvent{name: "Ben", date: ~N[2016-09-20 20:01:02]}

--- a/test/serialization/json_serializer_test.exs
+++ b/test/serialization/json_serializer_test.exs
@@ -1,12 +1,12 @@
 defmodule Commanded.Serialization.JsonSerializerTest do
-	use ExUnit.Case
+  use ExUnit.Case
 
   alias Commanded.Serialization.JsonSerializer
   alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
 
-  @serialized_event_json "{\"initial_balance\":1000,\"account_number\":\"ACC123\"}"
+  @serialized_event_json "{\"account_number\":\"ACC123\",\"initial_balance\":1000}"
 
-	test "should serialize event to JSON" do
+  test "should serialize event to JSON" do
     account_opened = %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}
 
     assert JsonSerializer.serialize(account_opened) == @serialized_event_json
@@ -19,11 +19,18 @@ defmodule Commanded.Serialization.JsonSerializerTest do
     assert JsonSerializer.deserialize(@serialized_event_json, type: type) == account_opened
   end
 
-  defmodule NamedEvent, do: defstruct [data: nil]
-  defmodule AnotherNamedEvent, do: defstruct [data: nil]
+  defmodule(NamedEvent, do: defstruct(data: nil))
+  defmodule(AnotherNamedEvent, do: defstruct(data: nil))
 
   test "should deserialize to event type which is specifying the module name" do
-    assert %NamedEvent{data: "data"} == JsonSerializer.deserialize("{\"data\": \"data\"}", type: "Elixir.Commanded.Serialization.JsonSerializerTest.NamedEvent")
-    assert %AnotherNamedEvent{data: "data"} == JsonSerializer.deserialize("{\"data\": \"data\"}", type: "Elixir.Commanded.Serialization.JsonSerializerTest.AnotherNamedEvent")
+    assert %NamedEvent{data: "data"} ==
+             JsonSerializer.deserialize("{\"data\": \"data\"}",
+               type: "Elixir.Commanded.Serialization.JsonSerializerTest.NamedEvent"
+             )
+
+    assert %AnotherNamedEvent{data: "data"} ==
+             JsonSerializer.deserialize("{\"data\": \"data\"}",
+               type: "Elixir.Commanded.Serialization.JsonSerializerTest.AnotherNamedEvent"
+             )
   end
 end


### PR DESCRIPTION
Hi,
This is still work in progress but wanted to share to get some feedback.
As you know Ecto moved away to Jason in v3, which breaks Commanded.
This PR is an effort to align Commanded with Ecto by moving it to Jason as well.
I've made a couple assumptions in this PR which i'm happy to discuss:
- It's a breaking change. Since Jason requires explicit ```@derive Jason.Encoder``` vs the implicit behavior in Poison.. If you think this is too harsh of a change, i think we can, with more work, do something to have a better upgrade experience. E.g have a Commanded.JsonEncoder which will define the encoding behaviour depending if Jason or Poison is loaded and basically delegate to the appropriate ```@derive```. But this is quite a lot of work and i'm not sure its worth the effort - What do you think?
- Aside from that the only change is in how Jason handles NaiveDateTime, seems like Poison automatically decodes it to DateTime when Jason keeps it as string for manual decoding. Not sure how to overcome this or whats the best approach - Suggestions are welcome(1 test is failing due to this)

I've updated the documentation but i think more needs to be written in regard to this change.

Help appreciated.
Thank you for the awesome lib!