### PR TITLE
Fix aggregate multis not returning intermediate events

### DIFF
--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -112,7 +112,12 @@ defmodule Commanded.Aggregate.Multi do
             throw(error)
 
           %Multi{} = multi ->
-            Multi.run(multi)
+            case Multi.run(multi) do
+              {evolved_aggregate, pending_events} ->
+                {evolved_aggregate, events ++ pending_events}
+              {:error, _reason} = error -> 
+                throw(error)
+            end
 
           none when none in [:ok, nil, []] ->
             {aggregate, events}

--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -113,10 +113,10 @@ defmodule Commanded.Aggregate.Multi do
 
           %Multi{} = multi ->
             case Multi.run(multi) do
-              {evolved_aggregate, pending_events} ->
-                {evolved_aggregate, events ++ pending_events}
               {:error, _reason} = error -> 
                 throw(error)
+              {evolved_aggregate, pending_events} ->
+                {evolved_aggregate, events ++ pending_events}
             end
 
           none when none in [:ok, nil, []] ->

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -243,6 +243,15 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | false
 
   @doc """
+  If provided, the event that returns {:stop, process_uuid} from `c:interested/2`
+  will be handled and applied to the PM's state before being stopped.
+  
+  During the stop call, the `c:cleanup/1` function will be called with the final 
+  state of the Process Manager.
+  """
+  @callback cleanup(process_manager) :: :ok
+
+  @doc """
   Process manager instance handles a domain event, returning any commands to
   dispatch.
 
@@ -325,6 +334,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | {:skip, :discard_pending}
               | {:skip, :continue_pending}
               | {:stop, reason :: term()}
+
+  @optional_callbacks cleanup: 1
 
   alias Commanded.Event.Handler
   alias Commanded.ProcessManagers.ProcessManager

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -110,6 +110,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @doc false
   @impl GenServer
   def handle_call(:stop, _from, %State{} = state) do
+    %State{
+      process_manager_module: process_manager_module,
+      process_state: process_state
+    } = state
+
+    if function_exported?(process_manager_module, :cleanup, 1) do
+      process_manager_module.cleanup(process_state)
+    end
     :ok = delete_state(state)
 
     # Stop the process with a normal reason


### PR DESCRIPTION
Events returned by `Multi.execute` calls are not persisted if followed by `Multi.execute` calls that return another `multi` instead of events.