### PR TITLE
Ignores :not_found when reseting InMemory store

### DIFF
--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -361,7 +361,11 @@ defmodule Commanded.EventStore.Adapters.InMemory do
     } = state
 
     for {_name, %Subscription{subscriber: subscriber}} <- subscriptions, is_pid(subscriber) do
-      :ok = stop_subscription(subscriber, state)
+      case stop_subscription(subscriber, state) do
+        :ok -> :ok
+        {:error, :not_found} -> :ok
+        error -> error
+      end
     end
 
     initial_state = %State{name: name, serializer: serializer}

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -361,11 +361,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
     } = state
 
     for {_name, %Subscription{subscriber: subscriber}} <- subscriptions, is_pid(subscriber) do
-      case stop_subscription(subscriber, state) do
-        :ok -> :ok
-        {:error, :not_found} -> :ok
-        error -> error
-      end
+      _ = stop_subscription(subscriber, state)
     end
 
     initial_state = %State{name: name, serializer: serializer}


### PR DESCRIPTION
I'm not sure if this is just a problem in our codebase, or if it should also be handled here in some way, so opening the discussion.

After getting our commanded 1.0 upgrade ready, we're having a few sporading build errors because `InMemory.reset!` sometimes fails with `{:error, :not_found}`.
We believe this is caused when somehow a handler ends up stopping when cleaning up the test, but before the reset call is made. Since this only affects the clean-up part of a test, I feel it should be safe to ignore this particular error