### PR TITLE
Strict process manager routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Enhancements
 
-- Do not start new process manager instance on `:continue` ([#181](https://github.com/commanded/commanded/pull/181)).
 - Rename `uuid` dependency to `elixir_uuid` ([#178](https://github.com/commanded/commanded/pull/178)).
 - Allow aggregate identity to be of any type that implements the `String.Chars` protocol ([#166](https://github.com/commanded/commanded/pull/166)).
 - Process manager and event handler error & exception handling ([#192](https://github.com/commanded/commanded/pull/192)).
@@ -14,7 +13,6 @@
 - Export `Commanded.Commands.Router` macros in `.formatter.exs` file ([#204](https://github.com/commanded/commanded/pull/204)).
 - Generate specs and docs for Router dispatch functions only once ([#206](https://github.com/commanded/commanded/pull/206)).
 - Allow two-arity predicate function in `wait_for_event` receiving both event data and recorded event struct ([#213](https://github.com/commanded/commanded/pull/213)).
-- Make poison an optional dependency ([#215](https://github.com/commanded/commanded/pull/215)).
 - Allow `:infinity` timeout on command dispatch ([#227](https://github.com/commanded/commanded/pull/227))
 - Strict process manager routing ([#243](https://github.com/commanded/commanded/pull/243)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Allow two-arity predicate function in `wait_for_event` receiving both event data and recorded event struct ([#213](https://github.com/commanded/commanded/pull/213)).
 - Make poison an optional dependency ([#215](https://github.com/commanded/commanded/pull/215)).
 - Allow `:infinity` timeout on command dispatch ([#227](https://github.com/commanded/commanded/pull/227))
+- Strict process manager routing ([#243](https://github.com/commanded/commanded/pull/243)).
 
 ### Bug fixes
 

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -139,6 +139,10 @@ defmodule Commanded.Commands.Router do
       :ok = BankRouter.dispatch(command, metadata: %{"ip_address" => "127.0.0.1"})
 
   """
+
+  @callback dispatch(struct, keyword()) ::
+              :ok | {:ok, non_neg_integer()} | {:ok, struct} | {:error, term}
+
   defmacro __using__(_opts) do
     quote do
       require Logger

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -535,7 +535,7 @@ defmodule Commanded.Event.Handler do
 
       invalid ->
         Logger.warn(fn ->
-          describe(state) <> " returned an invalid error reponse: #{inspect(invalid)}"
+          describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 
         # Stop event handler with original error

--- a/lib/commanded/process_managers/failure_context.ex
+++ b/lib/commanded/process_managers/failure_context.ex
@@ -13,16 +13,16 @@ defmodule Commanded.ProcessManagers.FailureContext do
   """
 
   @type t :: %__MODULE__{
-    pending_commands: [struct()],
-    process_manager_state: struct(),
-    last_event: struct(),
-    context: map()
-  }
+          pending_commands: [struct()],
+          process_manager_state: struct(),
+          last_event: struct(),
+          context: map()
+        }
 
   defstruct [
-    pending_commands: nil,
-    process_manager_state: nil,
-    last_event: nil,
-    context: nil
+    :process_manager_state,
+    :last_event,
+    context: %{},
+    pending_commands: []
   ]
 end

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -132,17 +132,38 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   instance or start a new process instance:
 
   - `{:start, process_uuid}` - create a new instance of the process manager.
+  - `{:start!, process_uuid}` - create a new instance of the process manager (strict).
   - `{:continue, process_uuid}` - continue execution of an existing process manager.
+  - `{:continue!, process_uuid}` - continue execution of an existing process manager (strict).
   - `{:stop, process_uuid}` - stop an existing process manager, shutdown its
     process, and delete its persisted state.
   - `false` - ignore the event.
 
-  You can return a list of process identifiers when a single domain event must
+  You can return a list of process identifiers when a single domain event is to
   be handled by multiple process instances.
+
+  ## Strict process routing
+
+  Using strict routing, with `:start!` or `:continue`, enforces the following
+  validation checks:
+
+  - `{:start!, process_uuid}` - validate process does not already exist.
+  - `{:continue!, process_uuid}` - validate process already exists.
+
+  If the check fails an error will be passed to the `error/3` callback function:
+
+  - `{:error, {:start!, :process_already_started}}`
+  - `{:error, {:continue!, :process_not_started}}`
+
+  The `error/3` function can choose to `:stop` the process or `:skip` the
+  problematic event.
+
   """
   @callback interested?(domain_event) ::
               {:start, process_uuid}
+              | {:start!, process_uuid}
               | {:continue, process_uuid}
+              | {:continue!, process_uuid}
               | {:stop, process_uuid}
               | false
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -245,7 +245,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       invalid ->
         Logger.warn(fn ->
-          describe(state) <> " returned an invalid error reponse: #{inspect(invalid)}"
+          describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 
         # Stop process manager with original error

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -78,7 +78,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   def handle_call(:stop, _from, %ProcessManagerInstance{} = state) do
     :ok = delete_state(state)
 
-    # stop the process with a normal reason
+    # Stop the process with a normal reason
     {:stop, :normal, :ok, state}
   end
 
@@ -126,11 +126,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     end
   end
 
-  defp event_already_seen?(
-         %RecordedEvent{event_number: event_number},
-         %ProcessManagerInstance{last_seen_event: last_seen_event}
-       ) do
-    not is_nil(last_seen_event) and event_number <= last_seen_event
+  defp event_already_seen?(%RecordedEvent{}, %ProcessManagerInstance{last_seen_event: nil}),
+    do: false
+
+  defp event_already_seen?(%RecordedEvent{} = event, %ProcessManagerInstance{} = state) do
+    %RecordedEvent{event_number: event_number} = event
+    %ProcessManagerInstance{last_seen_event: last_seen_event} = state
+
+    event_number <= last_seen_event
   end
 
   # Already seen event, so just ack
@@ -196,8 +199,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     try do
       process_manager_module.handle(process_state, data)
     rescue
-      e ->
-        {:error, e}
+      e -> {:error, e}
     end
   end
 

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -346,6 +346,8 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
 
           ack_and_continue(event, state)
       end
+    rescue
+      e -> handle_routing_error({:error, e}, event, state)
     catch
       reply -> reply
     end

--- a/test/helpers/event_factory.ex
+++ b/test/helpers/event_factory.ex
@@ -2,7 +2,7 @@ defmodule Commanded.Helpers.EventFactory do
   @moduledoc false
   alias Commanded.EventStore.RecordedEvent
 
-  def map_to_recorded_events(events) do
+  def map_to_recorded_events(events, initial_event_number \\ 1) do
     stream_id = UUID.uuid4()
     causation_id = UUID.uuid4()
     correlation_id = UUID.uuid4()
@@ -10,7 +10,7 @@ defmodule Commanded.Helpers.EventFactory do
 
     events
     |> Commanded.Event.Mapper.map_to_event_data(fields)
-    |> Enum.with_index(1)
+    |> Enum.with_index(initial_event_number)
     |> Enum.map(fn {event, index} ->
       %RecordedEvent{
         event_id: UUID.uuid4(),

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -42,7 +42,8 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
   end
 
   test "should provide `__name__/0` function" do
-    assert TransferMoneyProcessManager.__name__() == "transfer_money_process_manager"
+    assert TransferMoneyProcessManager.__name__() ==
+             "Commanded.ExampleDomain.TransferMoneyProcessManager"
   end
 
   test "should ensure a process manager name is provided" do

--- a/test/process_managers/process_manager_integration_test.exs
+++ b/test/process_managers/process_manager_integration_test.exs
@@ -1,0 +1,63 @@
+defmodule Commanded.ProcessManagers.ProcessManagerIntegrationTest do
+  use Commanded.StorageCase
+
+  import Commanded.Assertions.EventAssertions
+
+  alias Commanded.ExampleDomain.BankRouter
+  alias Commanded.ExampleDomain.TransferMoneyProcessManager
+  alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited
+  alias Commanded.ExampleDomain.BankAccount.Events.MoneyWithdrawn
+  alias Commanded.ExampleDomain.MoneyTransfer.Commands.TransferMoney
+  alias Commanded.ExampleDomain.MoneyTransfer.Events.MoneyTransferRequested
+  alias Commanded.Helpers.CommandAuditMiddleware
+  alias Commanded.ProcessManagers.ProcessRouter
+
+  setup do
+    CommandAuditMiddleware.start_link()
+    :ok
+  end
+
+  test "should start a process manager in response to an event" do
+    account_number1 = UUID.uuid4()
+    account_number2 = UUID.uuid4()
+    transfer_uuid = UUID.uuid4()
+
+    {:ok, process_router} = TransferMoneyProcessManager.start_link()
+
+    # Create two bank accounts
+    :ok =
+      BankRouter.dispatch(%OpenAccount{account_number: account_number1, initial_balance: 1_000})
+
+    :ok = BankRouter.dispatch(%OpenAccount{account_number: account_number2, initial_balance: 500})
+
+    # Transfer funds between account 1 and account 2
+    :ok =
+      BankRouter.dispatch(%TransferMoney{
+        transfer_uuid: transfer_uuid,
+        debit_account: account_number1,
+        credit_account: account_number2,
+        amount: 100
+      })
+
+    assert_receive_event(MoneyTransferRequested, fn event ->
+      assert event.debit_account == account_number1
+      assert event.credit_account == account_number2
+      assert event.amount == 100
+    end)
+
+    assert_receive_event(MoneyWithdrawn, fn event ->
+      assert event.account_number == account_number1
+      assert event.amount == 100
+      assert event.balance == 900
+    end)
+
+    assert_receive_event(MoneyDeposited, fn event ->
+      assert event.account_number == account_number2
+      assert event.amount == 100
+      assert event.balance == 600
+    end)
+
+    assert [{^transfer_uuid, _}] = ProcessRouter.process_instances(process_router)
+  end
+end

--- a/test/process_managers/support/routing/routing_process_manager.ex
+++ b/test/process_managers/support/routing/routing_process_manager.ex
@@ -1,0 +1,85 @@
+defmodule Commanded.ProcessManagers.RoutingProcessManager do
+  use Commanded.ProcessManagers.ProcessManager,
+    name: __MODULE__,
+    router: Commanded.Commands.MockRouter
+
+  defmodule Started do
+    @enforce_keys [:process_uuid]
+    defstruct [:process_uuid, :reply_to, strict?: false]
+  end
+
+  defmodule Continued do
+    @enforce_keys [:process_uuid]
+    defstruct [:process_uuid, :reply_to, strict?: false]
+  end
+
+  defmodule Stopped do
+    @enforce_keys [:process_uuid]
+    defstruct [:process_uuid]
+  end
+
+  defmodule Errored do
+    @enforce_keys [:process_uuid]
+    defstruct [:process_uuid, :reply_to, :on_error]
+  end
+
+  alias Commanded.ProcessManagers.FailureContext
+  alias Commanded.ProcessManagers.RoutingProcessManager
+
+  defstruct [:processes]
+
+  def interested?(%Started{process_uuid: process_uuid, strict?: true}),
+    do: {:start!, process_uuid}
+
+  def interested?(%Started{process_uuid: process_uuid}),
+    do: {:start, process_uuid}
+
+  def interested?(%Continued{process_uuid: process_uuid, strict?: true}),
+    do: {:continue!, process_uuid}
+
+  def interested?(%Continued{process_uuid: process_uuid}), do: {:continue, process_uuid}
+
+  def interested?(%Stopped{process_uuid: process_uuid}), do: {:stop, process_uuid}
+
+  def interested?(%Errored{}), do: raise("error")
+
+  def handle(%RoutingProcessManager{}, %Started{} = event) do
+    %Started{reply_to: reply_to} = event
+
+    send(reply_to, {:started, self()})
+
+    []
+  end
+
+  def handle(%RoutingProcessManager{}, %Continued{} = event) do
+    %Continued{reply_to: reply_to} = event
+
+    send(reply_to, {:continued, self()})
+
+    []
+  end
+
+  def error({:error, error}, %Started{} = event, %FailureContext{}) do
+    %Started{reply_to: reply_to} = event
+
+    send(reply_to, {:error, error})
+
+    {:stop, error}
+  end
+
+  def error({:error, error}, %Continued{} = event, %FailureContext{}) do
+    %Continued{reply_to: reply_to} = event
+
+    send(reply_to, {:error, error})
+
+    {:stop, error}
+  end
+
+  def error({:error, error}, %Errored{} = event, %FailureContext{}) do
+    %Errored{reply_to: reply_to, on_error: on_error} = event
+
+    send(reply_to, {:error, error})
+
+    on_error
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,1 +1,2 @@
 Mox.defmock(Commanded.EventStore.Adapters.Mock, for: Commanded.EventStore)
+Mox.defmock(Commanded.Commands.MockRouter, for: Commanded.Commands.Router)


### PR DESCRIPTION
Add `:start!` and `:continue!` for strict process routing replies to process manager `interested?/1` callback.

Strict routing enforces the following validation checks:

- `{:start!, process_uuid}` - validate process does not already exist.
- `{:continue!, process_uuid}` - validate process already exists.

If the check fails an error will be passed to the `error/3` callback function:

- `{:error, {:start!, :process_already_started}}`
- `{:error, {:continue!, :process_not_started}}`

The `error/3` function can choose to `:stop` the process or `:skip` the  problematic event.

Fixes #212.