### PR TITLE
`refute_receive_event/4` only tests newly created events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allow `Commanded.Aggregate.Multi` to return events as `:ok` tagged tuples.
 - Run the formatter in CI ([#341](https://github.com/commanded/commanded/pull/341)).
 - Add stacktraces to EventHandler error logging ([#340](https://github.com/commanded/commanded/pull/340))
+- `refute_receive_event/4` only tests newly created events ([#347](https://github.com/commanded/commanded/pull/347)).
 
 ### Bug fixes
 


### PR DESCRIPTION
Subscription is created from `:current` to ensure only events produced by the given function are considered as failing. Any existing events are ignored. The `refute_receive_event/4` macro is also changed to a function.

### Examples

Refute that `ExampleEvent` is produced by given anonymous function:

```elixir
refute_receive_event(ExampleApp, ExampleEvent, fn ->
  :ok = MyApp.dispatch(command)
end)
```

Refute that `ExampleEvent` produced by `some_func/0` function is published to a given stream:

```elixir
refute_receive_event(ExampleApp, ExampleEvent, &some_func/0,
  predicate: fn event -> event.value == 1 end,
  stream: "foo-1234"
)
```
