### PR TITLE
Add include_execution_result and aggregate_version to type spec.

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -500,6 +500,8 @@ defmodule Commanded.Commands.Router do
       """
       @spec dispatch(command :: struct, timeout_or_opts :: integer | :infinity | keyword()) ::
               :ok
+              | {:ok, execution_result :: Commanded.Commands.Dispatcher.ExecutionResult.t()}
+              | {:ok, aggregate_version :: integer}
               | {:error, :unregistered_command}
               | {:error, :consistency_timeout}
               | {:error, reason :: term}


### PR DESCRIPTION
This fixes dialyzer warnings when pattern matching on the results of `Router.dispatch(cmd, include_execution_results: true)`