### PR TITLE
Add `delete_subscription/2` to `Commanded.EventStore` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Allow `:infinity` timeout on command dispatch ([#227](https://github.com/commanded/commanded/pull/227))
 - Strict process manager routing ([#243](https://github.com/commanded/commanded/pull/243)).
 - Allow `Commanded.Aggregate.Multi` to be nested ([#244](https://github.com/commanded/commanded/pull/244)).
+- Add `delete_subscription/2` to `Commanded.EventStore` behaviour ([#245](https://github.com/commanded/commanded/pull/245)).
 
 ### Bug fixes
 

--- a/lib/commanded/event_store/event_store.ex
+++ b/lib/commanded/event_store/event_store.ex
@@ -100,8 +100,26 @@ defmodule Commanded.EventStore do
 
   @doc """
   Unsubscribe an existing subscriber from event notifications.
+
+  This will not delete the subscription.
+
+  ## Example
+
+      :ok = Commanded.EventStore.unsubscribe(subscription)
+
   """
   @callback unsubscribe(subscription) :: :ok
+
+  @doc """
+  Delete an existing subscription.
+
+  ## Example
+
+      :ok = Commanded.EventStore.delete_subscription(:all, "Example")
+
+  """
+  @callback delete_subscription(stream_uuid | :all, subscription_name) ::
+              :ok | {:error, :subscription_not_found} | {:error, error}
 
   @doc """
   Read a snapshot, if available, for a given source.
@@ -190,6 +208,15 @@ defmodule Commanded.EventStore do
   @spec unsubscribe(subscription) :: :ok
   def unsubscribe(subscription) do
     event_store_adapter().unsubscribe(subscription)
+  end
+
+  @doc """
+  Delete an existing subscription.
+  """
+  @spec delete_subscription(stream_uuid | :all, subscription_name) ::
+          :ok | {:error, :subscription_not_found} | {:error, error}
+  def delete_subscription(stream_uuid, subscription_name) do
+    event_store_adapter().delete_subscription(stream_uuid, subscription_name)
   end
 
   @doc """


### PR DESCRIPTION
Unsubscribing an event store subscription should not delete the subscription. This pull request adds `Commanded.EventStore.delete_subscription/2` to allow an existing subscription to be completely removed.

### Example usage

Create a subscription to all events: 

```elixir
{:ok, subscription} = Commanded.EventStore.subscribe_to(:all, "Example", self())
```

Unsubscribe the subscription to stop receiving events, but still remember the subscription's last acknowledged event pointer:

```elixir
:ok = Commanded.EventStore.unsubscribe(subscription)
```

Finally, delete the subscription:

```elixir
:ok = Commanded.EventStore.delete_subscription(:all, "Example")
```