### PR TITLE
Update typespec for EventData.

### DIFF
--- a/lib/commanded/event_store/event_data.ex
+++ b/lib/commanded/event_store/event_data.ex
@@ -10,8 +10,8 @@ defmodule Commanded.EventStore.EventData do
           causation_id: uuid(),
           correlation_id: uuid(),
           event_type: String.t(),
-          data: binary(),
-          metadata: binary()
+          data: struct(),
+          metadata: map()
         }
 
   defstruct [


### PR DESCRIPTION
`data` should be a struct, not a binary.
`metadata` should be a map, not a binary.