### PR TITLE
Modify Registration.start_child/3 to pass a child_spec

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -38,7 +38,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
   """
 
-  use GenServer
+  use GenServer, restart: :temporary
   use Commanded.Registration
 
   require Logger
@@ -61,8 +61,15 @@ defmodule Commanded.Aggregates.Aggregate do
     lifespan_timeout: :infinity
   ]
 
-  def start_link(aggregate_module, aggregate_uuid, opts \\ [])
-      when is_atom(aggregate_module) and is_binary(aggregate_uuid) do
+  def start_link(args) do
+    opts = [name: args[:name]]
+    aggregate_module = args[:aggregate_module]
+    aggregate_uuid = args[:aggregate_uuid]
+
+    unless is_atom(aggregate_module) and is_binary(aggregate_uuid) do
+      raise "aggregate_module must be an atom and aggregate_uuid must be a string"
+    end
+
     aggregate = %Aggregate{
       aggregate_module: aggregate_module,
       aggregate_uuid: aggregate_uuid,

--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Commanded.Aggregates.Supervisor do
   Supervises `Commanded.Aggregates.Aggregate` instance processes.
   """
 
-  use Supervisor
+  use DynamicSupervisor
 
   require Logger
 
@@ -11,7 +11,7 @@ defmodule Commanded.Aggregates.Supervisor do
   alias Commanded.Registration
 
   def start_link(arg) do
-    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   @doc """
@@ -28,8 +28,8 @@ defmodule Commanded.Aggregates.Supervisor do
     end)
 
     name = Aggregate.name(aggregate_module, aggregate_uuid)
-
-    case Registration.start_child(name, __MODULE__, [aggregate_module, aggregate_uuid]) do
+    args = [aggregate_module: aggregate_module, aggregate_uuid: aggregate_uuid]
+    case Registration.start_child(name, __MODULE__, {Aggregate, args}) do
       {:ok, _pid} ->
         {:ok, aggregate_uuid}
 
@@ -47,11 +47,7 @@ defmodule Commanded.Aggregates.Supervisor do
   def open_aggregate(_aggregate_module, aggregate_uuid),
     do: {:error, {:unsupported_aggregate_identity_type, aggregate_uuid}}
 
-  def init(_) do
-    children = [
-      worker(Commanded.Aggregates.Aggregate, [], restart: :temporary)
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+  def init(_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/lib/commanded/registration/registration.ex
+++ b/lib/commanded/registration/registration.ex
@@ -10,6 +10,8 @@ defmodule Commanded.Registration do
   cluster of nodes.
   """
 
+  @type start_child_arg :: {module(), keyword} | module()
+
   @doc """
   Return an optional supervisor spec for the registry
   """
@@ -21,7 +23,7 @@ defmodule Commanded.Registration do
 
   Registers the pid with the given name.
   """
-  @callback start_child(name :: term(), supervisor :: module(), args :: [any()]) ::
+  @callback start_child(name :: term(), supervisor :: module(), child_spec :: start_child_arg) ::
               {:ok, pid} | {:error, term}
 
   @doc """
@@ -49,10 +51,10 @@ defmodule Commanded.Registration do
   def child_spec, do: registry_provider().child_spec()
 
   @doc false
-  @callback start_child(name :: term(), supervisor :: module(), args :: [any()]) ::
-              {:ok, pid()} | {:error, reason :: term()}
-  def start_child(name, supervisor, args),
-    do: registry_provider().start_child(name, supervisor, args)
+  @spec start_child(name :: term(), supervisor :: module(), child_spec :: start_child_arg) ::
+          {:ok, pid()} | {:error, reason :: term()}
+  def start_child(name, supervisor, child_spec),
+    do: registry_provider().start_child(name, supervisor, child_spec)
 
   @doc false
   @spec start_link(name :: term(), module :: module(), args :: any()) ::

--- a/test/event/upcaster_test.exs
+++ b/test/event/upcaster_test.exs
@@ -89,7 +89,8 @@ defmodule Event.UpcasterTest do
 
   describe "upcast events received by aggregate" do
     test "should receive upcasted events" do
-      {:ok, pid} = Aggregate.start_link(UpcastAggregate, "upcast")
+      args = [aggregate_module: UpcastAggregate, aggregate_uuid: "upcast"]
+      {:ok, pid} = Aggregate.start_link(args)
 
       event = %RecordedEvent{
         event_id: UUID.uuid4(),

--- a/test/registration/support/registered_server.ex
+++ b/test/registration/support/registered_server.ex
@@ -2,8 +2,9 @@ defmodule Commanded.Registration.RegisteredServer do
   use GenServer
   use Commanded.Registration
 
-  def start_link(name, opts \\ []) do
-    GenServer.start_link(__MODULE__, name, opts)
+  def start_link(args) do
+    name = args[:name]
+    GenServer.start_link(__MODULE__, name, [name: name])
   end
 
   def init(name), do: {:ok, name}

--- a/test/registration/support/registered_supervisor.ex
+++ b/test/registration/support/registered_supervisor.ex
@@ -1,22 +1,18 @@
 defmodule Commanded.Registration.RegisteredSupervisor do
-  use Supervisor
+  use DynamicSupervisor
 
   alias Commanded.Registration
   alias Commanded.Registration.RegisteredServer
 
   def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def start_child(name) do
-    Registration.start_child(name, __MODULE__, [name])
+    Registration.start_child(name, __MODULE__, {RegisteredServer, []})
   end
 
   def init(:ok) do
-    children = [
-      worker(RegisteredServer, [], restart: :temporary)
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end


### PR DESCRIPTION
In order to support DynamicSupervisor, Commanded.Registration.start_child/3
needed to receive a child_spec instead of args like a :simple_one_for_one
supervisor would expect. Supporting DynamicSupervisor will allow us to
support distributed supervisors like Horde.Supervisor.