### PR TITLE
Retry event handler and process manager suscriptions on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - Fix distributed subscription registration bug ([#345](https://github.com/commanded/commanded/pull/345)).
+- Retry event handler and process manager suscriptions on error ([#348](https://github.com/commanded/commanded/pull/348)).
 
 ## v1.0.0
 

--- a/lib/commanded/event_store/recorded_event.ex
+++ b/lib/commanded/event_store/recorded_event.ex
@@ -21,9 +21,9 @@ defmodule Commanded.EventStore.RecordedEvent do
     - `correlation_id` - an optional UUID identifier used to correlate related
       messages.
 
-    - `data` - the serialized event as binary data.
+    - `data` - the event data deserialized into a struct.
 
-    - `metadata` - the serialized event metadata as binary data.
+    - `metadata` - a string keyed map of metadata associated with the event.
 
     - `created_at` - the datetime, in UTC, indicating when the event was
       created.
@@ -40,8 +40,8 @@ defmodule Commanded.EventStore.RecordedEvent do
           causation_id: uuid() | nil,
           correlation_id: uuid() | nil,
           event_type: String.t(),
-          data: binary(),
-          metadata: binary(),
+          data: struct(),
+          metadata: map(),
           created_at: DateTime.t()
         }
 

--- a/lib/commanded/event_store/subscription.ex
+++ b/lib/commanded/event_store/subscription.ex
@@ -1,0 +1,131 @@
+defmodule Commanded.EventStore.Subscription do
+  @moduledoc false
+
+  alias Commanded.EventStore
+  alias Commanded.EventStore
+  alias Commanded.EventStore.RecordedEvent
+  alias Commanded.EventStore.Subscription
+
+  @enforce_keys [:application, :subscribe_to, :subscribe_from, :subscription_name]
+
+  @type t :: %Subscription{
+          application: Commanded.Application.t(),
+          backoff: any(),
+          subscribe_to: EventStore.Adapter.stream_uuid() | :all,
+          subscribe_from: EventStore.Adapter.start_from(),
+          subscription_name: EventStore.Adapter.subscription_name(),
+          subscription_pid: nil | pid(),
+          subscription_ref: nil | reference()
+        }
+
+  defstruct [
+    :application,
+    :backoff,
+    :subscribe_to,
+    :subscribe_from,
+    :subscription_name,
+    :subscription_pid,
+    :subscription_ref
+  ]
+
+  def new(opts) do
+    %Subscription{
+      application: Keyword.fetch!(opts, :application),
+      backoff: init_backoff(),
+      subscription_name: Keyword.fetch!(opts, :subscription_name),
+      subscribe_to: parse_subscribe_to(opts),
+      subscribe_from: parse_subscribe_from(opts)
+    }
+  end
+
+  @spec subscribe(Subscription.t(), pid()) :: {:ok, Subscription.t()} | {:error, any()}
+  def subscribe(%Subscription{} = subscription, pid) do
+    with {:ok, pid} <- subscribe_to(subscription, pid) do
+      subscription_ref = Process.monitor(pid)
+
+      subscription = %Subscription{
+        subscription
+        | subscription_pid: pid,
+          subscription_ref: subscription_ref
+      }
+
+      {:ok, subscription}
+    end
+  end
+
+  @spec backoff(Subscription.t()) :: {non_neg_integer(), Subscription.t()}
+  def backoff(%Subscription{} = subscription) do
+    %Subscription{backoff: backoff} = subscription
+
+    {next, backoff} = :backoff.fail(backoff)
+
+    subscription = %Subscription{subscription | backoff: backoff}
+
+    {next, subscription}
+  end
+
+  @spec ack_event(Subscription.t(), RecordedEvent.t()) :: :ok
+  def ack_event(%Subscription{} = subscription, %RecordedEvent{} = event) do
+    %Subscription{application: application, subscription_pid: subscription_pid} = subscription
+
+    EventStore.ack_event(application, subscription_pid, event)
+  end
+
+  @spec reset(Subscription.t()) :: Subscription.t()
+  def reset(%Subscription{} = subscription) do
+    %Subscription{
+      application: application,
+      subscribe_to: subscribe_to,
+      subscription_name: subscription_name,
+      subscription_pid: subscription_pid,
+      subscription_ref: subscription_ref
+    } = subscription
+
+    Process.demonitor(subscription_ref)
+
+    :ok = EventStore.unsubscribe(application, subscription_pid)
+    :ok = EventStore.delete_subscription(application, subscribe_to, subscription_name)
+
+    %Subscription{
+      subscription
+      | backoff: init_backoff(),
+        subscription_pid: nil,
+        subscription_ref: nil
+    }
+  end
+
+  defp subscribe_to(%Subscription{} = subscription, pid) do
+    %Subscription{
+      application: application,
+      subscribe_to: subscribe_to,
+      subscription_name: subscription_name,
+      subscribe_from: subscribe_from
+    } = subscription
+
+    EventStore.subscribe_to(application, subscribe_to, subscription_name, pid, subscribe_from)
+  end
+
+  defp parse_subscribe_to(opts) do
+    case opts[:subscribe_to] || :all do
+      :all -> :all
+      stream when is_binary(stream) -> stream
+      invalid -> "Invalid `subscribe_to` option: #{inspect(invalid)}"
+    end
+  end
+
+  defp parse_subscribe_from(opts) do
+    case opts[:subscribe_from] || :origin do
+      start_from when start_from in [:origin, :current] -> start_from
+      start_from when is_integer(start_from) -> start_from
+      invalid -> "Invalid `start_from` option: #{inspect(invalid)}"
+    end
+  end
+
+  @backoff_min :timer.seconds(1)
+  @backoff_max :timer.minutes(1)
+
+  # Exponential backoff with jitter
+  defp init_backoff do
+    :backoff.init(@backoff_min, @backoff_max) |> :backoff.type(:jitter)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule Commanded.Mixfile do
 
   defp deps do
     [
+      {:backoff, "~> 1.1"},
       {:elixir_uuid, "~> 1.2"},
 
       # Optional dependencies

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm", "cf0cfff8995fb20562f822e5cc47d8ccf664c5ecdc26a684cbe85c225f9d7c39"},
   "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm", "23f27cbc482cbac03fc8926441eb60a5e111759c17642bac005c3225f5eb809d"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "506294d6c543e4e5282d4852aead19ace8a35bedeb043f9256a06a6336827122"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},

--- a/test/event/event_handler_subscription_test.exs
+++ b/test/event/event_handler_subscription_test.exs
@@ -1,27 +1,24 @@
 defmodule Commanded.Event.EventHandlerSubscriptionTest do
   use Commanded.MockEventStoreCase
 
+  alias Commanded.Event.Handler
+
   defmodule ExampleHandler do
     use Commanded.Event.Handler,
       application: Commanded.MockedApp,
       name: "ExampleHandler"
   end
 
-  setup do
-    {:ok, subscription} = start_subscription()
-    {:ok, handler} = start_handler(subscription)
-
-    [
-      handler: handler,
-      subscription: subscription
-    ]
-  end
-
   describe "event handler subscription" do
-    test "should monitor subscription and terminate handler on shutdown", %{
-      handler: handler,
-      subscription: subscription
-    } do
+    setup [:verify_on_exit!]
+
+    test "should monitor subscription and terminate handler on shutdown" do
+      {:ok, subscription} = start_subscription()
+
+      expect_subscribe_to(subscription)
+
+      {:ok, handler} = start_handler(subscription)
+
       Process.unlink(handler)
       ref = Process.monitor(handler)
 
@@ -29,11 +26,58 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
 
       assert_receive {:DOWN, ^ref, :process, ^handler, _reason}
     end
+
+    test "should retry subscription on error" do
+      {:ok, subscription} = start_subscription()
+
+      reply_to = self()
+
+      # First and second subscription attempts fail
+      expect(MockEventStore, :subscribe_to, 2, fn _event_store_meta,
+                                                  :all,
+                                                  "ExampleHandler",
+                                                  handler,
+                                                  :origin ->
+        send(reply_to, {:subscribe_to, handler})
+
+        {:error, :subscription_already_exists}
+      end)
+
+      # Third subscription attempt succeeds
+      expect_subscribe_to(subscription)
+
+      {:ok, handler} = ExampleHandler.start_link()
+
+      assert_receive {:subscribe_to, ^handler}
+      assert_handler_subscription_timer(handler, 1..3_000)
+      refute_receive {:subscribed, ^subscription}
+
+      send(handler, :subscribe_to_events)
+
+      assert_receive {:subscribe_to, ^handler}
+      assert_handler_subscription_timer(handler, 1_000..9_000)
+      refute_receive {:subscribed, ^subscription}
+
+      send(handler, :subscribe_to_events)
+
+      assert_receive {:subscribed, ^subscription}
+    end
+  end
+
+  defp assert_handler_subscription_timer(handler, expected_timer_range) do
+    %Handler{subscribe_timer: subscribe_timer} = :sys.get_state(handler)
+
+    assert is_reference(subscribe_timer)
+
+    timer = Process.read_timer(subscribe_timer)
+
+    assert is_integer(timer)
+    assert timer in expected_timer_range
   end
 
   defp start_subscription do
     pid =
-      spawn(fn ->
+      spawn_link(fn ->
         receive do
           :shutdown -> :ok
         end
@@ -42,7 +86,7 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
     {:ok, pid}
   end
 
-  defp start_handler(subscription) do
+  defp expect_subscribe_to(subscription) do
     reply_to = self()
 
     expect(MockEventStore, :subscribe_to, fn _event_store_meta,
@@ -55,7 +99,9 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
 
       {:ok, subscription}
     end)
+  end
 
+  defp start_handler(subscription) do
     {:ok, pid} = ExampleHandler.start_link()
 
     assert_receive {:subscribed, ^subscription}
@@ -68,6 +114,6 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
 
     send(subscription, :shutdown)
 
-    assert_receive {:DOWN, ^ref, :process, _, _}
+    assert_receive {:DOWN, ^ref, :process, ^subscription, _reason}
   end
 end

--- a/test/process_managers/process_manager_subscription_test.exs
+++ b/test/process_managers/process_manager_subscription_test.exs
@@ -2,6 +2,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
   use Commanded.MockEventStoreCase
 
   alias Commanded.MockedApp
+  alias Commanded.ProcessManagers.ProcessRouter
 
   defmodule ExampleProcessManager do
     use Commanded.ProcessManagers.ProcessManager,
@@ -12,21 +13,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
     defstruct [:data]
   end
 
-  setup do
-    {:ok, subscription} = start_subscription()
-    {:ok, pm} = start_process_manager(subscription)
-
-    [
-      pm: pm,
-      subscription: subscription
-    ]
-  end
-
   describe "process manager subscription" do
-    test "should monitor subscription and terminate process manager on shutdown", %{
-      pm: pm,
-      subscription: subscription
-    } do
+    test "should monitor subscription and terminate process manager on shutdown" do
+      {:ok, subscription} = start_subscription()
+
+      expect_subscribe_to(subscription)
+
+      {:ok, pm} = start_process_manager(subscription)
+
       Process.unlink(pm)
       ref = Process.monitor(pm)
 
@@ -36,9 +30,56 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
     end
   end
 
+  test "should retry subscription on error" do
+    {:ok, subscription} = start_subscription()
+
+    reply_to = self()
+
+    # First and second subscription attempts fail
+    expect(MockEventStore, :subscribe_to, 2, fn _event_store_meta,
+                                                :all,
+                                                "ExampleProcessManager",
+                                                pm,
+                                                :origin ->
+      send(reply_to, {:subscribe_to, pm})
+
+      {:error, :subscription_already_exists}
+    end)
+
+    # Third subscription attempt succeeds
+    expect_subscribe_to(subscription)
+
+    {:ok, pm} = ExampleProcessManager.start_link()
+
+    assert_receive {:subscribe_to, ^pm}
+    assert_subscription_timer(pm, 1..3_000)
+    refute_receive {:subscribed, ^subscription}
+
+    send(pm, :subscribe_to_events)
+
+    assert_receive {:subscribe_to, ^pm}
+    assert_subscription_timer(pm, 1_000..9_000)
+    refute_receive {:subscribed, ^subscription}
+
+    send(pm, :subscribe_to_events)
+
+    assert_receive {:subscribed, ^subscription}
+  end
+
+  defp assert_subscription_timer(pm, expected_timer_range) do
+    %ProcessRouter.State{subscribe_timer: subscribe_timer} = :sys.get_state(pm)
+
+    assert is_reference(subscribe_timer)
+
+    timer = Process.read_timer(subscribe_timer)
+
+    assert is_integer(timer)
+    assert timer in expected_timer_range
+  end
+
   defp start_subscription do
     pid =
-      spawn(fn ->
+      spawn_link(fn ->
         receive do
           :shutdown -> :ok
         end
@@ -47,7 +88,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
     {:ok, pid}
   end
 
-  defp start_process_manager(subscription) do
+  defp expect_subscribe_to(subscription) do
     reply_to = self()
 
     expect(MockEventStore, :subscribe_to, fn _event_store_meta,
@@ -60,7 +101,9 @@ defmodule Commanded.ProcessManagers.ProcessManagerSubscriptionTest do
 
       {:ok, subscription}
     end)
+  end
 
+  defp start_process_manager(subscription) do
     {:ok, pid} = ExampleProcessManager.start_link()
 
     assert_receive {:subscribed, ^subscription}


### PR DESCRIPTION
Restarting an event handler or process manager, such as after a crash when supervised, may encounter an error attempting to subscribe to the event store. Instead of crashing the process again, the subscription will attempt be retried with an exponentially increasing delay, including random jitter. The maximum delay between attempts is one minute. This will allow an event handler or process manager to recover more gracefully on error.