### PR TITLE
Add the supervisor_child_spec back to the Aggregates supervisor

### DIFF
--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -10,6 +10,11 @@ defmodule Commanded.Aggregates.Supervisor do
   alias Commanded.Aggregates.Aggregate
   alias Commanded.Registration
 
+  def child_spec(arg) do
+    application = Keyword.fetch!(arg, :application)
+    Registration.supervisor_child_spec(application, __MODULE__, arg)
+  end
+
   def start_link(args) do
     application = Keyword.fetch!(args, :application)
     name = Module.concat([application, __MODULE__])


### PR DESCRIPTION
This was deleted somewhere along the way and the horde registry
requires this.