### PR TITLE
add .formatter.exs to hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -98,6 +98,7 @@ defmodule Commanded.Mixfile do
       files: [
         "lib",
         "mix.exs",
+        ".formatter.exs",
         "README*",
         "LICENSE*",
         "CHANGELOG*",


### PR DESCRIPTION
it's required for dependent projects to import `locals_without_parens`