### PR TITLE
Handle the {:ok, _} tuple dispatch result.

### DIFF
--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -273,6 +273,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
       :ok ->
         dispatch_commands(pending_commands, opts, state, last_event)
 
+      # when include_execution_result is set to true, the dispatcher returns an :ok tuple
+      {:ok, _} ->
+        dispatch_commands(pending_commands, opts, state, last_event)
+
       error ->
         Logger.warn(fn ->
           describe(state) <>


### PR DESCRIPTION
This addresses #235 