### PR TITLE
Define adapter behaviour modules for event store, pubsub, and registry

### DIFF
--- a/guides/Choosing an Event Store.md
+++ b/guides/Choosing an Event Store.md
@@ -36,6 +36,6 @@ Use the `--run-projections=all --start-standard-projections=true` flags when run
 
 ## Writing your own event store provider
 
-To use an alternative event store with Commanded you will need to implement the `Commanded.EventStore` behaviour. This defines the contract to be implemented by an adapter module to allow an event store to be used with Commanded. Tests to verify an adapter conforms to the behaviour are provided in `test/event_store_adapter`.
+To use an alternative event store with Commanded you will need to implement the `Commanded.EventStore.Adapter` behaviour. This defines the contract to be implemented by an adapter module to allow an event store to be used with Commanded. Tests to verify an adapter conforms to the behaviour are provided in `test/event_store_adapter`.
 
 You can use one of the existing adapters ([commanded_eventstore_adapter](https://github.com/commanded/commanded-eventstore-adapter) or [commanded_extreme_adapter](https://github.com/commanded/commanded-extreme-adapter)) to understand what is required.

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -52,6 +52,7 @@ defmodule Commanded.Aggregates.Aggregate do
   alias Commanded.Event.Upcast
   alias Commanded.EventStore
   alias Commanded.EventStore.{RecordedEvent, SnapshotData}
+  alias Commanded.Registration
   alias Commanded.Snapshotting
 
   @read_event_batch_size 100
@@ -548,7 +549,8 @@ defmodule Commanded.Aggregates.Aggregate do
 
   defp via_name(application, aggregate_module, aggregate_uuid) do
     name = name(application, aggregate_module, aggregate_uuid)
-    via_tuple(application, name)
+
+    Registration.via_tuple(application, name)
   end
 
   defp describe(%Aggregate{} = aggregate) do

--- a/lib/commanded/application/supervisor.ex
+++ b/lib/commanded/application/supervisor.ex
@@ -35,43 +35,83 @@ defmodule Commanded.Application.Supervisor do
   @doc """
   Starts the application supervisor.
   """
-  def start_link(application, otp_app, event_store, pubsub, registry, config, opts) do
+  def start_link(application, otp_app, config, opts) do
     sup_opts = if name = Keyword.get(opts, :name, application), do: [name: name], else: []
 
     Supervisor.start_link(
       __MODULE__,
-      {application, otp_app, event_store, registry, pubsub, config, opts},
+      {application, otp_app, config, opts},
       sup_opts
     )
   end
 
-  def init({application, otp_app, event_store, pubsub, registry, config, opts}) do
+  def init({application, otp_app, config, opts}) do
     case runtime_config(application, otp_app, config, opts) do
       {:ok, config} ->
+        {event_store_child_spec, config} = event_store_child_spec(application, config)
+        {pubsub_child_spec, config} = pubsub_child_spec(application, config)
+        {registry_child_spec, config} = registry_child_spec(application, config)
+
         :ok = Config.associate(self(), config)
 
-        task_dispatcher_name = Module.concat([application, Commanded.Commands.TaskDispatcher])
-        subscriptions_name = Module.concat([application, Commanded.Subscriptions])
-        registry_name = Module.concat([application, Commanded.Subscriptions.Registry])
-        snapshotting = Keyword.get(config, :snapshotting, %{})
-
         children =
-          event_store.child_spec(Keyword.get(config, :event_store, [])) ++
-            pubsub.child_spec(Keyword.get(config, :pubsub, [])) ++
-            registry.child_spec(Keyword.get(config, :registry, [])) ++
-            [
-              {Task.Supervisor, name: task_dispatcher_name},
-              {Commanded.Aggregates.Supervisor,
-               application: application, snapshotting: snapshotting},
-              {Commanded.Subscriptions.Registry, application: application, name: registry_name},
-              {Commanded.Subscriptions, application: application, name: subscriptions_name}
-            ]
+          event_store_child_spec ++
+            pubsub_child_spec ++
+            registry_child_spec ++
+            commanded_child_spec(application, config)
 
         Supervisor.init(children, strategy: :one_for_one)
 
       :ignore ->
         :ignore
     end
+  end
+
+  defp commanded_child_spec(application, config) do
+    task_dispatcher_name = Module.concat([application, Commanded.Commands.TaskDispatcher])
+    subscriptions_name = Module.concat([application, Commanded.Subscriptions])
+    registry_name = Module.concat([application, Commanded.Subscriptions.Registry])
+    snapshotting = Keyword.get(config, :snapshotting, %{})
+
+    [
+      {Task.Supervisor, name: task_dispatcher_name},
+      {Commanded.Aggregates.Supervisor, application: application, snapshotting: snapshotting},
+      {Commanded.Subscriptions.Registry, application: application, name: registry_name},
+      {Commanded.Subscriptions, application: application, name: subscriptions_name}
+    ]
+  end
+
+  defp event_store_child_spec(application, config) do
+    {adapter, adapter_config} =
+      Commanded.EventStore.adapter(application, Keyword.get(config, :event_store))
+
+    {:ok, child_spec, adapter_meta} = adapter.child_spec(application, adapter_config)
+
+    config = Keyword.put(config, :event_store, {adapter, adapter_meta})
+
+    {child_spec, config}
+  end
+
+  defp pubsub_child_spec(application, config) do
+    {adapter, adapter_config} =
+      Commanded.PubSub.adapter(application, Keyword.get(config, :pubsub, :local))
+
+    {:ok, child_spec, adapter_meta} = adapter.child_spec(application, adapter_config)
+
+    config = Keyword.put(config, :pubsub, {adapter, adapter_meta})
+
+    {child_spec, config}
+  end
+
+  defp registry_child_spec(application, config) do
+    {adapter, adapter_config} =
+      Commanded.Registration.adapter(application, Keyword.get(config, :registry, :local))
+
+    {:ok, child_spec, adapter_meta} = adapter.child_spec(application, adapter_config)
+
+    config = Keyword.put(config, :registry, {adapter, adapter_meta})
+
+    {child_spec, config}
   end
 
   defp application_init(application, config) do

--- a/lib/commanded/event_store/adapter.ex
+++ b/lib/commanded/event_store/adapter.ex
@@ -1,135 +1,53 @@
 defmodule Commanded.EventStore.Adapter do
-  @moduledoc false
+  @moduledoc """
+  Defines the behaviour to be implemented by an event store adapter to be used by Commanded.
+  """
 
-  alias Commanded.Application.Config
   alias Commanded.EventStore.{EventData, RecordedEvent, SnapshotData}
-  alias Commanded.Event.Upcast
 
-  defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts] do
-      @adapter Keyword.fetch!(opts, :adapter)
-      @application __MODULE__ |> Module.split() |> Enum.drop(-1) |> Module.concat()
-
-      @behaviour Commanded.EventStore.Adapter
-
-      def child_spec(config) do
-        @adapter.child_spec(__MODULE__, config)
-      end
-
-      def append_to_stream(stream_uuid, expected_version, events)
-          when is_binary(stream_uuid) and
-                 (is_integer(expected_version) or
-                    expected_version in [:any_version, :no_stream, :stream_exists]) and
-                 is_list(events) do
-        @adapter.append_to_stream(
-          {__MODULE__, config()},
-          stream_uuid,
-          expected_version,
-          events
-        )
-      end
-
-      def stream_forward(
-            stream_uuid,
-            start_version \\ 0,
-            read_batch_size \\ 1_000
-          )
-          when is_binary(stream_uuid) and
-                 is_integer(start_version) and
-                 is_integer(read_batch_size) do
-        case @adapter.stream_forward(
-               {__MODULE__, config()},
-               stream_uuid,
-               start_version,
-               read_batch_size
-             ) do
-          {:error, _} = error -> error
-          stream -> Upcast.upcast_event_stream(stream)
-        end
-      end
-
-      def subscribe(stream_uuid)
-          when stream_uuid == :all or is_binary(stream_uuid) do
-        @adapter.subscribe({__MODULE__, config()}, stream_uuid)
-      end
-
-      def subscribe_to(
-            stream_uuid,
-            subscription_name,
-            subscriber,
-            start_from
-          )
-          when (stream_uuid == :all or is_binary(stream_uuid)) and is_pid(subscriber) do
-        @adapter.subscribe_to(
-          {__MODULE__, config()},
-          stream_uuid,
-          subscription_name,
-          subscriber,
-          start_from
-        )
-      end
-
-      def ack_event(pid, %RecordedEvent{} = event) when is_pid(pid) do
-        @adapter.ack_event({__MODULE__, config()}, pid, event)
-      end
-
-      def unsubscribe(subscription) do
-        @adapter.unsubscribe({__MODULE__, config()}, subscription)
-      end
-
-      def delete_subscription(stream_uuid, subscription_name) do
-        @adapter.delete_subscription(
-          {__MODULE__, config()},
-          stream_uuid,
-          subscription_name
-        )
-      end
-
-      def read_snapshot(source_uuid) when is_binary(source_uuid) do
-        @adapter.read_snapshot({__MODULE__, config()}, source_uuid)
-      end
-
-      def record_snapshot(%SnapshotData{} = snapshot) do
-        @adapter.record_snapshot({__MODULE__, config()}, snapshot)
-      end
-
-      def delete_snapshot(source_uuid) when is_binary(source_uuid) do
-        @adapter.delete_snapshot({__MODULE__, config()}, source_uuid)
-      end
-
-      defp config, do: Config.get(@application, :event_store)
-    end
-  end
+  @type adapter_meta :: map
+  @type application :: Commanded.Application.t()
+  @type config :: Keyword.t()
+  @type stream_uuid :: String.t()
+  @type start_from :: :origin | :current | integer
+  @type expected_version :: :any_version | :no_stream | :stream_exists | non_neg_integer
+  @type subscription_name :: String.t()
+  @type subscription :: any
+  @type subscriber :: pid
+  @type source_uuid :: String.t()
+  @type error :: term
 
   @doc """
   Return a child spec defining all processes required by the event store.
   """
-  @callback child_spec(config :: Keyword.t()) :: [:supervisor.child_spec()]
+  @callback child_spec(application, config) :: {:ok, [:supervisor.child_spec()], adapter_meta}
 
   @doc """
   Append one or more events to a stream atomically.
   """
   @callback append_to_stream(
-              Commanded.EventStore.stream_uuid(),
-              Commanded.EventStore.expected_version(),
+              adapter_meta,
+              stream_uuid,
+              expected_version,
               events :: list(EventData.t())
             ) ::
               :ok
               | {:error, :wrong_expected_version}
-              | {:error, term}
+              | {:error, error}
 
   @doc """
   Streams events from the given stream, in the order in which they were
   originally written.
   """
   @callback stream_forward(
-              Commanded.EventStore.stream_uuid(),
+              adapter_meta,
+              stream_uuid,
               start_version :: non_neg_integer,
               read_batch_size :: non_neg_integer
             ) ::
               Enumerable.t()
               | {:error, :stream_not_found}
-              | {:error, term}
+              | {:error, error}
 
   @doc """
   Create a transient subscription to a single event stream.
@@ -139,97 +57,61 @@ defmodule Commanded.EventStore.Adapter do
 
   The subscriber does not need to acknowledge receipt of the events.
   """
-  @callback subscribe(Commanded.EventStore.stream_uuid() | :all) :: :ok | {:error, term}
+  @callback subscribe(adapter_meta, stream_uuid | :all) ::
+              :ok | {:error, error}
 
   @doc """
   Create a persistent subscription to an event stream.
-
-  To subscribe to all events appended to any stream use `:all` as the stream
-  when subscribing.
-
-  The event store will remember the subscribers last acknowledged event.
-  Restarting the named subscription will resume from the next event following
-  the last seen.
-
-  Once subscribed, the subscriber process should be sent a
-  `{:subscribed, subscription}` message to allow it to defer initialisation
-  until the subscription has started.
-
-  The subscriber process will be sent all events persisted to any stream. It
-  will receive a `{:events, events}` message for each batch of events persisted
-  for a single aggregate.
-
-  The subscriber must ack each received, and successfully processed event, using
-  `Commanded.EventStore.ack_event/2`.
-
-  ## Examples
-
-  Subscribe to all streams:
-
-      {:ok, subscription} =
-        Commanded.EventStore.subscribe_to(:all, "Example", self(), :current)
-
-  Subscribe to a single stream:
-
-      {:ok, subscription} =
-        Commanded.EventStore.subscribe_to("stream1", "Example", self(), :origin)
-
   """
   @callback subscribe_to(
-              Commanded.EventStore.stream_uuid() | :all,
-              Commanded.EventStore.subscription_name(),
-              Commanded.EventStore.subscriber(),
-              Commanded.EventStore.start_from()
+              adapter_meta,
+              stream_uuid | :all,
+              subscription_name,
+              subscriber,
+              start_from
             ) ::
-              {:ok, Commanded.EventStore.subscription()}
+              {:ok, subscription}
               | {:error, :subscription_already_exists}
-              | {:error, term}
+              | {:error, error}
 
   @doc """
   Acknowledge receipt and successful processing of the given event received from
   a subscription to an event stream.
   """
-  @callback ack_event(pid, RecordedEvent.t()) :: :ok
+  @callback ack_event(adapter_meta, pid, RecordedEvent.t()) :: :ok
 
   @doc """
   Unsubscribe an existing subscriber from event notifications.
 
-  This will not delete the subscription.
-
-  ## Example
-
-      :ok = Commanded.EventStore.unsubscribe(subscription)
-
+  This should not delete the subscription.
   """
-  @callback unsubscribe(Commanded.EventStore.subscription()) :: :ok
+  @callback unsubscribe(adapter_meta, subscription) :: :ok
 
   @doc """
   Delete an existing subscription.
-
-  ## Example
-
-      :ok = Commanded.EventStore.delete_subscription(:all, "Example")
-
   """
   @callback delete_subscription(
-              Commanded.EventStore.stream_uuid() | :all,
-              Commanded.EventStore.subscription_name()
+              adapter_meta,
+              stream_uuid | :all,
+              subscription_name
             ) ::
-              :ok | {:error, :subscription_not_found} | {:error, term}
+              :ok | {:error, :subscription_not_found} | {:error, error}
 
   @doc """
   Read a snapshot, if available, for a given source.
   """
-  @callback read_snapshot(Commanded.EventStore.source_uuid()) ::
+  @callback read_snapshot(adapter_meta, source_uuid) ::
               {:ok, SnapshotData.t()} | {:error, :snapshot_not_found}
 
   @doc """
   Record a snapshot of the data and metadata for a given source
   """
-  @callback record_snapshot(SnapshotData.t()) :: :ok | {:error, term}
+  @callback record_snapshot(adapter_meta, SnapshotData.t()) ::
+              :ok | {:error, error}
 
   @doc """
   Delete a previously recorded snapshot for a given source
   """
-  @callback delete_snapshot(Commanded.EventStore.source_uuid()) :: :ok | {:error, term}
+  @callback delete_snapshot(adapter_meta, source_uuid) ::
+              :ok | {:error, error}
 end

--- a/lib/commanded/pubsub.ex
+++ b/lib/commanded/pubsub.ex
@@ -1,51 +1,21 @@
 defmodule Commanded.PubSub do
-  @moduledoc """
-  Pub/sub behaviour for use by Commanded to subcribe to and broadcast messages.
-  """
-
-  @type application :: module
-  @type pubsub :: module
-
-  @doc """
-  Return an optional supervisor spec for pub/sub.
-  """
-  @callback child_spec(pubsub, config :: Keyword.t()) :: [:supervisor.child_spec()]
-
-  @doc """
-  Subscribes the caller to the PubSub adapter's topic.
-  """
-  @callback subscribe(pubsub, topic :: String.t()) :: :ok | {:error, term}
-
-  @doc """
-  Broadcasts message on given topic.
-
-    * `topic` - The topic to broadcast to, ie: `"users:123"`
-    * `message` - The payload of the broadcast
-
-  """
-  @callback broadcast(pubsub, topic :: String.t(), message :: term) :: :ok | {:error, term}
-
-  @doc """
-  Track the current process under the given `topic`, uniquely identified by
-  `key`.
-  """
-  @callback track(pubsub, topic :: String.t(), key :: term) :: :ok | {:error, term}
-
-  @doc """
-  List tracked PIDs for a given topic.
-  """
-  @callback list(pubsub, topic :: String.t()) :: [{term, pid}]
-
   alias Commanded.Application
+
+  @type application :: Commanded.Application.t()
+  @type config :: Keyword.t() | atom
 
   @doc false
   def subscribe(application, topic) do
-    Application.pubsub_adapter(application).subscribe(topic)
+    {adapter, adapter_meta} = Application.pubsub_adapter(application)
+
+    adapter.subscribe(adapter_meta, topic)
   end
 
   @doc false
   def broadcast(application, topic, message) do
-    Application.pubsub_adapter(application).broadcast(topic, message)
+    {adapter, adapter_meta} = Application.pubsub_adapter(application)
+
+    adapter.broadcast(adapter_meta, topic, message)
   end
 
   @doc """
@@ -53,14 +23,14 @@ defmodule Commanded.PubSub do
 
   Defaults to a local pub/sub, restricted to running on a single node.
   """
-  @spec pubsub_provider(application, config :: Keyword.t()) :: module()
-  def pubsub_provider(application, config) do
-    case Keyword.get(config, :pubsub, :local) do
+  @spec adapter(application, config) :: {module, config}
+  def adapter(application, config) do
+    case config do
       :local ->
-        Commanded.PubSub.LocalPubSub
+        {Commanded.PubSub.LocalPubSub, []}
 
-      provider when is_atom(provider) ->
-        provider
+      adapter when is_atom(adapter) ->
+        {adapter, []}
 
       config ->
         if Keyword.keyword?(config) do
@@ -70,8 +40,8 @@ defmodule Commanded.PubSub do
                     "invalid Phoenix pubsub configuration #{inspect(config)} for application " <>
                       inspect(application)
 
-            _phoenix_pubsub ->
-              Commanded.PubSub.PhoenixPubSub
+            phoenix_pubsub_config ->
+              {Commanded.PubSub.PhoenixPubSub, phoenix_pubsub_config}
           end
         else
           raise ArgumentError,

--- a/lib/commanded/pubsub/adapter.ex
+++ b/lib/commanded/pubsub/adapter.ex
@@ -1,33 +1,21 @@
 defmodule Commanded.PubSub.Adapter do
-  @moduledoc false
+  @moduledoc """
+  Pub/sub behaviour for use by Commanded to subcribe to and broadcast messages.
+  """
 
-  defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts] do
-      @adapter Keyword.fetch!(opts, :adapter)
-
-      @behaviour Commanded.PubSub.Adapter
-
-      def child_spec(config), do: @adapter.child_spec(__MODULE__, config)
-
-      def subscribe(topic), do: @adapter.subscribe(__MODULE__, topic)
-
-      def broadcast(topic, message), do: @adapter.broadcast(__MODULE__, topic, message)
-
-      def track(topic, key), do: @adapter.broadcast(__MODULE__, topic, key)
-
-      def list(topic), do: @adapter.list(__MODULE__, topic)
-    end
-  end
+  @type adapter_meta :: map
+  @type application :: Commanded.Application.t()
 
   @doc """
   Return an optional supervisor spec for pub/sub.
   """
-  @callback child_spec(config :: Keyword.t()) :: [:supervisor.child_spec()]
+  @callback child_spec(application, config :: Keyword.t()) ::
+              {:ok, [:supervisor.child_spec()], adapter_meta}
 
   @doc """
-  Subscribes the caller to the PubSub topic.
+  Subscribes the caller to the PubSub adapter's topic.
   """
-  @callback subscribe(topic :: String.t()) :: :ok | {:error, term}
+  @callback subscribe(adapter_meta, topic :: String.t()) :: :ok | {:error, term}
 
   @doc """
   Broadcasts message on given topic.
@@ -36,16 +24,16 @@ defmodule Commanded.PubSub.Adapter do
     * `message` - The payload of the broadcast
 
   """
-  @callback broadcast(topic :: String.t(), message :: term) :: :ok | {:error, term}
+  @callback broadcast(adapter_meta, topic :: String.t(), message :: term) :: :ok | {:error, term}
 
   @doc """
   Track the current process under the given `topic`, uniquely identified by
   `key`.
   """
-  @callback track(String.t(), key :: term) :: :ok | {:error, term}
+  @callback track(adapter_meta, topic :: String.t(), key :: term) :: :ok | {:error, term}
 
   @doc """
   List tracked PIDs for a given topic.
   """
-  @callback list(String.t()) :: [{term, pid}]
+  @callback list(adapter_meta, topic :: String.t()) :: [{term, pid}]
 end

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -10,14 +10,14 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
 
   setup do
     expect(MockEventStore, :subscribe_to, fn
-      {MockedApp.EventStore, _config}, stream_uuid, handler_name, handler, _subscribe_from ->
+      _event_store_meta, stream_uuid, handler_name, handler, _subscribe_from ->
         assert is_binary(stream_uuid)
         assert is_binary(handler_name)
 
         {:ok, handler}
     end)
 
-    expect(MockEventStore, :subscribe, fn {MockedApp.EventStore, _config}, aggregate_uuid ->
+    expect(MockEventStore, :subscribe, fn _event_store_meta, aggregate_uuid ->
       assert is_binary(aggregate_uuid)
 
       :ok
@@ -46,7 +46,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
       }
 
       # Fail to append once
-      expect(MockEventStore, :append_to_stream, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :append_to_stream, fn _event_store_meta,
                                                    ^account_number,
                                                    1,
                                                    _event_data ->
@@ -54,7 +54,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
       end)
 
       # Return "missing" event
-      expect(MockEventStore, :stream_forward, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :stream_forward, fn _event_store_meta,
                                                  ^account_number,
                                                  2,
                                                  _batch_size ->
@@ -77,7 +77,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
       end)
 
       # Succeed on second attempt
-      expect(MockEventStore, :append_to_stream, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :append_to_stream, fn _event_store_meta,
                                                    ^account_number,
                                                    2,
                                                    _event_data ->
@@ -100,14 +100,14 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
       %{account_number: account_number} = context
 
       # fail to append to stream
-      expect(MockEventStore, :append_to_stream, 6, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :append_to_stream, 6, fn _event_store_meta,
                                                       ^account_number,
                                                       1,
                                                       _event_data ->
         {:error, :wrong_expected_version}
       end)
 
-      expect(MockEventStore, :stream_forward, 6, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :stream_forward, 6, fn _event_store_meta,
                                                     ^account_number,
                                                     2,
                                                     _batch_size ->
@@ -134,14 +134,14 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
     defp open_account(_context) do
       account_number = UUID.uuid4()
 
-      expect(MockEventStore, :stream_forward, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :stream_forward, fn _event_store_meta,
                                                  ^account_number,
                                                  1,
                                                  _batch_size ->
         []
       end)
 
-      expect(MockEventStore, :append_to_stream, fn {MockedApp.EventStore, _config},
+      expect(MockEventStore, :append_to_stream, fn _event_store_meta,
                                                    ^account_number,
                                                    0,
                                                    _event_data ->

--- a/test/application/application_test.exs
+++ b/test/application/application_test.exs
@@ -2,7 +2,6 @@ defmodule Commanded.ApplicationTest do
   use ExUnit.Case
 
   alias Commanded.Application
-  alias Commanded.EventStore.EventData
   alias Commanded.ExampleApplication
 
   describe "a Commanded application" do
@@ -22,46 +21,24 @@ defmodule Commanded.ApplicationTest do
     end
 
     test "should expose an event store adapter" do
-      assert Application.event_store_adapter(ExampleApplication) == ExampleApplication.EventStore
-    end
-
-    test "should define an event store adapter" do
-      assert_implements(ExampleApplication.EventStore, Commanded.EventStore.Adapter)
-
-      events = [
-        %EventData{
-          correlation_id: UUID.uuid4(),
-          causation_id: UUID.uuid4(),
-          event_type: "#{__MODULE__}.Event",
-          data: %Event{name: "1"},
-          metadata: %{"metadata" => "value"}
-        }
-      ]
-
-      assert :ok = ExampleApplication.EventStore.append_to_stream("1", 0, events)
+      assert Application.event_store_adapter(ExampleApplication) ==
+               {Commanded.EventStore.Adapters.InMemory,
+                %{name: Commanded.ExampleApplication.EventStore}}
     end
 
     test "should expose a pubsub adapter" do
-      assert Application.pubsub_adapter(ExampleApplication) == ExampleApplication.PubSub
-    end
-
-    test "should define a pubsub adapter" do
-      assert_implements(ExampleApplication.PubSub, Commanded.PubSub.Adapter)
+      assert Application.pubsub_adapter(ExampleApplication) ==
+               {Commanded.PubSub.LocalPubSub,
+                %{
+                  pubsub_name: Commanded.ExampleApplication.LocalPubSub,
+                  tracker_name: Commanded.ExampleApplication.LocalPubSub.Tracker
+                }}
     end
 
     test "should expose a registry adapter" do
-      assert Application.registry_adapter(ExampleApplication) == ExampleApplication.Registration
+      assert Application.registry_adapter(ExampleApplication) ==
+               {Commanded.Registration.LocalRegistry,
+                %{registry_name: Commanded.ExampleApplication.LocalRegistry}}
     end
-
-    test "should define a registration adapter" do
-      assert_implements(ExampleApplication.Registration, Commanded.Registration.Adapter)
-    end
-  end
-
-  # Returns `true` if module implements behaviour.
-  defp assert_implements(module, behaviour) do
-    all = Keyword.take(module.__info__(:attributes), [:behaviour])
-
-    assert [behaviour] in Keyword.values(all)
   end
 end

--- a/test/event/event_handler_subscription_test.exs
+++ b/test/event/event_handler_subscription_test.exs
@@ -45,7 +45,7 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
   defp start_handler(subscription) do
     reply_to = self()
 
-    expect(MockEventStore, :subscribe_to, fn _event_store,
+    expect(MockEventStore, :subscribe_to, fn _event_store_meta,
                                              :all,
                                              "ExampleHandler",
                                              handler,

--- a/test/event_store/adapters/in_memory/append_events_test.exs
+++ b/test/event_store/adapters/in_memory/append_events_test.exs
@@ -1,3 +1,6 @@
 defmodule Commanded.EventStore.Adapters.InMemory.AppendEventsTest do
-  use Commanded.EventStore.AppendEventsTestCase, application: InMemoryApplication
+  alias Commanded.EventStore.Adapters.InMemory
+
+  use Commanded.EventStore.InMemoryTestCase
+  use Commanded.EventStore.AppendEventsTestCase, event_store: InMemory
 end

--- a/test/event_store/adapters/in_memory/in_memory_test.exs
+++ b/test/event_store/adapters/in_memory/in_memory_test.exs
@@ -1,34 +1,21 @@
 defmodule Commanded.EventStore.Adapters.InMemoryTest do
-  use ExUnit.Case
+  use Commanded.EventStore.InMemoryTestCase
 
   alias Commanded.EventStore.Adapters.InMemory
   alias Commanded.EventStore.EventData
-  alias Commanded.Serialization.JsonSerializer
 
   defmodule BankAccountOpened do
     @derive Jason.Encoder
     defstruct [:account_number, :initial_balance]
   end
 
-  @config [name: InMemory, serializer: JsonSerializer]
-
-  setup do
-    {:ok, child_spec, adapter_meta} = InMemory.child_spec(InMemory, @config)
-
-    for child <- child_spec do
-      start_supervised!(child)
-    end
-
-    [adapter_meta: adapter_meta]
-  end
-
   describe "reset!/0" do
-    test "wipes all data from memory", %{adapter_meta: adapter_meta} do
+    test "wipes all data from memory", %{event_store_meta: event_store_meta} do
       pid = Process.whereis(InMemory.EventStore)
       initial = :sys.get_state(pid)
       events = [build_event(1)]
 
-      :ok = InMemory.append_to_stream(adapter_meta, "stream", 0, events)
+      :ok = InMemory.append_to_stream(event_store_meta, "stream", 0, events)
       after_event = :sys.get_state(pid)
 
       InMemory.reset!(InMemory)

--- a/test/event_store/adapters/in_memory/snapshot_test.exs
+++ b/test/event_store/adapters/in_memory/snapshot_test.exs
@@ -1,3 +1,6 @@
 defmodule Commanded.EventStore.Adapters.InMemory.SnapshotTest do
-  use Commanded.EventStore.SnapshotTestCase, application: InMemoryApplication
+  alias Commanded.EventStore.Adapters.InMemory
+
+  use Commanded.EventStore.InMemoryTestCase
+  use Commanded.EventStore.SnapshotTestCase, event_store: InMemory
 end

--- a/test/event_store/adapters/in_memory/subscription_test.exs
+++ b/test/event_store/adapters/in_memory/subscription_test.exs
@@ -1,5 +1,8 @@
 defmodule Commanded.EventStore.Adapters.InMemory.SubscriptionTest do
-  use Commanded.EventStore.SubscriptionTestCase, application: InMemoryApplication
+  alias Commanded.EventStore.Adapters.InMemory
+
+  use Commanded.EventStore.InMemoryTestCase
+  use Commanded.EventStore.SubscriptionTestCase, event_store: InMemory
 
   defp event_store_wait(default \\ nil), do: default
 end

--- a/test/event_store/support/append_events_test_case.ex
+++ b/test/event_store/support/append_events_test_case.ex
@@ -4,7 +4,6 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
   define_tests do
     import Commanded.Enumerable, only: [pluck: 2]
 
-    alias Commanded.EventStore
     alias Commanded.EventStore.EventData
 
     defmodule BankAccountOpened do
@@ -12,69 +11,99 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
       defstruct [:account_number, :initial_balance]
     end
 
-    setup %{application: application} do
-      start_supervised!(application)
-
-      :ok
+    describe "event store adapter" do
+      test "should implement `Commanded.EventStore.Adapter` behaviour", %{
+        event_store: event_store
+      } do
+        assert_implements(event_store, Commanded.EventStore.Adapter)
+      end
     end
 
     describe "append events to a stream" do
-      test "should append events", %{application: application} do
-        assert :ok == EventStore.append_to_stream(application, "stream", 0, build_events(1))
-        assert :ok == EventStore.append_to_stream(application, "stream", 1, build_events(2))
-        assert :ok == EventStore.append_to_stream(application, "stream", 3, build_events(3))
+      test "should append events", %{event_store: event_store, event_store_meta: event_store_meta} do
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 0, build_events(1))
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 1, build_events(2))
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 3, build_events(3))
       end
 
       test "should append events with `:any_version` without checking expected version", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
         assert :ok ==
-                 EventStore.append_to_stream(
-                   application,
+                 event_store.append_to_stream(
+                   event_store_meta,
                    "stream",
                    :any_version,
                    build_events(3)
                  )
 
         assert :ok ==
-                 EventStore.append_to_stream(
-                   application,
+                 event_store.append_to_stream(
+                   event_store_meta,
                    "stream",
                    :any_version,
                    build_events(2)
                  )
 
         assert :ok ==
-                 EventStore.append_to_stream(
-                   application,
+                 event_store.append_to_stream(
+                   event_store_meta,
                    "stream",
                    :any_version,
                    build_events(1)
                  )
       end
 
-      test "should append events with `:no_stream` parameter", %{application: application} do
+      test "should append events with `:no_stream` parameter", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         assert :ok ==
-                 EventStore.append_to_stream(application, "stream", :no_stream, build_events(2))
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :no_stream,
+                   build_events(2)
+                 )
       end
 
       test "should fail when stream aleady exists with `:no_stream` parameter", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
         assert :ok ==
-                 EventStore.append_to_stream(application, "stream", :no_stream, build_events(2))
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :no_stream,
+                   build_events(2)
+                 )
 
         assert {:error, :stream_exists} ==
-                 EventStore.append_to_stream(application, "stream", :no_stream, build_events(1))
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :no_stream,
+                   build_events(1)
+                 )
       end
 
-      test "should append events with `:stream_exists` parameter", %{application: application} do
+      test "should append events with `:stream_exists` parameter", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         assert :ok ==
-                 EventStore.append_to_stream(application, "stream", :no_stream, build_events(2))
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :no_stream,
+                   build_events(2)
+                 )
 
         assert :ok ==
-                 EventStore.append_to_stream(
-                   application,
+                 event_store.append_to_stream(
+                   event_store_meta,
                    "stream",
                    :stream_exists,
                    build_events(1)
@@ -82,11 +111,12 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
       end
 
       test "should fail with `:stream_exists` parameter when stream does not exist", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
         assert {:error, :stream_does_not_exist} ==
-                 EventStore.append_to_stream(
-                   application,
+                 event_store.append_to_stream(
+                   event_store_meta,
                    "stream",
                    :stream_exists,
                    build_events(1)
@@ -94,45 +124,49 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
       end
 
       test "should fail to append to a stream because of wrong expected version when no stream",
-           %{application: application} do
+           %{event_store: event_store, event_store_meta: event_store_meta} do
         assert {:error, :wrong_expected_version} ==
-                 EventStore.append_to_stream(application, "stream", 1, build_events(1))
+                 event_store.append_to_stream(event_store_meta, "stream", 1, build_events(1))
       end
 
       test "should fail to append to a stream because of wrong expected version", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
-        assert :ok == EventStore.append_to_stream(application, "stream", 0, build_events(3))
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 0, build_events(3))
 
         assert {:error, :wrong_expected_version} ==
-                 EventStore.append_to_stream(application, "stream", 0, build_events(1))
+                 event_store.append_to_stream(event_store_meta, "stream", 0, build_events(1))
 
         assert {:error, :wrong_expected_version} ==
-                 EventStore.append_to_stream(application, "stream", 1, build_events(1))
+                 event_store.append_to_stream(event_store_meta, "stream", 1, build_events(1))
 
         assert {:error, :wrong_expected_version} ==
-                 EventStore.append_to_stream(application, "stream", 2, build_events(1))
+                 event_store.append_to_stream(event_store_meta, "stream", 2, build_events(1))
 
-        assert :ok == EventStore.append_to_stream(application, "stream", 3, build_events(1))
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 3, build_events(1))
       end
     end
 
     describe "stream events from an unknown stream" do
-      test "should return stream not found error", %{application: application} do
+      test "should return stream not found error", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         assert {:error, :stream_not_found} ==
-                 EventStore.stream_forward(application, "unknownstream")
+                 event_store.stream_forward(event_store_meta, "unknownstream")
       end
     end
 
     describe "stream events from an existing stream" do
-      test "should read events", %{application: application} do
+      test "should read events", %{event_store: event_store, event_store_meta: event_store_meta} do
         correlation_id = UUID.uuid4()
         causation_id = UUID.uuid4()
         events = build_events(4, correlation_id, causation_id)
 
-        assert :ok == EventStore.append_to_stream(application, "stream", 0, events)
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 0, events)
 
-        read_events = EventStore.stream_forward(application, "stream") |> Enum.to_list()
+        read_events = event_store.stream_forward(event_store_meta, "stream") |> Enum.to_list()
         assert length(read_events) == 4
         assert coerce(events) == coerce(read_events)
         assert pluck(read_events, :stream_version) == [1, 2, 3, 4]
@@ -146,33 +180,43 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
           assert %DateTime{} = event.created_at
         end)
 
-        read_events = EventStore.stream_forward(application, "stream", 3) |> Enum.to_list()
+        read_events = event_store.stream_forward(event_store_meta, "stream", 3) |> Enum.to_list()
         assert coerce(Enum.slice(events, 2, 2)) == coerce(read_events)
         assert pluck(read_events, :stream_version) == [3, 4]
       end
 
-      test "should read from single stream", %{application: application} do
+      test "should read from single stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         events1 = build_events(2)
         events2 = build_events(4)
 
-        assert :ok == EventStore.append_to_stream(application, "stream", 0, events1)
-        assert :ok == EventStore.append_to_stream(application, "secondstream", 0, events2)
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 0, events1)
+        assert :ok == event_store.append_to_stream(event_store_meta, "secondstream", 0, events2)
 
-        read_events = EventStore.stream_forward(application, "stream", 0) |> Enum.to_list()
+        read_events = event_store.stream_forward(event_store_meta, "stream", 0) |> Enum.to_list()
         assert 2 == length(read_events)
         assert coerce(events1) == coerce(read_events)
 
-        read_events = EventStore.stream_forward(application, "secondstream", 0) |> Enum.to_list()
+        read_events =
+          event_store.stream_forward(event_store_meta, "secondstream", 0) |> Enum.to_list()
+
         assert 4 == length(read_events)
         assert coerce(events2) == coerce(read_events)
       end
 
-      test "should read events in batches", %{application: application} do
+      test "should read events in batches", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         events = build_events(10)
 
-        assert :ok == EventStore.append_to_stream(application, "stream", 0, events)
+        assert :ok == event_store.append_to_stream(event_store_meta, "stream", 0, events)
 
-        read_events = EventStore.stream_forward(application, "stream", 0, 2) |> Enum.to_list()
+        read_events =
+          event_store.stream_forward(event_store_meta, "stream", 0, 2) |> Enum.to_list()
+
         assert length(read_events) == 10
         assert coerce(events) == coerce(read_events)
 
@@ -199,6 +243,13 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
 
     defp assert_is_uuid(uuid) do
       assert uuid |> UUID.string_to_binary!() |> is_binary()
+    end
+
+    # Returns `true` if module implements behaviour.
+    defp assert_implements(module, behaviour) do
+      all = Keyword.take(module.__info__(:attributes), [:behaviour])
+
+      assert [behaviour] in Keyword.values(all)
     end
 
     defp coerce(events) do

--- a/test/event_store/support/in_memory_application.ex
+++ b/test/event_store/support/in_memory_application.ex
@@ -1,8 +1,0 @@
-defmodule InMemoryApplication do
-  use Commanded.Application,
-    otp_app: :commanded,
-    event_store: [
-      adapter: Commanded.EventStore.Adapters.InMemory,
-      serializer: Commanded.Serialization.JsonSerializer
-    ]
-end

--- a/test/event_store/support/in_memory_test_case.ex
+++ b/test/event_store/support/in_memory_test_case.ex
@@ -1,0 +1,17 @@
+defmodule Commanded.EventStore.InMemoryTestCase do
+  use ExUnit.CaseTemplate
+
+  alias Commanded.EventStore.Adapters.InMemory
+  alias Commanded.Serialization.JsonSerializer
+
+  setup do
+    config = [name: InMemory, serializer: JsonSerializer]
+    {:ok, child_spec, event_store_meta} = InMemory.child_spec(InMemory, config)
+
+    for child <- child_spec do
+      start_supervised!(child)
+    end
+
+    [event_store_meta: event_store_meta]
+  end
+end

--- a/test/event_store/support/subscription_test_case.ex
+++ b/test/event_store/support/subscription_test_case.ex
@@ -2,7 +2,6 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
   import Commanded.SharedTestCase
 
   define_tests do
-    alias Commanded.EventStore
     alias Commanded.EventStore.EventData
     alias Commanded.EventStore.Subscriber
     alias Commanded.EventStore.RecordedEvent
@@ -13,21 +12,18 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
       defstruct [:account_number, :initial_balance]
     end
 
-    setup %{application: application} do
-      start_supervised!(application)
-
-      :ok
-    end
-
     describe "transient subscription to single stream" do
-      test "should receive events appended to the stream", %{application: application} do
+      test "should receive events appended to the stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         stream_uuid = UUID.uuid4()
 
-        assert :ok = EventStore.subscribe(application, stream_uuid)
+        assert :ok = event_store.subscribe(event_store_meta, stream_uuid)
 
-        :ok = EventStore.append_to_stream(application, stream_uuid, 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, stream_uuid, 0, build_events(1))
 
-        received_events = assert_receive_events(application, 1, from: 1)
+        received_events = assert_receive_events(event_store, event_store_meta, 1, from: 1)
 
         for %RecordedEvent{} = event <- received_events do
           assert event.stream_id == stream_uuid
@@ -36,9 +32,9 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
 
         assert Enum.map(received_events, & &1.stream_version) == [1]
 
-        :ok = EventStore.append_to_stream(application, stream_uuid, 1, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, stream_uuid, 1, build_events(2))
 
-        received_events = assert_receive_events(application, 2, from: 2)
+        received_events = assert_receive_events(event_store, event_store_meta, 2, from: 2)
 
         for %RecordedEvent{} = event <- received_events do
           assert event.stream_id == stream_uuid
@@ -47,9 +43,9 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
 
         assert Enum.map(received_events, & &1.stream_version) == [2, 3]
 
-        :ok = EventStore.append_to_stream(application, stream_uuid, 3, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, stream_uuid, 3, build_events(3))
 
-        received_events = assert_receive_events(application, 3, from: 4)
+        received_events = assert_receive_events(event_store, event_store_meta, 3, from: 4)
 
         for %RecordedEvent{} = event <- received_events do
           assert event.stream_id == stream_uuid
@@ -61,44 +57,53 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
         refute_receive {:events, _received_events}
       end
 
-      test "should not receive events appended to another stream", %{application: application} do
+      test "should not receive events appended to another stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         stream_uuid = UUID.uuid4()
         another_stream_uuid = UUID.uuid4()
 
-        assert :ok = EventStore.subscribe(application, stream_uuid)
+        assert :ok = event_store.subscribe(event_store_meta, stream_uuid)
 
-        :ok = EventStore.append_to_stream(application, another_stream_uuid, 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, another_stream_uuid, 1, build_events(2))
+        :ok =
+          event_store.append_to_stream(event_store_meta, another_stream_uuid, 0, build_events(1))
+
+        :ok =
+          event_store.append_to_stream(event_store_meta, another_stream_uuid, 1, build_events(2))
 
         refute_receive {:events, _received_events}
       end
     end
 
     describe "transient subscription to all streams" do
-      test "should receive events appended to any stream", %{application: application} do
-        assert :ok = EventStore.subscribe(application, :all)
+      test "should receive events appended to any stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
+        assert :ok = event_store.subscribe(event_store_meta, :all)
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
 
-        received_events = assert_receive_events(application, 1, from: 1)
+        received_events = assert_receive_events(event_store, event_store_meta, 1, from: 1)
         assert Enum.map(received_events, & &1.stream_id) == ["stream1"]
         assert Enum.map(received_events, & &1.stream_version) == [1]
 
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
 
-        received_events = assert_receive_events(application, 2, from: 2)
+        received_events = assert_receive_events(event_store, event_store_meta, 2, from: 2)
         assert Enum.map(received_events, & &1.stream_id) == ["stream2", "stream2"]
         assert Enum.map(received_events, & &1.stream_version) == [1, 2]
 
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        received_events = assert_receive_events(application, 3, from: 4)
+        received_events = assert_receive_events(event_store, event_store_meta, 3, from: 4)
         assert Enum.map(received_events, & &1.stream_id) == ["stream3", "stream3", "stream3"]
         assert Enum.map(received_events, & &1.stream_version) == [1, 2, 3]
 
-        :ok = EventStore.append_to_stream(application, "stream1", 1, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 1, build_events(2))
 
-        received_events = assert_receive_events(application, 2, from: 7)
+        received_events = assert_receive_events(event_store, event_store_meta, 2, from: 7)
         assert Enum.map(received_events, & &1.stream_id) == ["stream1", "stream1"]
         assert Enum.map(received_events, & &1.stream_version) == [2, 3]
 
@@ -107,260 +112,305 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
     end
 
     describe "subscribe to single stream" do
-      test "should receive `:subscribed` message once subscribed", %{application: application} do
+      test "should receive `:subscribed` message once subscribed", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, "stream1", "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, "stream1", "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
       end
 
-      test "should receive events appended to stream", %{application: application} do
+      test "should receive events appended to stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, "stream1", "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, "stream1", "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream1", 1, build_events(2))
-        :ok = EventStore.append_to_stream(application, "stream1", 3, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 1, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 3, build_events(3))
 
-        assert_receive_events(application, subscription, 1, from: 1)
-        assert_receive_events(application, subscription, 2, from: 2)
-        assert_receive_events(application, subscription, 3, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 2, from: 2)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 4)
 
         refute_receive {:events, _received_events}
       end
 
-      test "should not receive events appended to another stream", %{application: application} do
+      test "should not receive events appended to another stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, "stream1", "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, "stream1", "subscriber", self(), :origin)
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        assert_receive_events(application, subscription, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 1, from: 1)
         refute_receive {:events, _received_events}
       end
 
       test "should skip existing events when subscribing from current position", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream1", 1, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 1, build_events(2))
 
         wait_for_event_store()
 
         {:ok, subscription} =
-          EventStore.subscribe_to(application, "stream1", "subscriber", self(), :current)
+          event_store.subscribe_to(event_store_meta, "stream1", "subscriber", self(), :current)
 
         assert_receive {:subscribed, ^subscription}
         refute_receive {:events, _events}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 3, build_events(3))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(3))
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 3, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        assert_receive_events(application, subscription, 3, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 4)
         refute_receive {:events, _events}
       end
 
-      test "should receive events already apended to stream", %{application: application} do
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+      test "should receive events already apended to stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
         {:ok, subscription} =
-          EventStore.subscribe_to(application, "stream3", "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, "stream3", "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
 
-        assert_receive_events(application, subscription, 3, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 1)
 
-        :ok = EventStore.append_to_stream(application, "stream3", 3, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream3", 4, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 3, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 4, build_events(1))
 
-        assert_receive_events(application, subscription, 2, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 2, from: 4)
         refute_receive {:events, _received_events}
       end
 
-      test "should prevent duplicate subscriptions", %{application: application} do
+      test "should prevent duplicate subscriptions", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, _subscription} =
-          EventStore.subscribe_to(application, "stream1", "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, "stream1", "subscriber", self(), :origin)
 
         assert {:error, :subscription_already_exists} ==
-                 EventStore.subscribe_to(application, "stream1", "subscriber", self(), :origin)
+                 event_store.subscribe_to(
+                   event_store_meta,
+                   "stream1",
+                   "subscriber",
+                   self(),
+                   :origin
+                 )
       end
     end
 
     describe "subscribe to all streams" do
-      test "should receive `:subscribed` message once subscribed", %{application: application} do
+      test "should receive `:subscribed` message once subscribed", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
       end
 
-      test "should receive events appended to any stream", %{application: application} do
+      test "should receive events appended to any stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        assert_receive_events(application, subscription, 1, from: 1)
-        assert_receive_events(application, subscription, 2, from: 2)
-        assert_receive_events(application, subscription, 3, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 2, from: 2)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 4)
 
         refute_receive {:events, _received_events}
       end
 
-      test "should receive events already appended to any stream", %{application: application} do
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
+      test "should receive events already appended to any stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
 
         wait_for_event_store()
 
         {:ok, subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
 
-        assert_receive_events(application, subscription, 1, from: 1)
-        assert_receive_events(application, subscription, 2, from: 2)
+        assert_receive_events(event_store, event_store_meta, subscription, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 2, from: 2)
 
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        assert_receive_events(application, subscription, 3, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 4)
         refute_receive {:events, _received_events}
       end
 
       test "should skip existing events when subscribing from current position", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
 
         wait_for_event_store()
 
         {:ok, subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :current)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :current)
 
         assert_receive {:subscribed, ^subscription}
         refute_receive {:events, _received_events}
 
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
-        assert_receive_events(application, subscription, 3, from: 4)
+        assert_receive_events(event_store, event_store_meta, subscription, 3, from: 4)
 
         refute_receive {:events, _received_events}
       end
 
-      test "should prevent duplicate subscriptions", %{application: application} do
+      test "should prevent duplicate subscriptions", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, _subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert {:error, :subscription_already_exists} ==
-                 EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+                 event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
       end
     end
 
     describe "unsubscribe from all streams" do
-      test "should not receive further events appended to any stream", %{application: application} do
+      test "should not receive further events appended to any stream", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
 
-        assert_receive_events(application, subscription, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription, 1, from: 1)
 
-        :ok = unsubscribe(application, subscription)
+        :ok = unsubscribe(event_store, event_store_meta, subscription)
 
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(3))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(3))
 
         refute_receive {:events, _received_events}
       end
 
-      test "should resume subscription when subscribing again", %{application: application} do
+      test "should resume subscription when subscribing again", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription1} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription1}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
 
-        assert_receive_events(application, subscription1, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription1, 1, from: 1)
 
-        :ok = unsubscribe(application, subscription1)
+        :ok = unsubscribe(event_store, event_store_meta, subscription1)
 
         {:ok, subscription2} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
 
         assert_receive {:subscribed, ^subscription2}
-        assert_receive_events(application, subscription2, 2, from: 2)
+        assert_receive_events(event_store, event_store_meta, subscription2, 2, from: 2)
       end
     end
 
     describe "delete subscription" do
-      test "should be deleted", %{application: application} do
+      test "should be deleted", %{event_store: event_store, event_store_meta: event_store_meta} do
         {:ok, subscription1} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription1}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
 
-        assert_receive_events(application, subscription1, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription1, 1, from: 1)
 
-        :ok = unsubscribe(application, subscription1)
+        :ok = unsubscribe(event_store, event_store_meta, subscription1)
 
-        assert :ok = EventStore.delete_subscription(application, :all, "subscriber")
+        assert :ok = event_store.delete_subscription(event_store_meta, :all, "subscriber")
       end
 
-      test "should create new subscription after deletion", %{application: application} do
+      test "should create new subscription after deletion", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
         {:ok, subscription1} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         assert_receive {:subscribed, ^subscription1}
 
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
 
-        assert_receive_events(application, subscription1, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription1, 1, from: 1)
 
-        :ok = unsubscribe(application, subscription1)
+        :ok = unsubscribe(event_store, event_store_meta, subscription1)
 
-        :ok = EventStore.delete_subscription(application, :all, "subscriber")
+        :ok = event_store.delete_subscription(event_store_meta, :all, "subscriber")
 
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(2))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(2))
 
         refute_receive {:events, _received_events}
 
         {:ok, subscription2} =
-          EventStore.subscribe_to(application, :all, "subscriber", self(), :origin)
+          event_store.subscribe_to(event_store_meta, :all, "subscriber", self(), :origin)
 
         # Should receive all events as subscription has been recreated from `:origin`
         assert_receive {:subscribed, ^subscription2}
-        assert_receive_events(application, subscription2, 1, from: 1)
-        assert_receive_events(application, subscription2, 2, from: 2)
+        assert_receive_events(event_store, event_store_meta, subscription2, 1, from: 1)
+        assert_receive_events(event_store, event_store_meta, subscription2, 2, from: 2)
       end
     end
 
     describe "resume subscription" do
       test "should remember last seen event number when subscription resumes", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
-        :ok = EventStore.append_to_stream(application, "stream1", 0, build_events(1))
-        :ok = EventStore.append_to_stream(application, "stream2", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream1", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream2", 0, build_events(1))
 
-        {:ok, subscriber} = Subscriber.start_link(application, self())
+        {:ok, subscriber} = Subscriber.start_link(event_store, event_store_meta, self())
 
         assert_receive {:subscribed, _subscription}
         assert_receive {:events, received_events}
@@ -373,11 +423,11 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
 
         stop_subscriber(subscriber)
 
-        {:ok, _subscriber} = Subscriber.start_link(application, self())
+        {:ok, _subscriber} = Subscriber.start_link(event_store, event_store_meta, self())
 
         assert_receive {:subscribed, _subscription}
 
-        :ok = EventStore.append_to_stream(application, "stream3", 0, build_events(1))
+        :ok = event_store.append_to_stream(event_store_meta, "stream3", 0, build_events(1))
 
         assert_receive {:events, received_events}
         assert length(received_events) == 1
@@ -389,9 +439,10 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
 
     describe "subscription process" do
       test "should not stop subscriber process when subscription down", %{
-        application: application
+        event_store: event_store,
+        event_store_meta: event_store_meta
       } do
-        {:ok, subscriber} = Subscriber.start_link(application, self())
+        {:ok, subscriber} = Subscriber.start_link(event_store, event_store_meta, self())
 
         ref = Process.monitor(subscriber)
 
@@ -403,8 +454,11 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
         refute_receive {:DOWN, ^ref, :process, ^subscriber, _reason}
       end
 
-      test "should stop subscription process when subscriber down", %{application: application} do
-        {:ok, subscriber} = Subscriber.start_link(application, self())
+      test "should stop subscription process when subscriber down", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
+        {:ok, subscriber} = Subscriber.start_link(event_store, event_store_meta, self())
 
         assert_receive {:subscribed, subscription}
 
@@ -416,8 +470,8 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
       end
     end
 
-    defp unsubscribe(application, subscription) do
-      :ok = EventStore.unsubscribe(application, subscription)
+    defp unsubscribe(event_store, event_store_meta, subscription) do
+      :ok = event_store.unsubscribe(event_store_meta, subscription)
 
       wait_for_event_store()
     end
@@ -436,15 +490,16 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
       end
     end
 
-    defp assert_receive_events(application, subscription, expected_count, opts) do
+    defp assert_receive_events(event_store, event_store_meta, subscription, expected_count, opts) do
       assert_receive_events(
-        application,
+        event_store,
+        event_store_meta,
         expected_count,
         Keyword.put(opts, :subscription, subscription)
       )
     end
 
-    defp assert_receive_events(application, expected_count, opts) do
+    defp assert_receive_events(event_store, event_store_meta, expected_count, opts) do
       from_event_number = Keyword.get(opts, :from, 1)
 
       assert_receive {:events, received_events}
@@ -460,7 +515,7 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
           :ok
 
         subscription ->
-          EventStore.ack_event(application, subscription, List.last(received_events))
+          event_store.ack_event(event_store_meta, subscription, List.last(received_events))
       end
 
       case expected_count - length(received_events) do
@@ -470,7 +525,8 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
         remaining when remaining > 0 ->
           received_events ++
             assert_receive_events(
-              application,
+              event_store,
+              event_store_meta,
               remaining,
               Keyword.put(opts, :from, from_event_number + length(received_events))
             )

--- a/test/process_managers/process_manager_subscription_test.exs
+++ b/test/process_managers/process_manager_subscription_test.exs
@@ -50,7 +50,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
   defp start_process_manager(subscription) do
     reply_to = self()
 
-    expect(MockEventStore, :subscribe_to, fn {Commanded.MockedApp.EventStore, _config},
+    expect(MockEventStore, :subscribe_to, fn _event_store_meta,
                                              :all,
                                              "ExampleProcessManager",
                                              pm,

--- a/test/pubsub/local_pubsub_test.exs
+++ b/test/pubsub/local_pubsub_test.exs
@@ -4,10 +4,10 @@ defmodule Commanded.PubSub.LocalPubSubTest do
   use PubSubTestCase, pubsub: LocalPubSub
 
   setup do
-    child_spec = LocalPubSub.child_spec(LocalPubSub, [])
+    {:ok, child_spec, pubsub_meta} = LocalPubSub.child_spec(LocalPubSub, [])
 
     for child <- child_spec, do: start_supervised!(child)
 
-    :ok
+    [pubsub_meta: pubsub_meta]
   end
 end

--- a/test/pubsub/phoenix_pubsub_test.exs
+++ b/test/pubsub/phoenix_pubsub_test.exs
@@ -4,11 +4,11 @@ defmodule Commanded.PubSub.PhoenixPubSubTest do
   use PubSubTestCase, pubsub: PhoenixPubSub
 
   setup do
-    config = [phoenix_pubsub: [adapter: Phoenix.PubSub.PG2, pool_size: 1]]
-    child_spec = PhoenixPubSub.child_spec(PhoenixPubSub, config)
+    config = [adapter: Phoenix.PubSub.PG2, pool_size: 1]
+    {:ok, child_spec, pubsub_meta} = PhoenixPubSub.child_spec(PhoenixPubSub, config)
 
     for child <- child_spec, do: start_supervised!(child)
 
-    :ok
+    [pubsub_meta: pubsub_meta]
   end
 end

--- a/test/pubsub/support/pubsub_test_case.ex
+++ b/test/pubsub/support/pubsub_test_case.ex
@@ -3,9 +3,9 @@ defmodule Commanded.PubSub.PubSubTestCase do
 
   define_tests do
     describe "pub/sub" do
-      test "should receive broadcast message", %{pubsub: pubsub} do
-        :ok = pubsub.subscribe(pubsub, "topic")
-        :ok = pubsub.broadcast(pubsub, "topic", :message)
+      test "should receive broadcast message", %{pubsub: pubsub, pubsub_meta: pubsub_meta} do
+        :ok = pubsub.subscribe(pubsub_meta, "topic")
+        :ok = pubsub.broadcast(pubsub_meta, "topic", :message)
 
         assert_receive(:message)
         refute_receive(:message)
@@ -13,23 +13,26 @@ defmodule Commanded.PubSub.PubSubTestCase do
     end
 
     describe "tracker" do
-      test "should list tracked processes", %{pubsub: pubsub} do
+      test "should list tracked processes", %{pubsub: pubsub, pubsub_meta: pubsub_meta} do
         self = self()
 
-        :ok = pubsub.track(pubsub, "topic", :key1)
-        :ok = pubsub.track(pubsub, "topic", :key2)
+        :ok = pubsub.track(pubsub_meta, "topic", :key1)
+        :ok = pubsub.track(pubsub_meta, "topic", :key2)
 
-        assert [{:key1, ^self}, {:key2, ^self}] = pubsub.list(pubsub, "topic")
+        assert [{:key1, ^self}, {:key2, ^self}] = pubsub.list(pubsub_meta, "topic")
       end
 
-      test "should ignore duplicate tracks for existing process", %{pubsub: pubsub} do
+      test "should ignore duplicate tracks for existing process", %{
+        pubsub: pubsub,
+        pubsub_meta: pubsub_meta
+      } do
         self = self()
 
-        :ok = pubsub.track(pubsub, "topic", :key)
-        :ok = pubsub.track(pubsub, "topic", :key)
-        :ok = pubsub.track(pubsub, "topic", :key)
+        :ok = pubsub.track(pubsub_meta, "topic", :key)
+        :ok = pubsub.track(pubsub_meta, "topic", :key)
+        :ok = pubsub.track(pubsub_meta, "topic", :key)
 
-        assert [{:key, ^self}] = pubsub.list(pubsub, "topic")
+        assert [{:key, ^self}] = pubsub.list(pubsub_meta, "topic")
       end
     end
   end

--- a/test/registration/local_registry_test.exs
+++ b/test/registration/local_registry_test.exs
@@ -1,6 +1,7 @@
 defmodule Commanded.LocalRegistryTest do
+  alias Commanded.DefaultApp
   alias Commanded.RegistrationTestCase
   alias Commanded.Registration.LocalRegistry
 
-  use RegistrationTestCase, registry: LocalRegistry
+  use RegistrationTestCase, application: DefaultApp, registry: LocalRegistry
 end

--- a/test/registration/support/registered_supervisor.ex
+++ b/test/registration/support/registered_supervisor.ex
@@ -4,15 +4,15 @@ defmodule Commanded.Registration.RegisteredSupervisor do
   alias Commanded.Registration
   alias Commanded.Registration.RegisteredServer
 
-  def start_link do
-    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  def start_link(arg) do
+    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   def start_child(application, name) do
     Registration.start_child(application, name, __MODULE__, {RegisteredServer, []})
   end
 
-  def init(:ok) do
+  def init(_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/test/registration/support/registration_test_case.ex
+++ b/test/registration/support/registration_test_case.ex
@@ -2,60 +2,60 @@ defmodule Commanded.RegistrationTestCase do
   import Commanded.SharedTestCase
 
   define_tests do
-    alias Commanded.DefaultApp
     alias Commanded.Registration
     alias Commanded.Registration.{RegisteredServer, RegisteredSupervisor}
 
-    setup do
-      start_supervised!(DefaultApp)
-
-      {:ok, supervisor} = RegisteredSupervisor.start_link()
+    setup %{application: application} do
+      start_supervised!(application)
+      supervisor = start_supervised!(RegisteredSupervisor)
 
       [supervisor: supervisor]
     end
 
     describe "`start_child/3`" do
-      test "should return child process PID on success" do
-        assert {:ok, _pid} = RegisteredSupervisor.start_child(DefaultApp, "child")
+      test "should return child process PID on success", %{application: application} do
+        assert {:ok, _pid} = RegisteredSupervisor.start_child(application, "child")
       end
 
-      test "should return existing child process when already started" do
-        assert {:ok, pid} = RegisteredSupervisor.start_child(DefaultApp, "child")
-        assert {:ok, ^pid} = RegisteredSupervisor.start_child(DefaultApp, "child")
+      test "should return existing child process when already started", %{
+        application: application
+      } do
+        assert {:ok, pid} = RegisteredSupervisor.start_child(application, "child")
+        assert {:ok, ^pid} = RegisteredSupervisor.start_child(application, "child")
       end
     end
 
     describe "`start_link/3`" do
-      test "should return process PID on success" do
-        assert {:ok, pid} = start_link("registered")
+      test "should return process PID on success", %{application: application} do
+        assert {:ok, pid} = start_link(application, "registered")
         assert is_pid(pid)
       end
 
-      test "should return existing process when already started" do
-        assert {:ok, pid} = start_link("registered")
-        assert {:ok, ^pid} = start_link("registered")
+      test "should return existing process when already started", %{application: application} do
+        assert {:ok, pid} = start_link(application, "registered")
+        assert {:ok, ^pid} = start_link(application, "registered")
       end
     end
 
     describe "`whereis_name/1`" do
-      test "should return `:undefined` when not registered" do
-        assert Registration.whereis_name(DefaultApp, "notregistered") == :undefined
+      test "should return `:undefined` when not registered", %{application: application} do
+        assert Registration.whereis_name(application, "notregistered") == :undefined
       end
 
-      test "should return `PID` when child registered" do
-        assert {:ok, pid} = RegisteredSupervisor.start_child(DefaultApp, "child")
-        assert Registration.whereis_name(DefaultApp, "child") == pid
+      test "should return `PID` when child registered", %{application: application} do
+        assert {:ok, pid} = RegisteredSupervisor.start_child(application, "child")
+        assert Registration.whereis_name(application, "child") == pid
       end
 
-      test "should return `PID` when process registered" do
-        assert {:ok, pid} = start_link("registered")
-        assert Registration.whereis_name(DefaultApp, "registered") == pid
+      test "should return `PID` when process registered", %{application: application} do
+        assert {:ok, pid} = start_link(application, "registered")
+        assert Registration.whereis_name(application, "registered") == pid
       end
     end
 
     describe "`supervisor_child_spec/2`" do
-      test "should return a valid child_spec" do
-        assert Registration.supervisor_child_spec(DefaultApp, RegisteredSupervisor, "child") ==
+      test "should return a valid child_spec", %{application: application} do
+        assert Registration.supervisor_child_spec(application, RegisteredSupervisor, "child") ==
                  %{
                    id: Commanded.Registration.RegisteredSupervisor,
                    start: {Commanded.Registration.RegisteredSupervisor, :start_link, ["child"]},
@@ -64,8 +64,8 @@ defmodule Commanded.RegistrationTestCase do
       end
     end
 
-    defp start_link(name) do
-      Registration.start_link(DefaultApp, name, RegisteredServer, [])
+    defp start_link(application, name) do
+      Registration.start_link(application, name, RegisteredServer, [])
     end
   end
 end

--- a/test/support/mock_event_store_case.ex
+++ b/test/support/mock_event_store_case.ex
@@ -19,7 +19,7 @@ defmodule Commanded.MockEventStoreCase do
   setup do
     set_mox_global()
 
-    expect(MockEventStore, :child_spec, fn _event_store, _config -> [] end)
+    expect(MockEventStore, :child_spec, fn _event_store, _config -> {:ok, [], %{}} end)
 
     start_supervised!(MockedApp)
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,2 +1,2 @@
-Mox.defmock(Commanded.EventStore.Adapters.Mock, for: Commanded.EventStore)
+Mox.defmock(Commanded.EventStore.Adapters.Mock, for: Commanded.EventStore.Adapter)
 Mox.defmock(Commanded.Commands.MockRouter, for: Commanded.Commands.Router)


### PR DESCRIPTION
Rename `Commanded.EventStore` behaviour to `Commanded.EventStore.Adapter`, `Commanded.PubSub` to `Commanded.PubSub.Adapter` and `Commanded.Registration` behaviour to `Commanded.Registration.Adapter`.

The three adapters are dynamically configured at runtime.