### PR TITLE
Run the formatter in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ otp_release:
 
 script:
   - mix test
+  - mix format --check-formatted
   - travis_wait 30 mix dialyzer --halt-exit-status

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   - deps
 
 elixir:
-  - 1.9.4
+  - 1.10.1
 
 otp_release:
   - 22.0

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/commanded/event_store/type_provider.ex
+++ b/lib/commanded/event_store/type_provider.ex
@@ -4,7 +4,7 @@ defmodule Commanded.EventStore.TypeProvider do
   """
 
   @type t :: module
-  @type type :: String.t
+  @type type :: String.t()
 
   @doc """
   Type of the given Elixir struct as a string
@@ -29,6 +29,10 @@ defmodule Commanded.EventStore.TypeProvider do
   """
   @spec type_provider() :: module()
   def type_provider do
-    Application.get_env(:commanded, :type_provider, Commanded.Serialization.ModuleNameTypeProvider)
+    Application.get_env(
+      :commanded,
+      :type_provider,
+      Commanded.Serialization.ModuleNameTypeProvider
+    )
   end
 end

--- a/test/commands/support/aggregate_root.ex
+++ b/test/commands/support/aggregate_root.ex
@@ -2,9 +2,9 @@ defmodule Commanded.Commands.AggregateRoot do
   @moduledoc false
   alias Commanded.Commands.AggregateRoot
 
-  defmodule Command, do: defstruct [uuid: nil]
+  defmodule Command, do: defstruct(uuid: nil)
 
-  defstruct [uuid: nil]
+  defstruct uuid: nil
 
   def execute(%AggregateRoot{}, %Command{}), do: []
 end

--- a/test/commands/support/command_timeout_handler.ex
+++ b/test/commands/support/command_timeout_handler.ex
@@ -2,7 +2,7 @@ defmodule Commanded.Commands.TimeoutCommandHandler do
   @moduledoc false
   @behaviour Commanded.Commands.Handler
 
-  alias Commanded.Commands.{TimeoutAggregateRoot,TimeoutCommand}
+  alias Commanded.Commands.{TimeoutAggregateRoot, TimeoutCommand}
 
   def handle(%TimeoutAggregateRoot{}, %TimeoutCommand{sleep_in_ms: sleep_in_ms}) do
     :timer.sleep(sleep_in_ms)

--- a/test/commands/support/identity/identity_function_router.ex
+++ b/test/commands/support/identity/identity_function_router.ex
@@ -2,7 +2,7 @@ defmodule Commanded.Commands.IdentityFunctionRouter do
   @moduledoc false
   use Commanded.Commands.Router
 
-  alias Commanded.Commands.{IdentityFunctionAggregate,IdentityFunctionRouter}
+  alias Commanded.Commands.{IdentityFunctionAggregate, IdentityFunctionRouter}
   alias Commanded.Commands.IdentityFunctionAggregate.IdentityFunctionCommand
 
   identify IdentityFunctionAggregate,

--- a/test/commands/support/timeout_command.ex
+++ b/test/commands/support/timeout_command.ex
@@ -1,4 +1,4 @@
 defmodule Commanded.Commands.TimeoutCommand do
   @moduledoc false
-  defstruct [aggregate_uuid: nil, sleep_in_ms: nil]
+  defstruct aggregate_uuid: nil, sleep_in_ms: nil
 end

--- a/test/commands/support/timeout_router.ex
+++ b/test/commands/support/timeout_router.ex
@@ -2,7 +2,11 @@ defmodule Commanded.Commands.TimeoutRouter do
   @moduledoc false
   use Commanded.Commands.Router
 
-  alias Commanded.Commands.{TimeoutAggregateRoot,TimeoutCommandHandler,TimeoutCommand}
+  alias Commanded.Commands.{TimeoutAggregateRoot, TimeoutCommandHandler, TimeoutCommand}
 
-  dispatch TimeoutCommand, to: TimeoutCommandHandler, aggregate: TimeoutAggregateRoot, identity: :aggregate_uuid, timeout: 1_000
+  dispatch TimeoutCommand,
+    to: TimeoutCommandHandler,
+    aggregate: TimeoutAggregateRoot,
+    identity: :aggregate_uuid,
+    timeout: 1_000
 end

--- a/test/commands/support/unregistered_command.ex
+++ b/test/commands/support/unregistered_command.ex
@@ -1,4 +1,4 @@
 defmodule Commanded.Commands.UnregisteredCommand do
   @moduledoc false
-  defstruct [aggregate_uuid: UUID.uuid4]
+  defstruct aggregate_uuid: UUID.uuid4()
 end

--- a/test/event/support/ignored_event.ex
+++ b/test/event/support/ignored_event.ex
@@ -1,4 +1,4 @@
 defmodule Commanded.Event.IgnoredEvent do
   @moduledoc false
-  defstruct [name: nil]
+  defstruct name: nil
 end

--- a/test/event/support/uninteresting_event.ex
+++ b/test/event/support/uninteresting_event.ex
@@ -1,4 +1,4 @@
 defmodule Commanded.Event.UninterestingEvent do
   @moduledoc false
-  defstruct [field: nil]
+  defstruct field: nil
 end

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -1,6 +1,6 @@
 defmodule Commanded.ProcessManagers.ExampleRouter do
   @moduledoc false
-  
+
   use Commanded.Commands.Router
 
   alias Commanded.ProcessManagers.{ExampleAggregate, ExampleCommandHandler}

--- a/test/process_managers/support/resume/resume_command_handler.ex
+++ b/test/process_managers/support/resume/resume_command_handler.ex
@@ -3,7 +3,7 @@ defmodule Commanded.ProcessManagers.ResumeCommandHandler do
   @behaviour Commanded.Commands.Handler
 
   alias Commanded.ProcessManagers.ResumeAggregate
-  alias Commanded.ProcessManagers.ResumeAggregate.Commands.{StartProcess,ResumeProcess}
+  alias Commanded.ProcessManagers.ResumeAggregate.Commands.{StartProcess, ResumeProcess}
 
   def handle(%ResumeAggregate{} = aggregate, %StartProcess{} = start_process) do
     aggregate


### PR DESCRIPTION
This PR makes sure that all code pushed to `commanded` is formatted. I'm initially pushing it up unformatted to show that it works, then I will format and push a second commit.