### PR TITLE
Process manager `indentity/0` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,7 @@ Commanded scheduler:
 - Handle custom type serialization in snapshot source type ([#165](https://github.com/commanded/commanded/pull/165)).
 - Fix compiler warnings in generated code (routers, event handlers, and process managers).
 - Add `InMemory.reset!/0` for testing purposes ([#175](https://github.com/commanded/commanded/pull/175)).
+- Process manager `indentity/0` function ([#334](https://github.com/commanded/commanded/pull/334)).
 
 ### Bug fixes
 

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -398,6 +398,33 @@ defmodule Commanded.ProcessManagers.ProcessManager do
     end
   end
 
+  @doc """
+  Get the identity of the current process instance.
+
+  This must only be called within a process manager's `handle/2` or `apply/2`
+  callback function.
+
+  ## Example
+
+      defmodule ExampleProcessManager do
+        use Commanded.ProcessManagers.ProcessManager,
+          application: MyApp.Application,
+          name: __MODULE__
+
+        def interested?(%ProcessStarted{uuids: uuids}), do: {:start, uuids}
+
+        def handle(%IdentityProcessManager{}, %ProcessStarted{} = event) do
+          # Identify which uuid is associated with the current instance from the
+          # list of uuids in the event.
+          uuid = Commanded.ProcessManagers.ProcessManager.identity()
+
+          # ...
+        end
+      end
+
+  """
+  defdelegate identity, to: Commanded.ProcessManagers.ProcessManagerInstance
+
   def compile_config(module, opts) do
     application = Keyword.get(opts, :application)
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -71,6 +71,11 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     GenServer.call(instance, :process_state)
   end
 
+  @doc """
+  Get the current process manager instance's identity.
+  """
+  def identity, do: Process.get(:process_uuid)
+
   @doc false
   @impl GenServer
   def init(%State{} = state) do
@@ -82,10 +87,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   """
   @impl GenServer
   def handle_continue(:fetch_state, %State{} = state) do
-    %State{application: application} = state
+    %State{application: application, process_uuid: process_uuid} = state
 
     state =
-      case EventStore.read_snapshot(application, process_state_uuid(state)) do
+      case EventStore.read_snapshot(application, snapshot_uuid(state)) do
         {:ok, snapshot} ->
           %State{
             state
@@ -96,6 +101,8 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
         {:error, :snapshot_not_found} ->
           state
       end
+
+    Process.put(:process_uuid, process_uuid)
 
     {:noreply, state}
   end
@@ -386,7 +393,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     } = state
 
     snapshot = %SnapshotData{
-      source_uuid: process_state_uuid(state),
+      source_uuid: snapshot_uuid(state),
       source_version: source_version,
       source_type: Atom.to_string(process_manager_module),
       data: process_state
@@ -398,7 +405,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   defp delete_state(%State{} = state) do
     %State{application: application} = state
 
-    EventStore.delete_snapshot(application, process_state_uuid(state))
+    EventStore.delete_snapshot(application, snapshot_uuid(state))
   end
 
   defp ack_event(%RecordedEvent{} = event, %State{} = state) do
@@ -407,11 +414,8 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     ProcessRouter.ack_event(process_router, event, self())
   end
 
-  defp process_state_uuid(%State{} = state) do
-    %State{
-      process_manager_name: process_manager_name,
-      process_uuid: process_uuid
-    } = state
+  defp snapshot_uuid(%State{} = state) do
+    %State{process_manager_name: process_manager_name, process_uuid: process_uuid} = state
 
     inspect(process_manager_name) <> "-" <> inspect(process_uuid)
   end

--- a/test/process_managers/support/identity/identity_process_manager.ex
+++ b/test/process_managers/support/identity/identity_process_manager.ex
@@ -1,0 +1,32 @@
+defmodule Commanded.ProcessManagers.IdentityProcessManager do
+  @moduledoc false
+
+  alias Commanded.DefaultApp
+  alias Commanded.ProcessManagers.IdentityProcessManager
+  alias Commanded.ProcessManagers.ProcessManager
+
+  use Commanded.ProcessManagers.ProcessManager,
+    application: DefaultApp,
+    name: __MODULE__
+
+  @derive Jason.Encoder
+  defstruct [:uuid]
+
+  defmodule AnEvent do
+    defstruct [:uuids, :reply_to]
+  end
+
+  def interested?(%AnEvent{uuids: uuids}), do: {:start, uuids}
+
+  def handle(%IdentityProcessManager{}, %AnEvent{} = event) do
+    %AnEvent{reply_to: reply_to} = event
+
+    uuid = ProcessManager.identity()
+
+    send(reply_to, {:identity, uuid, self()})
+
+    []
+  end
+
+  def apply(%IdentityProcessManager{} = state, _event), do: state
+end


### PR DESCRIPTION
Used to determine the identity of the current process manager instance.

#### Example

```elixir
defmodule ExampleProcessManager do
  use Commanded.ProcessManagers.ProcessManager,
    application: MyApp.Application,
    name: __MODULE__

  def interested?(%ProcessStarted{uuids: uuids}), do: {:start, uuids}

  def handle(%ExampleProcessManager{}, %ProcessStarted{} = event) do
    # Identify which uuid is associated with the current instance from the
    # list of uuids in the event.
    uuid = Commanded.ProcessManagers.ProcessManager.identity()

    # ...
  end
end
```

Fixes #320.