### PR TITLE
Replace simple one for one

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -38,7 +38,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
   """
 
-  use GenServer
+  use GenServer, restart: :temporary
   use Commanded.Registration
 
   require Logger
@@ -60,7 +60,7 @@ defmodule Commanded.Aggregates.Aggregate do
     lifespan_timeout: :infinity
   ]
 
-  def start_link(aggregate_module, aggregate_uuid, opts \\ [])
+  def start_link([aggregate_module, aggregate_uuid, opts])
       when is_atom(aggregate_module) and is_binary(aggregate_uuid) do
     aggregate = %Aggregate{
       aggregate_module: aggregate_module,

--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -14,6 +14,11 @@ defmodule Commanded.Aggregates.Supervisor do
     DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
+  # args == Aggregate.start_link/1 arguments
+  def start_child(args) do
+    DynamicSupervisor.start_child(__MODULE__, {Commanded.Aggregates.Aggregate, args})
+  end
+
   @doc """
   Open an aggregate instance process for the given aggregate module and unique
   indentity.

--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Commanded.Aggregates.Supervisor do
   Supervises `Commanded.Aggregates.Aggregate` instance processes.
   """
 
-  use Supervisor
+  use DynamicSupervisor
 
   require Logger
 
@@ -11,7 +11,7 @@ defmodule Commanded.Aggregates.Supervisor do
   alias Commanded.Registration
 
   def start_link(arg) do
-    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   @doc """
@@ -48,10 +48,6 @@ defmodule Commanded.Aggregates.Supervisor do
     do: {:error, {:unsupported_aggregate_identity_type, aggregate_uuid}}
 
   def init(_) do
-    children = [
-      worker(Commanded.Aggregates.Aggregate, [], restart: :temporary)
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/lib/commanded/registration/local_registry.ex
+++ b/lib/commanded/registration/local_registry.ex
@@ -28,8 +28,9 @@ defmodule Commanded.Registration.LocalRegistry do
   @impl Commanded.Registration
   def start_child(name, supervisor, args) do
     via_name = {:via, Registry, {__MODULE__, name}}
+    aggregate_child_spec = {Commanded.Aggregates.Aggregate, args ++ [[name: via_name]]}
 
-    case Supervisor.start_child(supervisor, args ++ [[name: via_name]]) do
+    case DynamicSupervisor.start_child(supervisor, aggregate_child_spec) do
       {:error, {:already_started, pid}} -> {:ok, pid}
       reply -> reply
     end

--- a/lib/commanded/registration/local_registry.ex
+++ b/lib/commanded/registration/local_registry.ex
@@ -28,9 +28,8 @@ defmodule Commanded.Registration.LocalRegistry do
   @impl Commanded.Registration
   def start_child(name, supervisor, args) do
     via_name = {:via, Registry, {__MODULE__, name}}
-    aggregate_child_spec = {Commanded.Aggregates.Aggregate, args ++ [[name: via_name]]}
 
-    case DynamicSupervisor.start_child(supervisor, aggregate_child_spec) do
+    case supervisor.start_child(args ++ [[name: via_name]]) do
       {:error, {:already_started, pid}} -> {:ok, pid}
       reply -> reply
     end

--- a/test/registration/support/registered_server.ex
+++ b/test/registration/support/registered_server.ex
@@ -1,8 +1,8 @@
 defmodule Commanded.Registration.RegisteredServer do
-  use GenServer
+  use GenServer, restart: :temporary
   use Commanded.Registration
 
-  def start_link(name, opts \\ []) do
+  def start_link([name, opts]) do
     GenServer.start_link(__MODULE__, name, opts)
   end
 

--- a/test/registration/support/registered_supervisor.ex
+++ b/test/registration/support/registered_supervisor.ex
@@ -1,22 +1,22 @@
 defmodule Commanded.Registration.RegisteredSupervisor do
-  use Supervisor
+  use DynamicSupervisor
 
   alias Commanded.Registration
   alias Commanded.Registration.RegisteredServer
 
   def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  def start_child(name) do
+  def start_child(args) do
+    DynamicSupervisor.start_child(__MODULE__, {Commanded.Registration.RegisteredServer, args})
+  end
+
+  def start_registered_child(name) do
     Registration.start_child(name, __MODULE__, [name])
   end
 
-  def init(:ok) do
-    children = [
-      worker(RegisteredServer, [], restart: :temporary)
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/test/registration/support/registration_test_case.ex
+++ b/test/registration/support/registration_test_case.ex
@@ -19,12 +19,12 @@ defmodule Commanded.RegistrationTestCase do
 
     describe "`start_child/3`" do
       test "should return child process PID on success" do
-        assert {:ok, _pid} = RegisteredSupervisor.start_child("child")
+        assert {:ok, _pid} = RegisteredSupervisor.start_registered_child("child")
       end
 
       test "should return existing child process when already started" do
-        assert {:ok, pid} = RegisteredSupervisor.start_child("child")
-        assert {:ok, ^pid} = RegisteredSupervisor.start_child("child")
+        assert {:ok, pid} = RegisteredSupervisor.start_registered_child("child")
+        assert {:ok, ^pid} = RegisteredSupervisor.start_registered_child("child")
       end
     end
 
@@ -45,7 +45,7 @@ defmodule Commanded.RegistrationTestCase do
       end
 
       test "should return `PID` when child registered" do
-        assert {:ok, pid} = RegisteredSupervisor.start_child("child")
+        assert {:ok, pid} = RegisteredSupervisor.start_registered_child("child")
         assert Registration.whereis_name("child") == pid
       end
 


### PR DESCRIPTION
`:simple_one_for_one` supervisor strategy has been deprecated (since 1.5.0?), and this is an attempt to replace it in `Commanded.Aggregates.Supervisor`. (Noticed that `Commanded.ProcessManagers.Supervisor` also uses `:simple_one_for_one`, but won't touch it until feedback on this.)

**Commit b64e3b4 (Replace Aggregate.Supervisor :simple_one_for_one with DynamicSupervisor)**

Replaced deprecated parts with `DynamicSupervisor`. It works, but tests will fail, because `DynamicSupervisor` requires the child specification on `start_child/2` invocation, and not up front in `Supervisor.init/1`, and temporarily solved it by hard-coding `Commanded.Aggregates,Aggregate` in `Commanded.Registration.LocalRegistry`.

**Commit d6c3da2 (Put DynamicSupervisor.start_child/2 in Aggregates.Supervisor)**

Moving `DynamicSupervisor.start_child/2` invocation to `Commanded.Aggregates.Supervisor`, and invoking that in `Commanded.Registration.LocalRegistry`.

**Commit b112938 (Add tests for DynamicSupervisor registration)**

Updating tests for changes.

------

### Proposal

My understanding is that registration is always done by via tuples, therefore instead having a `start_link` and `start_child` in the `Registration` behaviour, wouldn't it be nicer to only have a `via_tuple` function there, and to push `start_*` functions to their respective modules? That is, `start_child` to the supervisor, and `start_link` to the worker module. (This has been implemented in 2 more commits [here](https://github.com/toraritte/commanded/tree/via-only-proposal), atop the 3 in this pull request.)

It is more than possible that my thinking is flawed, and don't have extensive knowledge regarding all registration techniques (distributed or local).

Should I open an issue regarding this instead?

Thank you!
