### PR TITLE
Fix multi aggregate

### DIFF
--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -113,8 +113,9 @@ defmodule Commanded.Aggregate.Multi do
 
           %Multi{} = multi ->
             case Multi.run(multi) do
-              {:error, _reason} = error -> 
+              {:error, _reason} = error ->
                 throw(error)
+
               {evolved_aggregate, pending_events} ->
                 {evolved_aggregate, events ++ pending_events}
             end

--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -112,7 +112,12 @@ defmodule Commanded.Aggregate.Multi do
             throw(error)
 
           %Multi{} = multi ->
-            Multi.run(multi)
+            case Multi.run(multi) do
+              {evolved_aggregate, pending_events} ->
+                {evolved_aggregate, events ++ pending_events}
+              {:error, _reason} = error -> 
+                throw(error)
+            end
 
           none when none in [:ok, nil, []] ->
             {aggregate, events}

--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -113,10 +113,10 @@ defmodule Commanded.Aggregate.Multi do
 
           %Multi{} = multi ->
             case Multi.run(multi) do
-              {evolved_aggregate, pending_events} ->
-                {evolved_aggregate, events ++ pending_events}
               {:error, _reason} = error -> 
                 throw(error)
+              {evolved_aggregate, pending_events} ->
+                {evolved_aggregate, events ++ pending_events}
             end
 
           none when none in [:ok, nil, []] ->


### PR DESCRIPTION
Events returned by `Multi.execute` calls are not persisted if followed by `Multi.execute` calls that return another `multi` instead of events.