### PR TITLE
Add support to event store subscription options

### DIFF
--- a/lib/commanded/event_store/adapter.ex
+++ b/lib/commanded/event_store/adapter.ex
@@ -16,7 +16,7 @@ defmodule Commanded.EventStore.Adapter do
   @type subscriber :: pid
   @type source_uuid :: String.t()
   @type error :: term
-  @type options :: map
+  @type options :: Keyword.t()
 
   @doc """
   Return a child spec defining all processes required by the event store.
@@ -86,7 +86,7 @@ defmodule Commanded.EventStore.Adapter do
               subscription_name,
               subscriber,
               start_from,
-              options | %{}
+              options | []
             ) ::
               {:ok, subscription}
               | {:error, :subscription_already_exists}

--- a/lib/commanded/event_store/adapter.ex
+++ b/lib/commanded/event_store/adapter.ex
@@ -16,6 +16,7 @@ defmodule Commanded.EventStore.Adapter do
   @type subscriber :: pid
   @type source_uuid :: String.t()
   @type error :: term
+  @type options :: map
 
   @doc """
   Return a child spec defining all processes required by the event store.
@@ -70,6 +71,22 @@ defmodule Commanded.EventStore.Adapter do
               subscription_name,
               subscriber,
               start_from
+            ) ::
+              {:ok, subscription}
+              | {:error, :subscription_already_exists}
+              | {:error, error}
+
+  @doc """
+  Create a persistent subscription to an event stream with custom options
+  """
+  @optional_callbacks subscribe_to: 6
+  @callback subscribe_to(
+              adapter_meta,
+              stream_uuid | :all,
+              subscription_name,
+              subscriber,
+              start_from,
+              options | %{}
             ) ::
               {:ok, subscription}
               | {:error, :subscription_already_exists}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Commanded.Mixfile do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.1.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Commanded.Mixfile do
   use Mix.Project
 
-  @version "1.1.2"
+  @version "1.2.0"
 
   def project do
     [


### PR DESCRIPTION
There are some events store backends that allows some persistent subscriptions tuning, right now there's no way to configure those since the base behavior only cares about start_from. This pull request adds a new optional callback that allows the user to send a Keyword list with custom adapter-specific options.