### PR TITLE
Transient event handler proof-of-concept

### DIFF
--- a/test/event/in_memory_handler_test.exs
+++ b/test/event/in_memory_handler_test.exs
@@ -1,0 +1,64 @@
+defmodule Commanded.Event.InMemoryHandlerTest do
+  use Commanded.StorageCase
+
+  alias Commanded.Helpers.Wait
+  alias Commanded.ExampleDomain.BankApp
+  alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
+  alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.Helpers.CommandAuditMiddleware
+
+  defmodule InMemoryHandler do
+    @moduledoc false
+
+    use Commanded.Event.Handler,
+      application: Commanded.ExampleDomain.BankApp,
+      name: __MODULE__,
+      projection: :in_memory
+
+    def init do
+      Agent.start_link(fn -> 0 end, name: __MODULE__)
+      :ok
+    end
+
+    def handle(%BankAccountOpened{}, _metadata) do
+      Agent.update(__MODULE__, fn opened_count -> opened_count + 1 end)
+      :ok
+    end
+
+    def event_count() do
+      try do
+        Agent.get(__MODULE__, fn opened_count -> opened_count end)
+      catch
+        :exit, _reason -> false
+      end
+    end
+  end
+
+  describe "in memory handler" do
+    setup do
+      start_supervised!(CommandAuditMiddleware)
+      start_supervised!(BankApp)
+
+      :ok = BankApp.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+      :ok = BankApp.dispatch(%OpenAccount{account_number: "ACC456", initial_balance: 2_000})
+
+      handler = start_supervised!(InMemoryHandler)
+
+      [handler: handler]
+    end
+
+    test "recieves previous events" do
+      Wait.until(fn ->
+        assert InMemoryHandler.event_count() == 2
+      end)
+    end
+
+    test "recieves new events" do
+      :ok = BankApp.dispatch(%OpenAccount{account_number: "ACC789", initial_balance: 3_000})
+
+      Wait.until(fn ->
+        assert InMemoryHandler.event_count() == 3
+      end)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary
This PR adds a `:projection` option to the `Commanded.Event.Handler` module. The `:projection` option can be either `:persistent` (default) or `:in_memory`.

The `:persistent` option does not change the behaviour of the current `Commanded.Event.Handler`, but when `:in_memory` is applied, event handlers receive all their events each time they start. This allows developers to create in-memory projections using OTP primitives.

I also implemented a separate `Commanded.Event.TransientHandler` module (not shown in PR), but since the behaviours almost entirely overlap, I figured this approach would have a much higher maintainability cost.

#### Outstanding questions
How can the tests/test coverage for this feature be improved?
How is the naming? Is `@type projection :: :persistent | :in_memory` intuitive?
I'm no expert in Commanded or Elixir, does it look like I introduced any concurrency bugs?

#### Potential shortcomings
Having multiple handlers from the same module subscribed to the same stream is not supported.

#### To do
I still need to update the documentation and improve tests/test coverage.
\
\
Looking forward to any feedback!