### PR TITLE
Fixes the typespec for command dispatch

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -36,9 +36,14 @@ defmodule Commanded.Commands.Dispatcher do
   @doc """
   Dispatch the given command to the handler module for the aggregate as identified
 
-  Returns `:ok` on success, or `{:error, error}` on failure.
+  Returns `:ok`, `{:ok, aggregate_version}` or 
+  `{:ok, %Commanded.Commands.ExecutionResult{}}` on success, or `{:error, error}`
+  on failure.
   """
-  @spec dispatch(payload :: struct) :: :ok | {:error, error :: term}
+  @spec dispatch(payload :: struct) :: :ok |
+    {:ok, Commanded.Commands.ExecutionResult.t()} |
+    {:ok, aggregate_version :: integer()} |
+    {:error, error :: term}
   def dispatch(%Payload{} = payload) do
     pipeline =
       payload


### PR DESCRIPTION
When running Dialyxir on a project that dispatches commands with either the `include_execution_result: true` or `include_aggregate_version: true` options set, an error would be encountered due to the incomplete typespec on the `Commanded.Commands.Dispatcher.dispatch/1` function. This change simply updates the documentation and the typespec to match the actual implementation. It is a nonfunctional change.