### PR TITLE
Fix high memory consumption during aggregate rebuild

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -399,7 +399,7 @@ defmodule Commanded.Aggregates.Aggregate do
     |> Stream.map(fn event ->
       {event.data, event.stream_version}
     end)
-    |> Stream.transform(state, fn {event, stream_version}, state ->
+    |> Enum.reduce_while(state, fn {event, stream_version}, state ->
       case event do
         nil ->
           {:halt, state}
@@ -411,11 +411,9 @@ defmodule Commanded.Aggregates.Aggregate do
               aggregate_state: aggregate_module.apply(state.aggregate_state, event)
           }
 
-          {[state], state}
+          {:cont, state}
       end
     end)
-    |> Stream.take(-1)
-    |> Enum.at(0)
     |> case do
       nil -> state
       state -> state


### PR DESCRIPTION
I tried benchmarking both solutions and the time it takes is around 60% of the old implementation.
Even bigger difference is in the amount of memory being allocated and not released during the rebuild. With old implementation it gradualy rises into gigabytes. With new implementation it stays around 100-200 megabytes. I am not sure if the Stream is not used correctly, or if there's some bug in the Stream internals or if it's just my special case, but it could be useful if somebody could do some benchmarks with his data to prove my suspicion.

**Before change:**
<img width="1392" alt="Screenshot 2020-04-30 at 10 52 08" src="https://user-images.githubusercontent.com/23926/80698452-c91f5980-8ada-11ea-8752-7ec78a8d0d7f.png">
<img width="1392" alt="Screenshot 2020-04-30 at 10 52 05" src="https://user-images.githubusercontent.com/23926/80698466-ce7ca400-8ada-11ea-808b-ec1ffc07328e.png">

**After change:**
<img width="1392" alt="Screenshot 2020-04-30 at 12 03 30" src="https://user-images.githubusercontent.com/23926/80698520-e6ecbe80-8ada-11ea-9fc3-b3c6b57078f4.png">
<img width="1392" alt="Screenshot 2020-04-30 at 12 03 24" src="https://user-images.githubusercontent.com/23926/80698526-e8b68200-8ada-11ea-8fd2-1292d4d31526.png">

I tested this on around `100_000` events stored as JSONB in PostgreSQL.

Benchmarking machine:
```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
Number of Available Cores: 4
Available memory: 16 GB
Elixir 1.10.2
Erlang 22.2.8
```

I didn't write new test(s). I assume, this is covered by `event_persistence_test.exs`.