### PR TITLE
Process manager idle process timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.8.0
+  - 1.8.2
 
 otp_release:
   - 21.2

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -290,11 +290,11 @@ defmodule Commanded.Event.Handler do
   def parse_name(_module, name), do: inspect(name)
 
   @doc false
-  def start_opts(module, module_opts, local_opts) do
+  def start_opts(module, module_opts, local_opts, additional_allowed_opts \\ []) do
     {valid, invalid} =
       module_opts
       |> Keyword.merge(local_opts)
-      |> Keyword.split([:consistency, :start_from])
+      |> Keyword.split([:consistency, :start_from] ++ additional_allowed_opts)
 
     if Enum.any?(invalid) do
       raise "#{inspect module} specifies invalid options: #{inspect Keyword.keys(invalid)}"

--- a/lib/commanded/process_managers/supervisor.ex
+++ b/lib/commanded/process_managers/supervisor.ex
@@ -1,21 +1,19 @@
 defmodule Commanded.ProcessManagers.Supervisor do
   @moduledoc false
+
   use Supervisor
-  require Logger
 
-  def start_link(command_dispatcher) do
-    Supervisor.start_link(__MODULE__, command_dispatcher)
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok)
   end
 
-  def start_process_manager(supervisor, process_manager_name, process_manager_module, process_uuid) do
-    Logger.debug(fn -> "Starting process manager process for `#{process_manager_module}` with uuid #{process_uuid}" end)
-
-    Supervisor.start_child(supervisor, [process_manager_name, process_manager_module, process_uuid])
+  def start_process_manager(supervisor, opts) do
+    Supervisor.start_child(supervisor, [opts])
   end
 
-  def init(command_dispatcher) do
+  def init(:ok) do
     children = [
-      worker(Commanded.ProcessManagers.ProcessManagerInstance, [command_dispatcher], restart: :temporary),
+      worker(Commanded.ProcessManagers.ProcessManagerInstance, [], restart: :temporary),
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/test/process_managers/process_manager_idle_timeout_test.exs
+++ b/test/process_managers/process_manager_idle_timeout_test.exs
@@ -1,0 +1,80 @@
+defmodule Commanded.ProcessManagers.ProcessManagerIdleTimeoutTest do
+  use Commanded.StorageCase
+
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Start
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Stop
+  alias Commanded.ProcessManagers.ExampleRouter
+  alias Commanded.ProcessManagers.ProcessRouter
+  alias Commanded.ProcessManagers.TimeoutProcessManager
+  alias Commanded.Helpers.Wait
+
+  describe "process manager idle timeout" do
+    test "should shutdown instance after inactivity" do
+      {:ok, pm} = TimeoutProcessManager.start_link(idle_timeout: 50)
+
+      aggregate_uuid = UUID.uuid4()
+
+      :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+      instance = wait_for_process_instance(pm, aggregate_uuid)
+
+      ref = Process.monitor(instance)
+      assert_receive {:DOWN, ^ref, :process, ^instance, :normal}
+    end
+
+    test "should stop instance on demand" do
+      {:ok, pm} = TimeoutProcessManager.start_link(idle_timeout: 10_000)
+
+      aggregate_uuid = UUID.uuid4()
+
+      :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+      instance = wait_for_process_instance(pm, aggregate_uuid)
+
+      :ok = ExampleRouter.dispatch(%Stop{aggregate_uuid: aggregate_uuid})
+
+      ref = Process.monitor(instance)
+      assert_receive {:DOWN, ^ref, :process, ^instance, :normal}
+    end
+  end
+
+  describe "process manager `:infinity` idle timeout" do
+    test "should not shutdown instance" do
+      {:ok, pm} = TimeoutProcessManager.start_link(idle_timeout: :infinity)
+
+      aggregate_uuid = UUID.uuid4()
+
+      :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+      instance = wait_for_process_instance(pm, aggregate_uuid)
+
+      ref = Process.monitor(instance)
+      refute_receive {:DOWN, ^ref, :process, ^instance, :normal}
+    end
+
+    test "should stop instance on demand" do
+      {:ok, pm} = TimeoutProcessManager.start_link(idle_timeout: :infinity)
+
+      aggregate_uuid = UUID.uuid4()
+
+      :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+
+      instance = wait_for_process_instance(pm, aggregate_uuid)
+
+      :ok = ExampleRouter.dispatch(%Stop{aggregate_uuid: aggregate_uuid})
+
+      ref = Process.monitor(instance)
+      assert_receive {:DOWN, ^ref, :process, ^instance, :normal}
+    end
+  end
+
+  defp wait_for_process_instance(pm, process_uuid) do
+    Wait.until(fn ->
+      with instance <- ProcessRouter.process_instance(pm, process_uuid) do
+        assert is_pid(instance)
+
+        instance
+      end
+    end)
+  end
+end

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -11,13 +11,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
     transfer_uuid = UUID.uuid4()
     account1_uuid = UUID.uuid4()
     account2_uuid = UUID.uuid4()
-
+    
     {:ok, process_manager} =
       ProcessManagerInstance.start_link(
-        NullRouter,
-        "TransferMoneyProcessManager",
-        TransferMoneyProcessManager,
-        transfer_uuid
+        command_dispatcher: NullRouter,
+        idle_timeout: :infinity,
+        process_manager_name: "TransferMoneyProcessManager",
+        process_manager_module: TransferMoneyProcessManager,
+        process_uuid: transfer_uuid
       )
 
     event = %RecordedEvent{

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -1,5 +1,6 @@
 defmodule Commanded.ProcessManagers.ExampleRouter do
   @moduledoc false
+  
   use Commanded.Commands.Router
 
   alias Commanded.ProcessManagers.{ExampleAggregate,ExampleCommandHandler}

--- a/test/process_managers/support/timeout_process_manager.ex
+++ b/test/process_managers/support/timeout_process_manager.ex
@@ -1,0 +1,24 @@
+defmodule Commanded.ProcessManagers.TimeoutProcessManager do
+  @moduledoc false
+
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Started
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Stopped
+  alias Commanded.ProcessManagers.ExampleRouter
+  alias Commanded.ProcessManagers.TimeoutProcessManager
+
+  use Commanded.ProcessManagers.ProcessManager,
+    name: "TimeoutProcessManager",
+    router: ExampleRouter,
+    idle_timeout: :timer.minutes(1)
+
+  defstruct [:status]
+
+  def interested?(%Started{aggregate_uuid: aggregate_uuid}), do: {:start, aggregate_uuid}
+  def interested?(%Stopped{aggregate_uuid: aggregate_uuid}), do: {:stop, aggregate_uuid}
+
+  ## State mutators
+
+  def apply(%TimeoutProcessManager{} = pm, %Started{}) do
+    %TimeoutProcessManager{pm | status: :started}
+  end
+end


### PR DESCRIPTION
Every started instance of a process manager runs indefinitely. To reduce memory usage this pull request adds an idle timeout configuration (in milliseconds) after which an instance process will be shutdown.

The process will be restarted on demand, whenever an event is routed to it, and its state will be rehydrated from the instance snapshot.

## Example

Define the `idle_timeout` option in the process manager module:

```elixir
defmodule ExampleProcessManager do
  use Commanded.ProcessManagers.ProcessManager,
    name: "ExampleProcessManager",
    router: ExampleRouter,
    idle_timeout: :timer.minutes(10)
end
```

Or provide the timeout on start:

```elixir
ExampleProcessManager.start_link(idle_timeout: 10_000)
```

By default the idle timeout will be configured as `:infinity` so every process manager instance will run indefinitely once started.

Fixes #148.