### PR TITLE
Command dispatch return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Dynamic Commanded applications ([#324](https://github.com/commanded/commanded/pull/324)).
+- Command dispatch return ([#331](https://github.com/commanded/commanded/pull/331)).
 
 ### Bug fixes
 

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -185,8 +185,9 @@ defmodule Commanded.Application do
   """
   @callback dispatch(command :: struct, timeout_or_opts :: integer | :infinity | Keyword.t()) ::
               :ok
-              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
+              | {:ok, aggregate_state :: struct}
               | {:ok, aggregate_version :: non_neg_integer()}
+              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
               | {:error, :unregistered_command}
               | {:error, :consistency_timeout}
               | {:error, reason :: term}

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -48,6 +48,7 @@ defmodule Commanded.Aggregates.Aggregate do
   require Logger
 
   alias Commanded.Aggregates.{Aggregate, ExecutionContext}
+  alias Commanded.Commands.ExecutionResult
   alias Commanded.Event.Mapper
   alias Commanded.Event.Upcast
   alias Commanded.EventStore
@@ -227,15 +228,17 @@ defmodule Commanded.Aggregates.Aggregate do
 
     lifespan_timeout =
       case reply do
-        {:ok, _stream_version, []} ->
+        {:ok, []} ->
           aggregate_lifespan_timeout(lifespan, :after_command, command)
 
-        {:ok, _stream_version, events} ->
+        {:ok, events} ->
           aggregate_lifespan_timeout(lifespan, :after_event, events)
 
         {:error, error} ->
           aggregate_lifespan_timeout(lifespan, :after_error, error)
       end
+
+    reply = ExecutionContext.reply(context, reply, state)
 
     state = %Aggregate{state | lifespan_timeout: lifespan_timeout}
 
@@ -447,56 +450,31 @@ defmodule Commanded.Aggregates.Aggregate do
 
     Logger.debug(fn -> describe(state) <> " executing command: #{inspect(command)}" end)
 
-    {reply, state} =
-      case Kernel.apply(handler, function, [aggregate_state, command]) do
-        {:error, _error} = reply ->
-          {reply, state}
+    case Kernel.apply(handler, function, [aggregate_state, command]) do
+      {:error, _error} = reply ->
+        {reply, state}
 
-        none when none in [:ok, nil, []] ->
-          {{:ok, expected_version, []}, state}
+      none when none in [:ok, nil, []] ->
+        {{:ok, []}, state}
 
-        %Commanded.Aggregate.Multi{} = multi ->
-          case Commanded.Aggregate.Multi.run(multi) do
-            {:error, _error} = reply ->
-              {reply, state}
-
-            {aggregate_state, pending_events} ->
-              persist_events(pending_events, aggregate_state, context, state)
-          end
-
-        {:ok, pending_events} ->
-          record_events(pending_events, context, state)
-
-        pending_events ->
-          record_events(pending_events, context, state)
-      end
-
-    case reply do
-      {:error, :wrong_expected_version} ->
-        # Fetch missing events from event store
-        state = rebuild_from_events(state)
-
-        # Retry command if there are any attempts left
-        case ExecutionContext.retry(context) do
-          {:ok, context} ->
-            Logger.debug(fn -> describe(state) <> " wrong expected version, retrying command" end)
-
-            execute_command(context, state)
-
-          reply ->
-            Logger.debug(fn ->
-              describe(state) <> " wrong expected version, but not retrying command"
-            end)
-
+      %Commanded.Aggregate.Multi{} = multi ->
+        case Commanded.Aggregate.Multi.run(multi) do
+          {:error, _error} = reply ->
             {reply, state}
+
+          {aggregate_state, pending_events} ->
+            persist_events(pending_events, aggregate_state, context, state)
         end
 
-      reply ->
-        {reply, state}
+      {:ok, pending_events} ->
+        apply_and_persist_events(pending_events, context, state)
+
+      pending_events ->
+        apply_and_persist_events(pending_events, context, state)
     end
   end
 
-  defp record_events(pending_events, context, %Aggregate{} = state) do
+  defp apply_and_persist_events(pending_events, context, %Aggregate{} = state) do
     %Aggregate{aggregate_module: aggregate_module, aggregate_state: aggregate_state} = state
 
     pending_events = List.wrap(pending_events)
@@ -521,8 +499,27 @@ defmodule Commanded.Aggregates.Aggregate do
           aggregate_version: aggregate_version
       }
 
-      {{:ok, aggregate_version, pending_events}, state}
+      {{:ok, pending_events}, state}
     else
+      {:error, :wrong_expected_version} ->
+        # Fetch missing events from event store
+        state = rebuild_from_events(state)
+
+        # Retry command if there are any attempts left
+        case ExecutionContext.retry(context) do
+          {:ok, context} ->
+            Logger.debug(fn -> describe(state) <> " wrong expected version, retrying command" end)
+
+            execute_command(context, state)
+
+          reply ->
+            Logger.debug(fn ->
+              describe(state) <> " wrong expected version, but not retrying command"
+            end)
+
+            {reply, state}
+        end
+
       {:error, _error} = reply ->
         {reply, state}
     end

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -47,12 +47,13 @@ defmodule Commanded.Aggregates.Aggregate do
 
   require Logger
 
-  alias Commanded.Aggregates.{Aggregate, ExecutionContext}
-  alias Commanded.Commands.ExecutionResult
+  alias Commanded.Aggregates.Aggregate
+  alias Commanded.Aggregates.ExecutionContext
   alias Commanded.Event.Mapper
   alias Commanded.Event.Upcast
   alias Commanded.EventStore
-  alias Commanded.EventStore.{RecordedEvent, SnapshotData}
+  alias Commanded.EventStore.RecordedEvent
+  alias Commanded.EventStore.SnapshotData
   alias Commanded.Registration
   alias Commanded.Snapshotting
 
@@ -238,7 +239,7 @@ defmodule Commanded.Aggregates.Aggregate do
           aggregate_lifespan_timeout(lifespan, :after_error, error)
       end
 
-    reply = ExecutionContext.reply(context, reply, state)
+    reply = ExecutionContext.format_reply(reply, context, state)
 
     state = %Aggregate{state | lifespan_timeout: lifespan_timeout}
 
@@ -446,7 +447,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
   defp execute_command(%ExecutionContext{} = context, %Aggregate{} = state) do
     %ExecutionContext{command: command, handler: handler, function: function} = context
-    %Aggregate{aggregate_version: expected_version, aggregate_state: aggregate_state} = state
+    %Aggregate{aggregate_state: aggregate_state} = state
 
     Logger.debug(fn -> describe(state) <> " executing command: #{inspect(command)}" end)
 

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -43,8 +43,8 @@ defmodule Commanded.Aggregates.ExecutionContext do
     :correlation_id,
     :function,
     :handler,
-    :returning,
     retry_attempts: 0,
+    returning: false,
     lifespan: DefaultLifespan,
     metadata: %{}
   ]
@@ -91,7 +91,7 @@ defmodule Commanded.Aggregates.ExecutionContext do
 
           {:ok, aggregate_version, events, result}
 
-        nil ->
+        false ->
           {:ok, aggregate_version, events}
       end
     end

--- a/lib/commanded/commands/execution_result.ex
+++ b/lib/commanded/commands/execution_result.ex
@@ -13,10 +13,10 @@ defmodule Commanded.Commands.ExecutionResult do
     - `aggregate_version` - resultant version of the aggregate after executing
       the command.
 
-    - `events` - a list of the created events, may be an empty list.
+    - `events` - a list of the created events, it may be an empty list.
 
-    - `metadata` - an optional map containing the metadata associated with the
-      command dispatch.
+    - `metadata` - an map containing the metadata associated with the command
+      dispatch.
 
   """
 

--- a/lib/commanded/commands/execution_result.ex
+++ b/lib/commanded/commands/execution_result.ex
@@ -1,30 +1,40 @@
 defmodule Commanded.Commands.ExecutionResult do
   @moduledoc """
-  Contains the events and metadata created by a command succesfully executed
-  against an aggregate.
+  Contains the aggregate, events, and metadata created by a successfully
+  executed command.
 
   The available fields are:
 
-  - `aggregate_uuid` - identity of the aggregate instance.
-  - `aggregate_version` - resultant version of the aggregate after executing
-    the command.
-  - `events` - a list of the created events, may be an empty list.
-  - `metadata` - an optional map containing the metadata associated with the
-    command dispatch.
+    - `aggregate_uuid` - identity of the aggregate instance.
+
+    - `aggregate_state` - resultant state of the aggregate after executing
+      the command.
+
+    - `aggregate_version` - resultant version of the aggregate after executing
+      the command.
+
+    - `events` - a list of the created events, may be an empty list.
+
+    - `metadata` - an optional map containing the metadata associated with the
+      command dispatch.
 
   """
 
   @type t :: %__MODULE__{
-    aggregate_uuid: String.t,
-    aggregate_version: non_neg_integer(),
-    events: list(struct()),
-    metadata: struct(),
-  }
+          aggregate_uuid: String.t(),
+          aggregate_state: struct,
+          aggregate_version: non_neg_integer(),
+          events: list(struct()),
+          metadata: struct()
+        }
+
+  @enforce_keys [:aggregate_uuid, :aggregate_state, :aggregate_version, :events, :metadata]
 
   defstruct [
-    aggregate_uuid: nil,
-    aggregate_version: nil,
-    events: nil,
-    metadata: nil,
+    :aggregate_uuid,
+    :aggregate_state,
+    :aggregate_version,
+    :events,
+    :metadata
   ]
 end

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -122,7 +122,7 @@ defmodule Commanded.Commands.Router do
   ## Dispatch return
 
   By default a successful command dispatch will return `:ok`. You can change
-  this behaviour by specifying a `return` option.
+  this behaviour by specifying a `returning` option.
 
     - `:aggregate_state` - to return the update aggregate state.
     - `:aggregate_version` - to return only the aggregate version.
@@ -133,9 +133,9 @@ defmodule Commanded.Commands.Router do
   ### Aggregate state
 
   Return the updated aggregate state as part of the dispatch result by setting
-  `return: :aggregate_state`:
+  `returning: :aggregate_state`:
 
-      {:ok, %BankAccount{}} = BankApp.dispatch(command, return: :aggregate_state)
+      {:ok, %BankAccount{}} = BankApp.dispatch(command, returning: :aggregate_state)
 
   This is useful when you want to return immediately fields from the aggregate's
   state without requiring an read model projection and waiting for the event(s)
@@ -149,9 +149,9 @@ defmodule Commanded.Commands.Router do
   ### Aggregate version
 
   You can optionally choose to include the aggregate's version as part of the
-  dispatch result by setting `return: :aggregate_version`:
+  dispatch result by setting `returning: :aggregate_version`:
 
-      {:ok, aggregate_version} = BankApp.dispatch(command, return: :aggregate_version)
+      {:ok, aggregate_version} = BankApp.dispatch(command, returning: :aggregate_version)
 
   This is useful when you need to wait for an event handler, such as a read model
   projection, to be up-to-date before querying its data.
@@ -159,11 +159,11 @@ defmodule Commanded.Commands.Router do
   ### Execution results
 
   You can also choose to include the execution result as part of the dispatch
-  result by setting `return: :execution_result`:
+  result by setting `returning: :execution_result`:
 
       alias Commanded.Commands.ExecutionResult
 
-      {:ok, %ExecutionResult{} = result} = BankApp.dispatch(command, return: :execution_result)
+      {:ok, %ExecutionResult{} = result} = BankApp.dispatch(command, returning: :execution_result)
 
   Or by setting the `default_dispatch_return` in your application config file:
 
@@ -204,7 +204,7 @@ defmodule Commanded.Commands.Router do
           Commanded.Middleware.ConsistencyGuarantee
         ],
         consistency: get_env(:default_consistency, :eventual),
-        return: get_default_return(),
+        returning: get_default_return(),
         dispatch_timeout: 5_000,
         lifespan: Commanded.Aggregates.DefaultLifespan,
         metadata: %{},
@@ -430,14 +430,14 @@ defmodule Commanded.Commands.Router do
         metadata = Keyword.get(opts, :metadata) || @default[:metadata]
         timeout = Keyword.get(opts, :timeout) || unquote(timeout) || @default[:dispatch_timeout]
 
-        return =
+        returning =
           cond do
-            (return = Keyword.get(opts, :return)) in [
+            (returning = Keyword.get(opts, :returning)) in [
               :aggregate_state,
               :aggregate_version,
               :execution_result
             ] ->
-              return
+              returning
 
             Keyword.get(opts, :include_execution_result) == true ->
               :execution_result
@@ -446,7 +446,7 @@ defmodule Commanded.Commands.Router do
               :aggregate_version
 
             true ->
-              @default[:return]
+              @default[:returning]
           end
 
         lifespan = Keyword.get(opts, :lifespan) || unquote(lifespan) || @default[:lifespan]
@@ -479,7 +479,7 @@ defmodule Commanded.Commands.Router do
           aggregate_module: unquote(aggregate),
           identity: identity,
           identity_prefix: identity_prefix,
-          return: return,
+          returning: returning,
           timeout: timeout,
           lifespan: lifespan,
           metadata: metadata,
@@ -541,7 +541,7 @@ defmodule Commanded.Commands.Router do
             the metadata to be associated with all events created by the
             command.
 
-          - `return` - to choose what response is returned from a successful
+          - `returning` - to choose what response is returned from a successful
               command dispatch. The default is to return an `:ok`.
 
               The available options are:
@@ -559,8 +559,8 @@ defmodule Commanded.Commands.Router do
 
           - `timeout` - as described above.
 
-      Returns `:ok` on success unless the `:return` option is specified where
-      it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}` or
+      Returns `:ok` on success unless the `:returning` option is specified where
+      it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}`, or
       `{:ok, %Commanded.Commands.ExecutionResult{}}`.
 
       Returns `{:error, reason}` on failure.

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -183,7 +183,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       commands ->
         # Copy event id, as causation id, and correlation id from handled event.
-        opts = [causation_id: event_id, correlation_id: correlation_id]
+        opts = [causation_id: event_id, correlation_id: correlation_id, returning: false]
 
         with :ok <- commands |> List.wrap() |> dispatch_commands(opts, state, event) do
           process_state = mutate_state(event, state)
@@ -298,10 +298,6 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
     case Application.dispatch(application, command, opts) do
       :ok ->
-        dispatch_commands(pending_commands, opts, state, last_event)
-
-      # When `include_execution_result` is set to true (globally), the dispatcher returns an :ok tuple
-      {:ok, _result} ->
         dispatch_commands(pending_commands, opts, state, last_event)
 
       error ->

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -84,8 +84,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         :ok
       end)
 
-      assert {:ok, 3, _events} =
-               Aggregate.execute(MockedApp, BankAccount, account_number, context)
+      assert {:ok, 3} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       assert Aggregate.aggregate_version(MockedApp, BankAccount, account_number) == 3
 
@@ -96,10 +95,8 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
              }
     end
 
-    test "should error after too many attempts", context do
-      %{account_number: account_number} = context
-
-      # fail to append to stream
+    test "should error after too many attempts", %{account_number: account_number} do
+      # Fail to append to stream
       expect(MockEventStore, :append_to_stream, 6, fn _event_store_meta,
                                                       ^account_number,
                                                       1,
@@ -160,7 +157,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         retry_attempts: 1
       }
 
-      {:ok, 1, _events} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
+      {:ok, 1} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       [
         account_number: account_number

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -84,7 +84,8 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         :ok
       end)
 
-      assert {:ok, 3} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
+      assert {:ok, 3, _events} =
+               Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       assert Aggregate.aggregate_version(MockedApp, BankAccount, account_number) == 3
 
@@ -157,7 +158,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         retry_attempts: 1
       }
 
-      {:ok, 1} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
+      {:ok, 1, _events} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       [
         account_number: account_number

--- a/test/aggregates/execute_command_test.exs
+++ b/test/aggregates/execute_command_test.exs
@@ -26,7 +26,7 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
 
     {:ok, 1, events} = Aggregate.execute(BankApp, BankAccount, account_number, context)
 
-    assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1000}]
+    assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1_000}]
 
     shutdown_aggregate(BankApp, BankAccount, account_number)
 
@@ -52,11 +52,11 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
 
     {:ok, 1, events} = Aggregate.execute(BankApp, BankAccount, account_number, context)
 
-    assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1000}]
+    assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1_000}]
 
     shutdown_aggregate(BankApp, BankAccount, account_number)
 
-    # reload aggregate to fetch persisted events from event store and rebuild state by applying saved events
+    # Reload aggregate to fetch persisted events from event store and rebuild state by applying saved events
     {:ok, ^account_number} = open_aggregate(BankAccount, account_number)
 
     assert Aggregate.aggregate_version(BankApp, BankAccount, account_number) == 1

--- a/test/commands/dispatch_consistency_test.exs
+++ b/test/commands/dispatch_consistency_test.exs
@@ -23,7 +23,6 @@ defmodule Commanded.Commands.DispatchConsistencyTest do
   setup do
     start_supervised!(DefaultApp)
     start_supervised!(ConsistencyApp)
-
     :ok
   end
 

--- a/test/commands/dispatch_return_test.exs
+++ b/test/commands/dispatch_return_test.exs
@@ -15,6 +15,14 @@ defmodule Commanded.Commands.DispatchReturnTest do
     :ok
   end
 
+  describe "dispatch return nothing" do
+    test "should return aggregate's updated state" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
+
+      assert :ok == BankApp.dispatch(command, returning: false)
+    end
+  end
+
   describe "dispatch return aggregate state" do
     test "should return aggregate's updated state" do
       assert {:ok, %BankAccount{account_number: "ACC123", balance: 1_000, state: :active}} ==
@@ -109,6 +117,43 @@ defmodule Commanded.Commands.DispatchReturnTest do
                    metadata: metadata
                  }
                }
+    end
+  end
+
+  describe "application dispatch return aggregate state" do
+    alias Commanded.Commands.DefaultDispatchReturnApp
+
+    setup do
+      start_supervised!(DefaultDispatchReturnApp)
+      :ok
+    end
+
+    test "should return aggregate's updated version" do
+      assert {:ok, 1} ==
+               DefaultDispatchReturnApp.dispatch(%OpenAccount{
+                 account_number: "ACC123",
+                 initial_balance: 1_000
+               })
+
+      assert {:ok, 2} ==
+               DefaultDispatchReturnApp.dispatch(%DepositMoney{
+                 account_number: "ACC123",
+                 amount: 100
+               })
+    end
+
+    test "should allow default to be overridden during dispatch" do
+      assert {:ok, 1} ==
+               DefaultDispatchReturnApp.dispatch(%OpenAccount{
+                 account_number: "ACC123",
+                 initial_balance: 1_000
+               })
+
+      assert {:ok, 2} ==
+               DefaultDispatchReturnApp.dispatch(%DepositMoney{
+                 account_number: "ACC123",
+                 amount: 100
+               })
     end
   end
 end

--- a/test/commands/dispatch_return_test.exs
+++ b/test/commands/dispatch_return_test.exs
@@ -20,13 +20,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
       assert {:ok, %BankAccount{account_number: "ACC123", balance: 1_000, state: :active}} ==
                BankApp.dispatch(
                  %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
-                 return: :aggregate_state
+                 returning: :aggregate_state
                )
 
       assert {:ok, %BankAccount{account_number: "ACC123", balance: 1_100, state: :active}} ==
                BankApp.dispatch(
                  %DepositMoney{account_number: "ACC123", amount: 100},
-                 return: :aggregate_state
+                 returning: :aggregate_state
                )
     end
   end
@@ -36,13 +36,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
       assert {:ok, 1} ==
                BankApp.dispatch(
                  %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
-                 return: :aggregate_version
+                 returning: :aggregate_version
                )
 
       assert {:ok, 2} ==
                BankApp.dispatch(
                  %DepositMoney{account_number: "ACC123", amount: 100},
-                 return: :aggregate_version
+                 returning: :aggregate_version
                )
     end
   end
@@ -52,13 +52,18 @@ defmodule Commanded.Commands.DispatchReturnTest do
       metadata = %{"ip_address" => "127.0.0.1"}
       command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
 
-      assert BankApp.dispatch(command, metadata: metadata, return: :execution_result) ==
+      assert BankApp.dispatch(command, metadata: metadata, returning: :execution_result) ==
                {
                  :ok,
                  %ExecutionResult{
                    aggregate_uuid: "ACC123",
+                   aggregate_state: %BankAccount{
+                     account_number: "ACC123",
+                     balance: 1_000,
+                     state: :active
+                   },
                    aggregate_version: 1,
-                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1000}],
+                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}],
                    metadata: metadata
                  }
                }
@@ -94,8 +99,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
                  :ok,
                  %ExecutionResult{
                    aggregate_uuid: "ACC123",
+                   aggregate_state: %BankAccount{
+                     account_number: "ACC123",
+                     balance: 1_000,
+                     state: :active
+                   },
                    aggregate_version: 1,
-                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1000}],
+                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}],
                    metadata: metadata
                  }
                }

--- a/test/commands/dispatch_return_test.exs
+++ b/test/commands/dispatch_return_test.exs
@@ -15,11 +15,18 @@ defmodule Commanded.Commands.DispatchReturnTest do
     :ok
   end
 
-  describe "dispatch return nothing" do
-    test "should return aggregate's updated state" do
+  describe "dispatch return disabled" do
+    test "should return `:ok`" do
       command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
 
       assert :ok == BankApp.dispatch(command, returning: false)
+    end
+
+    test "should return an error on failure" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: -1}
+
+      assert {:error, :invalid_initial_balance} ==
+               BankApp.dispatch(command, returning: false)
     end
   end
 
@@ -37,6 +44,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
                  returning: :aggregate_state
                )
     end
+
+    test "should return an error on failure" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: -1}
+
+      assert {:error, :invalid_initial_balance} ==
+               BankApp.dispatch(command, returning: :aggregate_state)
+    end
   end
 
   describe "dispatch return aggregate version" do
@@ -52,6 +66,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
                  %DepositMoney{account_number: "ACC123", amount: 100},
                  returning: :aggregate_version
                )
+    end
+
+    test "should return an error on failure" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: -1}
+
+      assert {:error, :invalid_initial_balance} ==
+               BankApp.dispatch(command, returning: :aggregate_version)
     end
   end
 
@@ -75,6 +96,13 @@ defmodule Commanded.Commands.DispatchReturnTest do
                    metadata: metadata
                  }
                }
+    end
+
+    test "should return an error on failure" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: -1}
+
+      assert {:error, :invalid_initial_balance} ==
+               BankApp.dispatch(command, returning: :execution_result)
     end
   end
 

--- a/test/commands/dispatch_return_test.exs
+++ b/test/commands/dispatch_return_test.exs
@@ -1,0 +1,104 @@
+defmodule Commanded.Commands.DispatchReturnTest do
+  use Commanded.StorageCase
+
+  alias Commanded.Commands.ExecutionResult
+  alias Commanded.ExampleDomain.BankApp
+  alias Commanded.ExampleDomain.BankAccount
+  alias Commanded.ExampleDomain.BankAccount.Commands.DepositMoney
+  alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
+  alias Commanded.Helpers.CommandAuditMiddleware
+
+  setup do
+    start_supervised!(BankApp)
+    start_supervised!(CommandAuditMiddleware)
+    :ok
+  end
+
+  describe "dispatch return aggregate state" do
+    test "should return aggregate's updated state" do
+      assert {:ok, %BankAccount{account_number: "ACC123", balance: 1_000, state: :active}} ==
+               BankApp.dispatch(
+                 %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
+                 return: :aggregate_state
+               )
+
+      assert {:ok, %BankAccount{account_number: "ACC123", balance: 1_100, state: :active}} ==
+               BankApp.dispatch(
+                 %DepositMoney{account_number: "ACC123", amount: 100},
+                 return: :aggregate_state
+               )
+    end
+  end
+
+  describe "dispatch return aggregate version" do
+    test "should return aggregate's updated version" do
+      assert {:ok, 1} ==
+               BankApp.dispatch(
+                 %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
+                 return: :aggregate_version
+               )
+
+      assert {:ok, 2} ==
+               BankApp.dispatch(
+                 %DepositMoney{account_number: "ACC123", amount: 100},
+                 return: :aggregate_version
+               )
+    end
+  end
+
+  describe "dispatch return execution result" do
+    test "should return created events" do
+      metadata = %{"ip_address" => "127.0.0.1"}
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
+
+      assert BankApp.dispatch(command, metadata: metadata, return: :execution_result) ==
+               {
+                 :ok,
+                 %ExecutionResult{
+                   aggregate_uuid: "ACC123",
+                   aggregate_version: 1,
+                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1000}],
+                   metadata: metadata
+                 }
+               }
+    end
+  end
+
+  describe "dispatch include aggregate version" do
+    test "should return aggregate's updated version" do
+      assert {:ok, 1} ==
+               BankApp.dispatch(
+                 %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
+                 include_aggregate_version: true
+               )
+
+      assert {:ok, 2} ==
+               BankApp.dispatch(
+                 %DepositMoney{account_number: "ACC123", amount: 100},
+                 include_aggregate_version: true
+               )
+    end
+  end
+
+  describe "dispatch include execution result" do
+    test "should return created events" do
+      metadata = %{"ip_address" => "127.0.0.1"}
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
+
+      assert BankApp.dispatch(command,
+               metadata: metadata,
+               include_execution_result: true
+             ) ==
+               {
+                 :ok,
+                 %ExecutionResult{
+                   aggregate_uuid: "ACC123",
+                   aggregate_version: 1,
+                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1000}],
+                   metadata: metadata
+                 }
+               }
+    end
+  end
+end

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -2,19 +2,16 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   use Commanded.StorageCase
 
   alias Commanded.DefaultApp
-  alias Commanded.Commands.{ExecutionResult, UnregisteredCommand}
+  alias Commanded.Commands.UnregisteredCommand
   alias Commanded.EventStore
   alias Commanded.ExampleDomain.BankAccount
-  alias Commanded.ExampleDomain.{OpenAccountHandler, DepositMoneyHandler, WithdrawMoneyHandler}
-
-  alias Commanded.ExampleDomain.BankAccount.Commands.{
-    OpenAccount,
-    CloseAccount,
-    DepositMoney,
-    WithdrawMoney
-  }
-
-  alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
+  alias Commanded.ExampleDomain.OpenAccountHandler
+  alias Commanded.ExampleDomain.DepositMoneyHandler
+  alias Commanded.ExampleDomain.WithdrawMoneyHandler
+  alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.ExampleDomain.BankAccount.Commands.CloseAccount
+  alias Commanded.ExampleDomain.BankAccount.Commands.DepositMoney
+  alias Commanded.ExampleDomain.BankAccount.Commands.WithdrawMoney
 
   @dispatch_opts [application: DefaultApp]
 
@@ -368,24 +365,6 @@ defmodule Commanded.Commands.RoutingCommandsTest do
              )
   end
 
-  describe "include aggregate version" do
-    test "should return aggregate's updated stream version" do
-      assert {:ok, 1} ==
-               MultiCommandHandlerRouter.dispatch(
-                 %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
-                 application: DefaultApp,
-                 include_aggregate_version: true
-               )
-
-      assert {:ok, 2} ==
-               MultiCommandHandlerRouter.dispatch(
-                 %DepositMoney{account_number: "ACC123", amount: 100},
-                 application: DefaultApp,
-                 include_aggregate_version: true
-               )
-    end
-  end
-
   test "should allow setting metadata" do
     metadata = %{"ip_address" => "127.0.0.1"}
 
@@ -409,27 +388,5 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     Enum.each(events, fn event ->
       assert event.metadata == metadata
     end)
-  end
-
-  describe "include execution result" do
-    test "should return created events" do
-      metadata = %{"ip_address" => "127.0.0.1"}
-      command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
-
-      assert MultiCommandHandlerRouter.dispatch(command,
-               application: DefaultApp,
-               metadata: metadata,
-               include_execution_result: true
-             ) ==
-               {
-                 :ok,
-                 %ExecutionResult{
-                   aggregate_uuid: "ACC123",
-                   aggregate_version: 1,
-                   events: [%BankAccountOpened{account_number: "ACC123", initial_balance: 1000}],
-                   metadata: metadata
-                 }
-               }
-    end
   end
 end

--- a/test/commands/support/returning/default_dispatch_return_app.ex
+++ b/test/commands/support/returning/default_dispatch_return_app.ex
@@ -1,0 +1,18 @@
+defmodule Commanded.Commands.DefaultDispatchReturnApp do
+  alias Commanded.ExampleDomain.BankRouter
+
+  use Commanded.Application,
+    otp_app: :commanded,
+    event_store: [
+      adapter: Commanded.EventStore.Adapters.InMemory,
+      serializer: Commanded.Serialization.JsonSerializer
+    ],
+    pubsub: :local,
+    registry: :local,
+    default_dispatch_opts: [
+      consistency: :eventual,
+      returning: :aggregate_version
+    ]
+
+  router(BankRouter)
+end


### PR DESCRIPTION
By default a successful command dispatch will return `:ok`. This pull request allows changing the default behaviour by specifying a `returning` option during command dispatch.

The supported options are:

- `:aggregate_state` - to return the update aggregate state.

- `:aggregate_version` - to return only the aggregate version.

- `:execution_result` - to return a `Commanded.Commands.ExecutionResult`
  struct containing the aggregate's identity, state, version, and any events
  produced from the command along with their associated metadata.

- `false` - don't return anything except an `:ok` (default).

Note this only affects successful command dispatch. If the command dispatch produces an error then it will always be returned, irrespective of the `returning` option.

### Example

```elixir
{:ok, %BankAccount{}} = BankApp.dispatch(command, returning: :aggregate_state)
```