### PR TITLE
Ensure Commanded can be compiled when optional Jason dependency is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support `:ok` tagged tuple events from aggregate ([#268](https://github.com/commanded/commanded/pull/268)).
 - Modify `Commanded.Registration.start_child/3` to pass a child_spec ([#273](https://github.com/commanded/commanded/pull/273)).
 - Add `supervisor_child_spec/2` to `Commanded.Registration` behaviour ([#277](https://github.com/commanded/commanded/pull/277)) used by [Commanded Horde Registry](https://github.com/uberbrodt/commanded_horde_registry).
+- Ensure Commanded can be compiled when optional Jason dependency is not present ([#286](https://github.com/commanded/commanded/pull/286)).
 
 ## v0.18.0
 

--- a/lib/commanded/event_store/snapshot_data.ex
+++ b/lib/commanded/event_store/snapshot_data.ex
@@ -12,7 +12,6 @@ defmodule Commanded.EventStore.SnapshotData do
           created_at: NaiveDateTime.t()
         }
 
-  @derive Jason.Encoder
   defstruct [
     :source_uuid,
     :source_version,

--- a/lib/commanded/serialization/json_serializer.ex
+++ b/lib/commanded/serialization/json_serializer.ex
@@ -33,4 +33,8 @@ if Code.ensure_loaded?(Jason) do
     defp to_struct(data, nil), do: data
     defp to_struct(data, struct), do: struct(struct, data)
   end
+
+  require Protocol
+
+  Protocol.derive(Jason.Encoder, Commanded.EventStore.SnapshotData)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Commanded.Mixfile do
       "test/event/support",
       "test/event_store/support",
       "test/example_domain",
+      "test/middleware/support",
       "test/helpers",
       "test/process_managers/support",
       "test/pubsub/support",

--- a/test/middleware/support/commands.ex
+++ b/test/middleware/support/commands.ex
@@ -1,4 +1,4 @@
-defmodule Commanded.Helpers.Commands do
+defmodule Commanded.Middleware.Commands do
   @moduledoc false
 
   defmodule IncrementCount do


### PR DESCRIPTION
Derive `Jason.Encoder` protocol only if the `Jason` module is available.

Fixes #275.