### PR TITLE
Allow `Commanded.Aggregate.Multi` to be nested

### DIFF
--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -46,58 +46,88 @@ defmodule Commanded.Aggregate.Multi do
         end
         defp check_balance(%BankAccount{}), do: []
       end
+
   """
 
   alias Commanded.Aggregate.Multi
 
   @type t :: %__MODULE__{
-    aggregate: struct(),
-    executions: list(function()),
-  }
+          aggregate: struct(),
+          executions: list(function())
+        }
 
-  defstruct [
-    aggregate: nil,
-    executions: [],
-  ]
+  defstruct [:aggregate, executions: []]
 
   @doc """
   Create a new `Commanded.Aggregate.Multi` struct.
   """
-  @spec new(aggregate :: struct()) :: Multi.t
+  @spec new(aggregate :: struct()) :: Multi.t()
   def new(aggregate), do: %Multi{aggregate: aggregate}
 
   @doc """
   Adds a command execute function to the multi.
   """
-  @spec execute(Multi.t, function()) :: Multi.t
-  def execute(%Multi{executions: executions} = multi, execute_fun)
-    when is_function(execute_fun)
-  do
-    %Multi{multi |
-      executions: [execute_fun | executions],
-    }
+  @spec execute(Multi.t(), function()) :: Multi.t()
+  def execute(%Multi{} = multi, execute_fun) when is_function(execute_fun, 1) do
+    %Multi{executions: executions} = multi
+
+    %Multi{multi | executions: [execute_fun | executions]}
+  end
+
+  @doc """
+  Reduce an enumerable by executing the function for each item.
+
+  The aggregate `apply/2` function will be called after each event returned by
+  the execute function. This allows you to calculate values from the aggregate
+  state based upon events produced by previous items in the enumerable, such as
+  running totals.
+
+  ## Example
+
+      alias Commanded.Aggregate.Multi
+
+      aggregate
+      |> Multi.new()
+      |> Multi.reduce([1, 2, 3], fn aggregate, item ->
+        %AnEvent{item: item, total: aggregate.total + item}
+      end)
+
+  """
+  @spec reduce(Multi.t(), Enum.t(), function()) :: Multi.t()
+  def reduce(%Multi{} = multi, enumerable, execute_fun) when is_function(execute_fun, 2) do
+    execute(multi, fn aggregate ->
+      Enum.reduce(enumerable, Multi.new(aggregate), fn item, %Multi{} = multi ->
+        execute(multi, &execute_fun.(&1, item))
+      end)
+    end)
   end
 
   @doc """
   Run the execute functions contained within the multi, returning the updated
-  aggregate state and any created events.
+  aggregate state and all created events.
   """
-  @spec run(Multi.t) :: {aggregate :: struct(), list(event :: struct())} | {:error, reason :: any()}
+  @spec run(Multi.t()) ::
+          {aggregate :: struct(), list(event :: struct())} | {:error, reason :: any()}
   def run(%Multi{aggregate: aggregate, executions: executions}) do
     try do
       executions
       |> Enum.reverse()
-      |> Enum.reduce({aggregate, []}, fn (execute_fun, {aggregate, events}) ->
-        pending_events =
-          case execute_fun.(aggregate) do
-            {:error, _reason} = error -> throw(error)
-            pending_events -> List.wrap(pending_events)
-          end
+      |> Enum.reduce({aggregate, []}, fn execute_fun, {aggregate, events} ->
+        case execute_fun.(aggregate) do
+          {:error, _reason} = error ->
+            throw(error)
 
-        {apply_events(aggregate, pending_events), events ++ pending_events}
+          %Multi{} = multi ->
+            Multi.run(multi)
+
+          pending_events ->
+            pending_events = List.wrap(pending_events)
+
+            {apply_events(aggregate, pending_events), events ++ pending_events}
+        end
       end)
     catch
-      {:error, _reason} = error -> error
+      {:error, _error} = error -> error
     end
   end
 

--- a/test/aggregates/multi_test.exs
+++ b/test/aggregates/multi_test.exs
@@ -6,42 +6,62 @@ defmodule Commanded.Aggregate.MultiTest do
   alias Commanded.EventStore
   alias Commanded.Aggregate.Multi
   alias Commanded.Aggregate.Multi.BankAccount
-  alias Commanded.Aggregate.Multi.BankAccount.Commands.{OpenAccount,WithdrawMoney}
-  alias Commanded.Aggregate.Multi.BankAccount.Events.{BankAccountOpened,MoneyWithdrawn}
+  alias Commanded.Aggregate.Multi.BankAccount.Commands.{OpenAccount, WithdrawMoney}
+  alias Commanded.Aggregate.Multi.BankAccount.Events.{BankAccountOpened, MoneyWithdrawn}
 
   defmodule MultiBankRouter do
     use Commanded.Commands.Router
 
     alias Commanded.Aggregate.Multi.BankAccount
-    alias Commanded.Aggregate.Multi.BankAccount.Commands.{OpenAccount,WithdrawMoney}
+    alias Commanded.Aggregate.Multi.BankAccount.Commands.{OpenAccount, WithdrawMoney}
 
-    dispatch [OpenAccount,WithdrawMoney],
-      to: BankAccount, identity: :account_number
+    dispatch [OpenAccount, WithdrawMoney], to: BankAccount, identity: :account_number
   end
 
   test "should return `Commanded.Aggregate.Multi` from command" do
     account_number = UUID.uuid4()
-    account = BankAccount.apply(%BankAccount{}, %BankAccountOpened{account_number: account_number, balance: 1_000})
 
-    assert %Multi{} = multi = BankAccount.execute(account, %WithdrawMoney{account_number: account_number, amount: 100})
+    account =
+      BankAccount.apply(%BankAccount{}, %BankAccountOpened{
+        account_number: account_number,
+        balance: 1_000
+      })
+
+    assert %Multi{} =
+             multi =
+             BankAccount.execute(account, %WithdrawMoney{
+               account_number: account_number,
+               amount: 100
+             })
 
     assert {account, events} = Multi.run(multi)
 
     assert account == %BankAccount{
-      account_number: account_number,
-      balance: 900,
-      state: :active,
-    }
+             account_number: account_number,
+             balance: 900,
+             status: :active
+           }
+
     assert events == [
-      %MoneyWithdrawn{account_number: account_number, amount: 100, balance: 900},
-    ]
+             %MoneyWithdrawn{account_number: account_number, amount: 100, balance: 900}
+           ]
   end
 
   test "should return errors encountered by `Commanded.Aggregate.Multi`" do
     account_number = UUID.uuid4()
-    account = BankAccount.apply(%BankAccount{}, %BankAccountOpened{account_number: account_number, balance: 1_000})
 
-    assert %Multi{} = multi = BankAccount.execute(account, %WithdrawMoney{account_number: account_number, amount: 1_100})
+    account =
+      BankAccount.apply(%BankAccount{}, %BankAccountOpened{
+        account_number: account_number,
+        balance: 1_000
+      })
+
+    assert %Multi{} =
+             multi =
+             BankAccount.execute(account, %WithdrawMoney{
+               account_number: account_number,
+               amount: 1_100
+             })
 
     assert {:error, :insufficient_funds_available} = Multi.run(multi)
   end
@@ -49,27 +69,102 @@ defmodule Commanded.Aggregate.MultiTest do
   test "should execute command using `Commanded.Aggregate.Multi` and return events" do
     account_number = UUID.uuid4()
 
-    assert :ok = MultiBankRouter.dispatch(%OpenAccount{account_number: account_number, initial_balance: 1_000})
-    assert :ok = MultiBankRouter.dispatch(%WithdrawMoney{account_number: account_number, amount: 250})
+    assert :ok =
+             MultiBankRouter.dispatch(%OpenAccount{
+               account_number: account_number,
+               initial_balance: 1_000
+             })
+
+    assert :ok =
+             MultiBankRouter.dispatch(%WithdrawMoney{account_number: account_number, amount: 250})
 
     recorded_events = EventStore.stream_forward(account_number, 0) |> Enum.to_list()
 
     assert pluck(recorded_events, :data) == [
-      %BankAccountOpened{account_number: account_number, balance: 1_000},
-      %MoneyWithdrawn{account_number: account_number, amount: 250, balance: 750},
-    ]
+             %BankAccountOpened{account_number: account_number, balance: 1_000},
+             %MoneyWithdrawn{account_number: account_number, amount: 250, balance: 750}
+           ]
   end
 
   test "should execute command using `Commanded.Aggregate.Multi` and return any error" do
     account_number = UUID.uuid4()
 
-    assert :ok = MultiBankRouter.dispatch(%OpenAccount{account_number: account_number, initial_balance: 1_000})
-    assert {:error, :insufficient_funds_available} = MultiBankRouter.dispatch(%WithdrawMoney{account_number: account_number, amount: 1_100})
+    assert :ok =
+             MultiBankRouter.dispatch(%OpenAccount{
+               account_number: account_number,
+               initial_balance: 1_000
+             })
+
+    assert {:error, :insufficient_funds_available} =
+             MultiBankRouter.dispatch(%WithdrawMoney{
+               account_number: account_number,
+               amount: 1_100
+             })
 
     recorded_events = EventStore.stream_forward(account_number, 0) |> Enum.to_list()
 
     assert pluck(recorded_events, :data) == [
-      %BankAccountOpened{account_number: account_number, balance: 1_000},
-    ]
+             %BankAccountOpened{account_number: account_number, balance: 1_000}
+           ]
+  end
+
+  describe "nested `Commanded.Aggregate.Multi`" do
+    defmodule ExampleAggregate do
+      defstruct events: []
+
+      defmodule Event do
+        defstruct [:data]
+      end
+
+      def apply(%ExampleAggregate{} = aggregate, event) do
+        %ExampleAggregate{events: events} = aggregate
+
+        %ExampleAggregate{aggregate | events: events ++ [event]}
+      end
+    end
+
+    alias ExampleAggregate.Event
+
+    test "should be supported" do
+      {%ExampleAggregate{}, events} =
+        %ExampleAggregate{}
+        |> Multi.new()
+        |> Multi.execute(fn %ExampleAggregate{} = aggregate ->
+          aggregate
+          |> Multi.new()
+          |> Multi.execute(fn %ExampleAggregate{events: events} ->
+            assert length(events) == 0
+
+            %Event{data: 1}
+          end)
+        end)
+        |> Multi.execute(fn %ExampleAggregate{events: events} ->
+          assert length(events) == 1
+
+          %Event{data: 2}
+        end)
+        |> Multi.execute(fn %ExampleAggregate{events: events} ->
+          assert length(events) == 2
+
+          []
+        end)
+        |> Multi.run()
+
+      assert events == [%Event{data: 1}, %Event{data: 2}]
+    end
+
+    test "should reduce enum" do
+      {%ExampleAggregate{}, events} =
+        %ExampleAggregate{}
+        |> Multi.new()
+        |> Multi.reduce([1, 2, 3], fn %ExampleAggregate{events: events}, index ->
+          assert length(events) == index - 1
+
+          %Event{data: index}
+        end)
+        |> Multi.run()
+
+      assert events == [%Event{data: 1}, %Event{data: 2}, %Event{data: 3}]
+    end
   end
 end


### PR DESCRIPTION
Allow the `Commanded.Aggregate.Multi.execute/2` to return an `Commanded.Aggregate.Multi` struct to support nesting, as shown in the example below:

```elixir
alias Commanded.Aggregate.Multi

aggregate
|> Multi.new()
|> Multi.execute(fn aggregate ->
  aggregate
  |> Multi.new()
  |> Multi.execute(fn aggregate ->
    %AnEvent{...}
  end)
end)
```

Add `Commanded.Aggregate.Multi.reduce/3` to reduce an enumerable by executing a given function for each item.

Fixes #242.