### PR TITLE
Include `application` and `handler_name` as additional event handler metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Add `init/1` callback function to event handlers and process managers ([#393](https://github.com/commanded/commanded/pull/393)).
+- Include `application` and `handler_name` as additional event handler metadata ([#396](https://github.com/commanded/commanded/pull/396)).
 
 ## v1.1.1
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -276,14 +276,14 @@ defmodule Commanded.Aggregates.Aggregate do
   @doc false
   @impl GenServer
   def handle_info({:events, events}, %Aggregate{} = state) do
-    %Aggregate{lifespan_timeout: lifespan_timeout} = state
+    %Aggregate{application: application, lifespan_timeout: lifespan_timeout} = state
 
     Logger.debug(fn -> describe(state) <> " received events: #{inspect(events)}" end)
 
     try do
       state =
         events
-        |> Upcast.upcast_event_stream()
+        |> Upcast.upcast_event_stream(additional_metadata: %{application: application})
         |> Enum.reduce(state, &handle_event/2)
 
       state = Enum.reduce(events, state, &handle_event/2)

--- a/lib/commanded/event/failure_context.ex
+++ b/lib/commanded/event/failure_context.ex
@@ -4,6 +4,8 @@ defmodule Commanded.Event.FailureContext do
 
   The available fields are:
 
+    - `application` - the associated `Commanded.Application`.
+    - `handler_name` - the name of the event handler.
     - `context` - a map that is passed between each failure. Use it to store any
       transient state between failures. As an example it could be used to count
       error failures and stop or skip the problematic event after too many.
@@ -13,12 +15,16 @@ defmodule Commanded.Event.FailureContext do
   """
 
   @type t :: %__MODULE__{
+          application: Commanded.Application.t(),
+          handler_name: String.t(),
           context: map(),
           metadata: map(),
           stacktrace: Exception.stacktrace() | nil
         }
 
   defstruct [
+    :application,
+    :handler_name,
     :context,
     :metadata,
     :stacktrace

--- a/lib/commanded/event/upcast.ex
+++ b/lib/commanded/event/upcast.ex
@@ -4,18 +4,18 @@ defmodule Commanded.Event.Upcast do
   alias Commanded.Event.Upcaster
   alias Commanded.EventStore.RecordedEvent
 
-  def upcast_event_stream(%Stream{} = event_stream) do
-    Stream.map(event_stream, &upcast_event/1)
-  end
+  def upcast_event_stream(event_stream, opts \\ [])
 
-  def upcast_event_stream(event_stream) do
-    Enum.map(event_stream, &upcast_event/1)
-  end
+  def upcast_event_stream(%Stream{} = event_stream, opts),
+    do: Stream.map(event_stream, &upcast_event(&1, opts))
 
-  defp upcast_event(%RecordedEvent{} = event) do
+  def upcast_event_stream(event_stream, opts),
+    do: Enum.map(event_stream, &upcast_event(&1, opts))
+
+  defp upcast_event(%RecordedEvent{} = event, opts) do
     %RecordedEvent{data: data} = event
 
-    enriched_metadata = RecordedEvent.enrich_metadata(event)
+    enriched_metadata = RecordedEvent.enrich_metadata(event, opts)
 
     %RecordedEvent{event | data: Upcaster.upcast(data, enriched_metadata)}
   end

--- a/lib/commanded/event/upcaster.ex
+++ b/lib/commanded/event/upcaster.ex
@@ -26,8 +26,9 @@ defprotocol Commanded.Event.Upcaster do
   associated with that event. The metadata is provided during command dispatch.
 
   In addition to the metadata key/values you provide, the following system
-  values will be included in the metadata passed to an event handler:
+  values will be included in the metadata:
 
+    - `application` - the `Commanded.Application` used to read the event.
     - `event_id` - a globally unique UUID to identify the event.
     - `event_number` - a globally unique, monotonically incrementing integer
       used to order the event amongst all events.

--- a/lib/commanded/event_store.ex
+++ b/lib/commanded/event_store.ex
@@ -36,8 +36,11 @@ defmodule Commanded.EventStore do
            start_version,
            read_batch_size
          ) do
-      {:error, _error} = error -> error
-      stream -> Upcast.upcast_event_stream(stream)
+      {:error, _error} = error ->
+        error
+
+      stream ->
+        Upcast.upcast_event_stream(stream, additional_metadata: %{application: application})
     end
   end
 

--- a/lib/commanded/event_store/recorded_event.ex
+++ b/lib/commanded/event_store/recorded_event.ex
@@ -60,7 +60,12 @@ defmodule Commanded.EventStore.RecordedEvent do
     :created_at
   ]
 
-  def enrich_metadata(%RecordedEvent{} = event) do
+  @doc """
+  Enrich the event's metadata with fields from the `RecordedEvent` struct and
+  any additional metadata passed as an option.
+  """
+  @spec enrich_metadata(t(), [{:additional_metadata, map()}]) :: map()
+  def enrich_metadata(%RecordedEvent{} = event, opts) do
     %RecordedEvent{
       event_id: event_id,
       event_number: event_number,
@@ -72,17 +77,16 @@ defmodule Commanded.EventStore.RecordedEvent do
       metadata: metadata
     } = event
 
-    Map.merge(
-      %{
-        event_id: event_id,
-        event_number: event_number,
-        stream_id: stream_id,
-        stream_version: stream_version,
-        correlation_id: correlation_id,
-        causation_id: causation_id,
-        created_at: created_at
-      },
-      metadata || %{}
-    )
+    %{
+      event_id: event_id,
+      event_number: event_number,
+      stream_id: stream_id,
+      stream_version: stream_version,
+      correlation_id: correlation_id,
+      causation_id: causation_id,
+      created_at: created_at
+    }
+    |> Map.merge(Keyword.get(opts, :additional_metadata, %{}))
+    |> Map.merge(metadata || %{})
   end
 end

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -176,7 +176,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
 
   @impl GenServer
   def handle_info({:events, events}, %State{} = state) do
-    %State{pending_events: pending_events} = state
+    %State{application: application, pending_events: pending_events} = state
 
     Logger.debug(fn -> describe(state) <> " received #{length(events)} event(s)" end)
 
@@ -184,7 +184,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     unseen_events =
       events
       |> Enum.reject(&event_already_seen?(&1, state))
-      |> Upcast.upcast_event_stream()
+      |> Upcast.upcast_event_stream(additional_metadata: %{application: application})
 
     state =
       case {pending_events, unseen_events} do

--- a/test/event/event_handler_error_handling_test.exs
+++ b/test/event/event_handler_error_handling_test.exs
@@ -4,7 +4,6 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
   import ExUnit.CaptureLog
 
   alias Commanded.DefaultApp
-  alias Commanded.Event.FailureContext
 
   alias Commanded.Event.ErrorAggregate.Events.{
     ErrorEvent,
@@ -13,6 +12,8 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
   }
 
   alias Commanded.Event.ErrorEventHandler
+  alias Commanded.Event.FailureContext
+  alias Commanded.Event.Handler
   alias Commanded.Helpers.EventFactory
 
   setup do
@@ -131,7 +132,8 @@ defmodule Commanded.Event.EventHandlerErrorHandlingTest do
     assert Process.alive?(handler)
 
     # Should ack errored event
-    assert GenServer.call(handler, :last_seen_event) == 1
+    %Handler{last_seen_event: last_seen_event} = :sys.get_state(handler)
+    assert last_seen_event == 1
   end
 
   defp send_error_event(handler, opts \\ []) do

--- a/test/event/event_handler_name_test.exs
+++ b/test/event/event_handler_name_test.exs
@@ -49,11 +49,13 @@ defmodule Commanded.Event.EventHandlerNameTest do
     end
   end
 
+  defmodule ModuleNamedEventHandler do
+    use Commanded.Event.Handler, application: Commanded.DefaultApp, name: __MODULE__
+  end
+
   test "should allow using event handler module as name" do
-    Code.eval_string("""
-      defmodule EventHandler do
-        use Commanded.Event.Handler, application: Commanded.DefaultApp, name: __MODULE__
-      end
-    """)
+    start_supervised!(Commanded.DefaultApp)
+
+    assert {:ok, _pid} = ModuleNamedEventHandler.start_link()
   end
 end

--- a/test/event/event_handler_subscription_test.exs
+++ b/test/event/event_handler_subscription_test.exs
@@ -33,14 +33,11 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
       reply_to = self()
 
       # First and second subscription attempts fail
-      expect(MockEventStore, :subscribe_to, 2, fn _event_store_meta,
-                                                  :all,
-                                                  "ExampleHandler",
-                                                  handler,
-                                                  :origin ->
-        send(reply_to, {:subscribe_to, handler})
+      expect(MockEventStore, :subscribe_to, 2, fn
+        _event_store_meta, :all, "ExampleHandler", handler, :origin ->
+          send(reply_to, {:subscribe_to, handler})
 
-        {:error, :subscription_already_exists}
+          {:error, :subscription_already_exists}
       end)
 
       # Third subscription attempt succeeds
@@ -89,15 +86,12 @@ defmodule Commanded.Event.EventHandlerSubscriptionTest do
   defp expect_subscribe_to(subscription) do
     reply_to = self()
 
-    expect(MockEventStore, :subscribe_to, fn _event_store_meta,
-                                             :all,
-                                             "ExampleHandler",
-                                             handler,
-                                             :origin ->
-      send(handler, {:subscribed, subscription})
-      send(reply_to, {:subscribed, subscription})
+    expect(MockEventStore, :subscribe_to, fn
+      _event_store_meta, :all, "ExampleHandler", handler, :origin ->
+        send(handler, {:subscribed, subscription})
+        send(reply_to, {:subscribed, subscription})
 
-      {:ok, subscription}
+        {:ok, subscription}
     end)
   end
 

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Event.HandlerInitTest do
   import Mox
 
   alias Commanded.DefaultApp
-  alias Commanded.Event.{InitHandler, RuntimeConfigHandler}
+  alias Commanded.Event.{Handler, InitHandler, RuntimeConfigHandler}
   alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
 
   describe "event handler `init/1` callback" do
@@ -17,13 +17,21 @@ defmodule Commanded.Event.HandlerInitTest do
     end
 
     test "should be called at runtime" do
-      {:ok, _handler1} = RuntimeConfigHandler.start_link(tenant: :tenant1, reply_to: self())
-      {:ok, _handler2} = RuntimeConfigHandler.start_link(tenant: :tenant2, reply_to: self())
-      {:ok, _handler3} = RuntimeConfigHandler.start_link(tenant: :tenant3, reply_to: self())
+      {:ok, handler1} = RuntimeConfigHandler.start_link(tenant: :tenant1, reply_to: self())
+      {:ok, handler2} = RuntimeConfigHandler.start_link(tenant: :tenant2, reply_to: self())
+      {:ok, handler3} = RuntimeConfigHandler.start_link(tenant: :tenant3, reply_to: self())
 
       assert_receive {:init, :tenant1}
       assert_receive {:init, :tenant2}
       assert_receive {:init, :tenant3}
+
+      assert_handler_application(handler1, Module.concat([DefaultApp, :tenant1]))
+      assert_handler_application(handler2, Module.concat([DefaultApp, :tenant2]))
+      assert_handler_application(handler3, Module.concat([DefaultApp, :tenant3]))
+
+      assert_handler_name(handler1, "Commanded.Event.RuntimeConfigHandler.tenant1")
+      assert_handler_name(handler2, "Commanded.Event.RuntimeConfigHandler.tenant2")
+      assert_handler_name(handler3, "Commanded.Event.RuntimeConfigHandler.tenant3")
     end
   end
 
@@ -53,9 +61,21 @@ defmodule Commanded.Event.HandlerInitTest do
 
       assert_receive {:init, ^handler}
     end
+  end
 
-    defp send_subscribed(handler) do
-      send(handler, {:subscribed, handler})
-    end
+  defp assert_handler_application(handler, expected_application) do
+    %Handler{application: application} = :sys.get_state(handler)
+
+    assert application == expected_application
+  end
+
+  defp assert_handler_name(handler, expected_handler_name) do
+    %Handler{handler_name: handler_name} = :sys.get_state(handler)
+
+    assert handler_name == expected_handler_name
+  end
+
+  defp send_subscribed(handler) do
+    send(handler, {:subscribed, handler})
   end
 end

--- a/test/event/reset_event_handler_test.exs
+++ b/test/event/reset_event_handler_test.exs
@@ -1,0 +1,76 @@
+defmodule Commanded.Event.ResetEventHandlerTest do
+  use ExUnit.Case
+
+  import Commanded.Assertions.EventAssertions
+
+  alias Commanded.EventStore
+  alias Commanded.Helpers.Wait
+  alias Commanded.ExampleDomain.BankApp
+  alias Commanded.ExampleDomain.BankAccount.BankAccountHandler
+  alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
+
+  describe "reset event handler" do
+    setup do
+      start_supervised!(BankApp)
+      :ok
+    end
+
+    test "should be reset when starting from `:origin`" do
+      stream_uuid = UUID.uuid4()
+      initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
+
+      :ok = EventStore.append_to_stream(BankApp, stream_uuid, 0, to_event_data(initial_events))
+
+      handler = start_supervised!(BankAccountHandler)
+
+      Wait.until(fn ->
+        assert BankAccountHandler.current_accounts() == ["ACC123"]
+      end)
+
+      :ok = BankAccountHandler.change_prefix("PREF_")
+
+      send(handler, :reset)
+
+      Wait.until(fn ->
+        assert BankAccountHandler.current_accounts() == ["PREF_ACC123"]
+      end)
+    end
+
+    test "should be reset when starting from `:current`" do
+      stream_uuid = UUID.uuid4()
+
+      # Ignored initial events
+      initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
+      :ok = EventStore.append_to_stream(BankApp, stream_uuid, 0, to_event_data(initial_events))
+
+      handler = start_supervised!({BankAccountHandler, start_from: :current})
+
+      Wait.until(fn ->
+        assert BankAccountHandler.current_accounts() == []
+      end)
+
+      :ok = BankAccountHandler.change_prefix("PREF_")
+
+      send(handler, :reset)
+
+      new_event = [%BankAccountOpened{account_number: "ACC1234", initial_balance: 1_000}]
+      :ok = EventStore.append_to_stream(BankApp, stream_uuid, 1, to_event_data(new_event))
+
+      wait_for_event(BankApp, BankAccountOpened, fn event, recorded_event ->
+        event.account_number == "ACC1234" and recorded_event.event_number == 2
+      end)
+
+      Wait.until(fn ->
+        assert BankAccountHandler.current_accounts() == ["PREF_ACC1234"]
+      end)
+    end
+  end
+
+  defp to_event_data(events) do
+    Commanded.Event.Mapper.map_to_event_data(events,
+      causation_id: UUID.uuid4(),
+      correlation_id: UUID.uuid4(),
+      metadata: %{}
+    )
+  end
+end

--- a/test/event/support/echo_handler.ex
+++ b/test/event/support/echo_handler.ex
@@ -1,0 +1,16 @@
+defmodule Commanded.Event.EchoHandler do
+  use Commanded.Event.Handler,
+    application: Commanded.DefaultApp,
+    name: __MODULE__
+
+  alias Commanded.Event.ReplyEvent
+
+  @impl Commanded.Event.Handler
+  def handle(%ReplyEvent{} = event, metadata) do
+    %ReplyEvent{reply_to: reply_to} = event
+
+    send(reply_to, {:event, self(), event, metadata})
+
+    :ok
+  end
+end

--- a/test/event/support/init/runtime_config_handler.ex
+++ b/test/event/support/init/runtime_config_handler.ex
@@ -10,7 +10,7 @@ defmodule Commanded.Event.RuntimeConfigHandler do
     config =
       config
       |> Keyword.put(:application, Module.concat([DefaultApp, tenant]))
-      |> Keyword.put(:name, Module.concat([__MODULE__, tenant]))
+      |> Keyword.put(:name, inspect(__MODULE__) <> ".#{tenant}")
 
     send(reply_to, {:init, tenant})
 

--- a/test/event/support/reply_event.ex
+++ b/test/event/support/reply_event.ex
@@ -1,0 +1,3 @@
+defmodule Commanded.Event.ReplyEvent do
+  defstruct [:reply_to, :value]
+end

--- a/test/event/support/upcast/event_handler.ex
+++ b/test/event/support/upcast/event_handler.ex
@@ -3,12 +3,13 @@ defmodule Commanded.Event.Upcast.EventHandler do
     application: Commanded.DefaultApp,
     name: __MODULE__
 
-  alias Commanded.Event.Upcast.Events.{EventOne, EventTwo, EventThree, EventFour}
+  alias Commanded.Event.Upcast.Events.{EventOne, EventTwo, EventThree, EventFour, EventFive}
 
   def handle(%EventOne{} = e, _), do: send_reply(e)
   def handle(%EventTwo{} = e, _), do: send_reply(e)
   def handle(%EventThree{} = e, _), do: send_reply(e)
   def handle(%EventFour{} = e, _), do: send_reply(e)
+  def handle(%EventFive{} = e, _), do: send_reply(e)
 
   defp send_reply(%{reply_to: reply_to} = e) do
     send(:erlang.list_to_pid(reply_to), e)

--- a/test/helpers/event_factory.ex
+++ b/test/helpers/event_factory.ex
@@ -2,11 +2,13 @@ defmodule Commanded.Helpers.EventFactory do
   @moduledoc false
   alias Commanded.EventStore.RecordedEvent
 
-  def map_to_recorded_events(events, initial_event_number \\ 1) do
+  def map_to_recorded_events(events, initial_event_number \\ 1, opts \\ []) do
     stream_id = UUID.uuid4()
-    causation_id = UUID.uuid4()
-    correlation_id = UUID.uuid4()
-    fields = [causation_id: causation_id, correlation_id: correlation_id, metadata: %{}]
+    causation_id = Keyword.get(opts, :causation_id, UUID.uuid4())
+    correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    metadata = Keyword.get(opts, :metadata, %{})
+
+    fields = [causation_id: causation_id, correlation_id: correlation_id, metadata: metadata]
 
     events
     |> Commanded.Event.Mapper.map_to_event_data(fields)


### PR DESCRIPTION
Include the associated Commanded Application and event handler name as additional system provided metadata key/values. This allows event handlers to determine the current application and handler name when started with these options configured at runtime.

## Example

```elixir
defmodule ExampleEventHandler do
  use Commanded.Event.Handler
  
  @impl Commanded.Event.Handler
  def handle(event, metadata) do
    application = Keyword.fetch!(metadata, :application)
    handler_name = Keyword.fetch!(metadata, :handler_name)

    :ok
  end
end
```

Usage:

```elixir
{:ok, _pid} = ExampleEventHandler.start_link(application: MyApp, name: "ExampleEventHandler1")
{:ok, _pid} = ExampleEventHandler.start_link(application: MyApp, name: "ExampleEventHandler2")
```

The above demonstrates using the same event handler module but configured at runtime with a unique name so that two event store subscriptions are created and both handlers receive events.