### PR TITLE
Call event handler's `error/3` callback function when `handle/2` function returns an invalid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Ignore `:not_found` error when reseting InMemory event store ([#354](https://github.com/commanded/commanded/pull/354)).
 - Add `router/1` to `locals_without_parens` in Mix format config ([#351](https://github.com/commanded/commanded/pull/351)).
 - Include stacktrace in event handler and process manager `error` callback functions ([#342](https://github.com/commanded/commanded/pull/342)).
+- Call event handler's `error/3` callback function when `handle/2` function returns an invalid value ([#372](https://github.com/commanded/commanded/pull/372)).
 
 ### Bug fixes
 

--- a/test/event/support/error/error_aggregate.ex
+++ b/test/event/support/error/error_aggregate.ex
@@ -23,6 +23,11 @@ defmodule Commanded.Event.ErrorAggregate do
       @derive Jason.Encoder
       defstruct [:uuid, :strategy, :delay, :reply_to]
     end
+
+    defmodule InvalidReturnValueEvent do
+      @derive Jason.Encoder
+      defstruct [:uuid, :reply_to]
+    end
   end
 
   alias Commanded.Event.ErrorAggregate

--- a/test/event/support/error/error_event_handler.ex
+++ b/test/event/support/error/error_event_handler.ex
@@ -6,7 +6,12 @@ defmodule Commanded.Event.ErrorEventHandler do
     name: __MODULE__
 
   alias Commanded.Event.FailureContext
-  alias Commanded.Event.ErrorAggregate.Events.{ErrorEvent, ExceptionEvent}
+
+  alias Commanded.Event.ErrorAggregate.Events.{
+    ErrorEvent,
+    ExceptionEvent,
+    InvalidReturnValueEvent
+  }
 
   # Simulate event handling error reply
   def handle(%ErrorEvent{}, _metadata) do
@@ -16,6 +21,11 @@ defmodule Commanded.Event.ErrorEventHandler do
   # Simulate event handling exception
   def handle(%ExceptionEvent{}, _metadata) do
     raise "exception"
+  end
+
+  # Simulate event handling returning an invalid value
+  def handle(%InvalidReturnValueEvent{}, _metadata) do
+    nil
   end
 
   # Default behaviour is to stop the event handler with the given error reason
@@ -70,6 +80,14 @@ defmodule Commanded.Event.ErrorEventHandler do
     %ExceptionEvent{reply_to: reply_to} = event
 
     send_reply(reply_to, {:exception, :stopping, error, failure_context})
+
+    {:stop, error}
+  end
+
+  def error({:error, error}, %InvalidReturnValueEvent{} = event, _failure_context) do
+    %InvalidReturnValueEvent{reply_to: reply_to} = event
+
+    send_reply(reply_to, {:error, error})
 
     {:stop, error}
   end


### PR DESCRIPTION
The valid return values for an event handler's `handle/2` callback function are `:ok` or `{:error, term}`. Returning any other value previously caused the handler to crash with a CaseClauseError. This is now caught and will call the handler's `error/3` callback function allowing the handler to decide what to do.

Closes #371.