### PR TITLE
Add stacktraces to EventHandler error logging

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -551,7 +551,7 @@ defmodule Commanded.Event.Handler do
   @doc false
   @impl GenServer
   def handle_info(message, state) do
-    Logger.error(fn -> describe(state) <> " received unexpected message: " <> inspect(message) end)
+    Logger.error(fn -> describe(state) <> " received unexpected message: " <> inspect(message, pretty: true) end)
 
     {:noreply, state}
   end
@@ -622,7 +622,7 @@ defmodule Commanded.Event.Handler do
       {:error, reason} = error ->
         Logger.error(fn ->
           describe(state) <>
-            " failed to handle event #{inspect(event)} due to: #{inspect(reason)}"
+            " failed to handle event #{inspect(event, pretty: true)} due to: #{inspect(reason, pretty: true)}"
         end)
 
         handle_event_error(error, event, state, context)
@@ -630,7 +630,7 @@ defmodule Commanded.Event.Handler do
       {:error, reason, stacktrace} ->
         Logger.error(fn ->
           describe(state) <>
-            " failed to handle event #{inspect(event)} due to: #{inspect(reason)}"
+            " failed to handle event #{inspect(event, pretty: true)} due to: #{inspect(reason, pretty: true)}"
         end)
         Logger.error(fn ->  Exception.format(:error, reason, stacktrace) end)
 

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -626,6 +626,15 @@ defmodule Commanded.Event.Handler do
         end)
 
         handle_event_error(error, event, state, context)
+
+      {:error, reason, stacktrace} ->
+        Logger.error(fn ->
+          describe(state) <>
+            " failed to handle event #{inspect(event)} due to: #{inspect(reason)}"
+        end)
+        Logger.error(Exception.format(:error, reason, stacktrace))
+
+        handle_event_error({:error, reason}, event, state, context)
     end
   end
 
@@ -638,7 +647,7 @@ defmodule Commanded.Event.Handler do
     try do
       handler_module.handle(data, metadata)
     rescue
-      e -> {:error, e}
+      e -> {:error, e, __STACKTRACE__}
     end
   end
 

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -551,7 +551,9 @@ defmodule Commanded.Event.Handler do
   @doc false
   @impl GenServer
   def handle_info(message, state) do
-    Logger.error(fn -> describe(state) <> " received unexpected message: " <> inspect(message, pretty: true) end)
+    Logger.error(fn ->
+      describe(state) <> " received unexpected message: " <> inspect(message, pretty: true)
+    end)
 
     {:noreply, state}
   end
@@ -622,7 +624,9 @@ defmodule Commanded.Event.Handler do
       {:error, reason} = error ->
         Logger.error(fn ->
           describe(state) <>
-            " failed to handle event #{inspect(event, pretty: true)} due to: #{inspect(reason, pretty: true)}"
+            " failed to handle event #{inspect(event, pretty: true)} due to: #{
+              inspect(reason, pretty: true)
+            }"
         end)
 
         handle_event_error(error, event, state, context)
@@ -630,9 +634,12 @@ defmodule Commanded.Event.Handler do
       {:error, reason, stacktrace} ->
         Logger.error(fn ->
           describe(state) <>
-            " failed to handle event #{inspect(event, pretty: true)} due to: #{inspect(reason, pretty: true)}"
+            " failed to handle event #{inspect(event, pretty: true)} due to: #{
+              inspect(reason, pretty: true)
+            }"
         end)
-        Logger.error(fn ->  Exception.format(:error, reason, stacktrace) end)
+
+        Logger.error(fn -> Exception.format(:error, reason, stacktrace) end)
 
         handle_event_error({:error, reason}, event, state, context)
     end

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -632,7 +632,7 @@ defmodule Commanded.Event.Handler do
           describe(state) <>
             " failed to handle event #{inspect(event)} due to: #{inspect(reason)}"
         end)
-        Logger.error(Exception.format(:error, reason, stacktrace))
+        Logger.error(fn ->  Exception.format(:error, reason, stacktrace) end)
 
         handle_event_error({:error, reason}, event, state, context)
     end

--- a/test/event/default_event_handler_error_handling_test.exs
+++ b/test/event/default_event_handler_error_handling_test.exs
@@ -29,4 +29,5 @@ defmodule Commanded.Event.DefaultEventHandlerErrorHandlingTest do
     assert_receive {:DOWN, ^ref, _, _, _}
     refute Process.alive?(handler)
   end
+
 end

--- a/test/event/default_event_handler_error_handling_test.exs
+++ b/test/event/default_event_handler_error_handling_test.exs
@@ -29,5 +29,4 @@ defmodule Commanded.Event.DefaultEventHandlerErrorHandlingTest do
     assert_receive {:DOWN, ^ref, _, _, _}
     refute Process.alive?(handler)
   end
-
 end

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -79,9 +79,9 @@ defmodule Commanded.Event.HandleEventTest do
                "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler received unexpected message: :unexpected_message"
     end
 
-
     test "should print the stack trace on errors", %{handler: handler} do
       import ExUnit.CaptureLog
+
       events = [
         %ErrorEvent{}
       ]

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -10,6 +10,7 @@ defmodule Commanded.Event.HandleEventTest do
   alias Commanded.Event.UninterestingEvent
   alias Commanded.Helpers.EventFactory
   alias Commanded.Helpers.Wait
+  alias Commanded.Event.ErrorEvent
   alias Commanded.ExampleDomain.BankApp
   alias Commanded.ExampleDomain.BankAccount.AccountBalanceHandler
   alias Commanded.ExampleDomain.BankAccount.BankAccountHandler
@@ -76,6 +77,29 @@ defmodule Commanded.Event.HandleEventTest do
 
       assert capture_log(send_unexpected_mesage) =~
                "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler received unexpected message: :unexpected_message"
+    end
+
+
+    test "should print the stack trace on errors", %{handler: handler} do
+      import ExUnit.CaptureLog
+      events = [
+        %ErrorEvent{}
+      ]
+
+      ref = Process.monitor(handler)
+
+      recorded_events = EventFactory.map_to_recorded_events(events)
+
+      send_error_message = fn ->
+        send(handler, {:events, recorded_events})
+        assert_receive {:DOWN, ^ref, :process, ^handler, _}
+      end
+
+      captured = capture_log(send_error_message)
+
+      assert captured =~ "(RuntimeError) ErrorEvent occurred"
+      assert captured =~ "test/example_domain/bank_account/account_balance_handler.ex"
+      assert captured =~ "Commanded.ExampleDomain.BankAccount.AccountBalanceHandler.handle/2"
     end
   end
 

--- a/test/event/support/error_event.ex
+++ b/test/event/support/error_event.ex
@@ -1,4 +1,4 @@
 defmodule Commanded.Event.ErrorEvent do
   @moduledoc false
-  defstruct [field: nil]
+  defstruct field: nil
 end

--- a/test/event/support/error_event.ex
+++ b/test/event/support/error_event.ex
@@ -1,0 +1,4 @@
+defmodule Commanded.Event.ErrorEvent do
+  @moduledoc false
+  defstruct [field: nil]
+end

--- a/test/example_domain/bank_account/account_balance_handler.ex
+++ b/test/example_domain/bank_account/account_balance_handler.ex
@@ -8,6 +8,7 @@ defmodule Commanded.ExampleDomain.BankAccount.AccountBalanceHandler do
   alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
   alias Commanded.ExampleDomain.BankAccount.Events.MoneyDeposited
   alias Commanded.ExampleDomain.BankAccount.Events.MoneyWithdrawn
+  alias Commanded.Event.ErrorEvent
 
   def init do
     with {:ok, _pid} <- Agent.start_link(fn -> 0 end, name: __MODULE__) do
@@ -25,6 +26,10 @@ defmodule Commanded.ExampleDomain.BankAccount.AccountBalanceHandler do
 
   def handle(%MoneyWithdrawn{balance: balance}, _metadata) do
     Agent.update(__MODULE__, fn _ -> balance end)
+  end
+
+  def handle(%ErrorEvent{}, _metadata) do
+    raise "ErrorEvent occurred"
   end
 
   def subscribed? do

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -49,6 +49,11 @@ defmodule Commanded.ExampleDomain.BankAccount do
       @derive Jason.Encoder
       defstruct [:account_number]
     end
+
+    defmodule BankAccountClosed do
+      @derive Jason.Encoder
+      defstruct [:account_number]
+    end
   end
 
   alias Commands.OpenAccount


### PR DESCRIPTION
### Issue
#303 

### Description
This PR logs the stacktrace when a user-written EventHandler raises an error. 

Note that I hacked in a test scenario, there might be a better way of doing that. I'm open to suggestions.

<img width="1649" alt="Screen Shot 2020-02-16 at 9 35 45 AM" src="https://user-images.githubusercontent.com/1019721/74606739-ef6b5680-50a0-11ea-84c8-5e2c1ae388a9.png">
