### PR TITLE
Fixed warning about deprecated time unit in elixir 1.8

### DIFF
--- a/lib/commanded/subscriptions.ex
+++ b/lib/commanded/subscriptions.ex
@@ -285,7 +285,7 @@ defmodule Commanded.Subscriptions do
 
   defp parse_exclude(exclude), do: exclude |> List.wrap() |> MapSet.new()
 
-  defp monotonic_time, do: System.monotonic_time(:seconds)
+  defp monotonic_time, do: System.monotonic_time(:second)
 
   @default_ttl :timer.hours(1)
   @default_consistency_timeout :timer.seconds(5)


### PR DESCRIPTION
fixes "warning: deprecated time unit: :seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer"