### PR TITLE
Add cleanup callback option to process manager

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -245,7 +245,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   @doc """
   If provided, the event that returns {:stop, process_uuid} from `c:interested/2`
   will be handled and applied to the PM's state before being stopped.
-  
+
   During the stop call, the `c:cleanup/1` function will be called with the final 
   state of the Process Manager.
   """

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -243,6 +243,15 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | false
 
   @doc """
+  If provided, the event that returns {:stop, process_uuid} from `c:interested/2`
+  will be handled and applied to the PM's state before being stopped.
+  
+  During the stop call, the `c:cleanup/1` function will be called with the final 
+  state of the Process Manager.
+  """
+  @callback cleanup(process_manager) :: :ok
+
+  @doc """
   Process manager instance handles a domain event, returning any commands to
   dispatch.
 
@@ -325,6 +334,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | {:skip, :discard_pending}
               | {:skip, :continue_pending}
               | {:stop, reason :: term()}
+
+  @optional_callbacks cleanup: 1
 
   alias Commanded.Event.Handler
   alias Commanded.ProcessManagers.ProcessManager

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -118,6 +118,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     if function_exported?(process_manager_module, :cleanup, 1) do
       process_manager_module.cleanup(process_state)
     end
+
     :ok = delete_state(state)
 
     # Stop the process with a normal reason

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -110,6 +110,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @doc false
   @impl GenServer
   def handle_call(:stop, _from, %State{} = state) do
+    %State{
+      process_manager_module: process_manager_module,
+      process_state: process_state
+    } = state
+
+    if function_exported?(process_manager_module, :cleanup, 1) do
+      process_manager_module.cleanup(process_state)
+    end
     :ok = delete_state(state)
 
     # Stop the process with a normal reason

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -33,7 +33,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
       process_managers: %{},
       pending_acks: %{},
       pending_events: [],
-      pending_process_managers: %{},
+      pending_process_managers: %{}
     ]
   end
 
@@ -125,16 +125,18 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
           # stop if necessary (cleanup callback provided, so stop happens after event
           # is processed)
           case Map.pop(ppm, event_number) do
-            {nil, _} -> 
+            {nil, _} ->
               state
 
             {process_uuid, ppm} ->
-              state = 
+              state =
                 process_uuid
                 |> List.wrap()
                 |> Enum.reduce(state, &stop_process_manager/2)
+
               %State{state | pending_process_managers: ppm}
           end
+
         pending ->
           # pending acks, don't ack event but wait for outstanding instances
           %State{state | pending_acks: Map.put(pending_acks, event_number, pending)}
@@ -404,8 +406,11 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
             true ->
               %State{pending_process_managers: ppm} = state
               %RecordedEvent{event_number: event_number} = event
-              state = %State{state | 
-                pending_process_managers: Map.put(ppm, event_number, process_uuid)}
+
+              state = %State{
+                state
+                | pending_process_managers: Map.put(ppm, event_number, process_uuid)
+              }
 
               process_uuid
               |> List.wrap()


### PR DESCRIPTION
This callback allows that last event on a process_manager to be processed before it is stopped. The cleanup callback will receive PM's state after all events were processed and will have the chance to cleanup/close any resources before the instance is stopped.

This is an optional callback, and not providing it reverts to the original PM behaviour.