### PR TITLE
Support {:system, varname} format in Phoenix PubSub

### DIFF
--- a/lib/commanded/pubsub/phoenix_pubsub.ex
+++ b/lib/commanded/pubsub/phoenix_pubsub.ex
@@ -66,6 +66,7 @@ if Code.ensure_loaded?(Phoenix.PubSub) do
         |> Keyword.put(:name, __MODULE__)
 
       {adapter, phoenix_pubsub_config} = Keyword.pop(phoenix_pubsub_config, :adapter)
+      phoenix_pubsub_config = parse_config(phoenix_pubsub_config)
 
       [
         %{
@@ -120,6 +121,19 @@ if Code.ensure_loaded?(Phoenix.PubSub) do
     @impl Commanded.PubSub
     def list(topic) when is_binary(topic) do
       Phoenix.Tracker.list(Tracker, topic) |> Enum.map(fn {key, %{pid: pid}} -> {key, pid} end)
+    end
+
+    defp parse_config(config) do
+      Enum.map(config, fn
+        {key, {:system, env}} when key in [:port, :pool_size] ->
+          {key, env |> System.get_env() |> String.to_integer()}
+
+        {key, {:system, env}} ->
+          {key, System.get_env(env)}
+
+        pair ->
+          pair
+      end)
     end
   end
 end


### PR DESCRIPTION
This is more of a PR for discussion on the best approach.

Currently the supervisor is calling `PubSub.child_spec/0` which in turn sets passes the options defined in `config/*.exs` down to `Phoenix.PubSub`.

With this setup, it is non-trivial to set values in runtime (like some environment variables which are not always available in compile time) for PubSub. It would be possible to overwrite the supervisor but we would need to explicitly start the tracker, among others.

The approach we went with was to change the `Commanded.PubSub.PhoenixPubSub` module to account for variables in the format of `{:system, varname}`. This is very hackish, however. Ideally this could be something set in the supervisor and propagated down or even to use an existing PubSub instance started in the supervisor, instead of spawning one.

/cc @naps62 