### PR TITLE
Fix process manager exception on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.0-rc.1
+
+### Bug fixes
+
+- Fix process manager exception on start ([#307](https://github.com/commanded/commanded/pull/307)).
+
 ## v1.0.0-rc.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ You can use Commanded with one of the following event stores for persistence:
 
 Please refer to the [CHANGELOG](CHANGELOG.md) for features, bug fixes, and any upgrade advice included for each release.
 
+Requires Erlang/OTP v21.0 and Elixir v1.6 or later.
+
 ---
 
 ### Supporting Commanded
 
 You can help support Commanded by helping to fund its ongoing development, new features, and releases.
 
-- [Become a backer or sponsor on OpenCollective](https://opencollective.com/commanded).
+- [Become a GitHub sponsor](https://github.com/sponsors/slashdotdash).
 - [View sponsors & backers](BACKERS.md)
 
 ---

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -95,14 +95,6 @@ defmodule Commanded.Aggregates.Aggregate do
       when is_atom(application) and is_atom(aggregate_module) and is_binary(aggregate_uuid),
       do: {application, aggregate_module, aggregate_uuid}
 
-  @doc false
-  @impl GenServer
-  def init(%Aggregate{} = state) do
-    # Initial aggregate state is populated by loading its state snapshot and/or
-    # events from the event store.
-    {:ok, state, {:continue, :populate_aggregate_state}}
-  end
-
   @doc """
   Execute the given command against the aggregate.
 
@@ -162,6 +154,15 @@ defmodule Commanded.Aggregates.Aggregate do
   end
 
   @doc false
+  @impl GenServer
+  def init(%Aggregate{} = state) do
+    # Initial aggregate state is populated by loading its state snapshot and/or
+    # events from the event store.
+    {:ok, state, {:continue, :populate_aggregate_state}}
+  end
+
+  @doc false
+  @impl GenServer
   def handle_continue(:populate_aggregate_state, %Aggregate{} = state) do
     # Subscribe to aggregate's events to catch any events appended to its stream
     # by another process, such as directly appended to the event store.

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -40,10 +40,6 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     GenServer.start_link(__MODULE__, state)
   end
 
-  def init(%State{} = state) do
-    {:ok, state, {:continue, :fetch_state}}
-  end
-
   @doc """
   Checks whether or not the process manager has already processed events
   """
@@ -74,9 +70,16 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     GenServer.call(process_manager, :process_state)
   end
 
+  @doc false
+  @impl GenServer
+  def init(%State{} = state) do
+    {:ok, state, {:continue, :fetch_state}}
+  end
+
   @doc """
   Attempt to fetch intial process state from snapshot storage.
   """
+  @impl GenServer
   def handle_continue(:fetch_state, %State{} = state) do
     %State{application: application} = state
 
@@ -97,6 +100,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc false
+  @impl GenServer
   def handle_call(:stop, _from, %State{} = state) do
     :ok = delete_state(state)
 
@@ -105,6 +109,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc false
+  @impl GenServer
   def handle_call(:process_state, _from, %State{} = state) do
     %State{idle_timeout: idle_timeout, process_state: process_state} = state
 
@@ -112,6 +117,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc false
+  @impl GenServer
   def handle_call(:new?, _from, %State{} = state) do
     %State{idle_timeout: idle_timeout, last_seen_event: last_seen_event} = state
 
@@ -121,6 +127,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @doc """
   Handle the given event, using the process manager module, against the current process state
   """
+  @impl GenServer
   def handle_cast({:process_event, event}, %State{} = state) do
     case event_already_seen?(event, state) do
       true -> process_seen_event(event, state)
@@ -129,6 +136,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc false
+  @impl GenServer
   def handle_info(:timeout, %State{} = state) do
     Logger.debug(fn -> describe(state) <> " stopping due to inactivity timeout" end)
 

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -37,13 +37,13 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     ]
   end
 
-  def start_link(application, name, module, opts \\ []) do
-    name = {application, ProcessRouter, name}
+  def start_link(application, process_name, process_module, opts \\ []) do
+    name = {application, ProcessRouter, process_name}
 
     state = %State{
       application: application,
-      process_manager_name: name,
-      process_manager_module: module,
+      process_manager_name: process_name,
+      process_manager_module: process_module,
       consistency: Keyword.get(opts, :consistency, :eventual),
       subscribe_from: Keyword.get(opts, :start_from, :origin),
       event_timeout: Keyword.get(opts, :event_timeout),
@@ -256,7 +256,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     {:stop, reason, state}
   end
 
-  # Register this process manager as a subscription with the given consistency
+  # Register this process manager as a subscription with the given consistency.
   defp register_subscription(%State{} = state) do
     %State{application: application, consistency: consistency, process_manager_name: name} = state
 

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -10,11 +10,16 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
 
   setup do
     expect(MockEventStore, :subscribe_to, fn
-      {MockedApp.EventStore, _config}, _stream_uuid, _handler_name, handler, _subscribe_from ->
+      {MockedApp.EventStore, _config}, stream_uuid, handler_name, handler, _subscribe_from ->
+        assert is_binary(stream_uuid)
+        assert is_binary(handler_name)
+
         {:ok, handler}
     end)
 
-    expect(MockEventStore, :subscribe, fn {MockedApp.EventStore, _config}, _aggregate_uuid ->
+    expect(MockEventStore, :subscribe, fn {MockedApp.EventStore, _config}, aggregate_uuid ->
+      assert is_binary(aggregate_uuid)
+
       :ok
     end)
 

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -9,7 +9,9 @@ defmodule Commanded.Event.HandlerInitTest do
   setup do
     reply_to = self()
 
-    subscribe_to = fn _event_store, :all, _handler_name, handler, _subscribe_from ->
+    subscribe_to = fn _event_store, :all, handler_name, handler, _subscribe_from ->
+      assert is_binary(handler_name)
+
       {:ok, handler}
     end
 

--- a/test/process_managers/process_manager_routing_test.exs
+++ b/test/process_managers/process_manager_routing_test.exs
@@ -12,7 +12,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerRoutingTest do
 
   setup do
     expect(MockEventStore, :subscribe_to, fn
-      _event_store, :all, _name, pid, :origin ->
+      _event_store, :all, name, pid, :origin ->
+        assert is_binary(name)
+        assert is_pid(pid)
+
         send(pid, {:subscribed, self()})
 
         {:ok, self()}

--- a/test/process_managers/process_manager_subscription_test.exs
+++ b/test/process_managers/process_manager_subscription_test.exs
@@ -50,11 +50,9 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
   defp start_process_manager(subscription) do
     reply_to = self()
 
-    expect(MockEventStore, :subscribe_to, fn _event_store,
+    expect(MockEventStore, :subscribe_to, fn {Commanded.MockedApp.EventStore, _config},
                                              :all,
-                                             {Commanded.MockedApp,
-                                              Commanded.ProcessManagers.ProcessRouter,
-                                              "ExampleProcessManager"},
+                                             "ExampleProcessManager",
                                              pm,
                                              :origin ->
       send(pm, {:subscribed, subscription})


### PR DESCRIPTION
Due to invalid name being passed to event store subscription.

Use `handle_continue` callback to subscribe to event store for event handlers to be consistent with process managers.