### PR TITLE
Add supervisor_child_spec/2 to Commanded.Registration

### DIFF
--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -10,6 +10,10 @@ defmodule Commanded.Aggregates.Supervisor do
   alias Commanded.Aggregates.Aggregate
   alias Commanded.Registration
 
+  def child_spec(arg) do
+    Registration.supervisor_child_spec(__MODULE__, arg)
+  end
+
   def start_link(arg) do
     DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end

--- a/lib/commanded/registration/local_registry.ex
+++ b/lib/commanded/registration/local_registry.ex
@@ -18,6 +18,21 @@ defmodule Commanded.Registration.LocalRegistry do
   end
 
   @doc """
+  Starts a supervisor.
+  """
+  @spec supervisor_child_spec(module :: atom, arg :: any()) :: :supervisor.child_spec()
+  @impl Commanded.Registration
+  def supervisor_child_spec(module, arg) do
+    default = %{
+     id: module,
+     start: {module, :start_link, [arg]},
+     type: :supervisor
+    }
+
+    Supervisor.child_spec(default, [])
+  end
+
+  @doc """
   Starts a uniquely named child process of a supervisor using the given module
   and args.
 

--- a/lib/commanded/registration/registration.ex
+++ b/lib/commanded/registration/registration.ex
@@ -17,6 +17,12 @@ defmodule Commanded.Registration do
   """
   @callback child_spec() :: [:supervisor.child_spec()]
 
+
+  @doc """
+  Use to start a supervisor.
+  """
+  @callback supervisor_child_spec(module :: atom, arg :: any()) :: :supervisor.child_spec()
+
   @doc """
   Starts a uniquely named child process of a supervisor using the given module
   and args.
@@ -49,6 +55,10 @@ defmodule Commanded.Registration do
   @doc false
   @spec child_spec() :: [:supervisor.child_spec()]
   def child_spec, do: registry_provider().child_spec()
+
+  @doc false
+  @spec supervisor_child_spec(module :: atom, arg :: any()) :: :supervisor.child_spec()
+  def supervisor_child_spec(module, arg), do: registry_provider().supervisor_child_spec(module, arg)
 
   @doc false
   @spec start_child(name :: term(), supervisor :: module(), child_spec :: start_child_arg) ::

--- a/test/registration/support/registration_test_case.ex
+++ b/test/registration/support/registration_test_case.ex
@@ -56,6 +56,17 @@ defmodule Commanded.RegistrationTestCase do
       end
     end
 
+    describe "`supervisor_child_spec/2`" do
+      test "should return a valid child_spec" do
+        assert Registration.supervisor_child_spec(RegisteredSupervisor, "child") ==
+                 %{
+                   id: Commanded.Registration.RegisteredSupervisor,
+                   start: {Commanded.Registration.RegisteredSupervisor, :start_link, ["child"]},
+                   type: :supervisor
+                 }
+      end
+    end
+
     defp start_link(name) do
       Registration.start_link(name, RegisteredServer, [])
     end


### PR DESCRIPTION
This will allow us to swap out Supervisor implementations, supporting
Horde.Supervisor for example. Supersedes the approach in #274 