### PR TITLE
Allow `GenServer` start options to be provided when starting event handlers and process managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `init/1` callback function to event handlers and process managers ([#393](https://github.com/commanded/commanded/pull/393)).
 - Include `application` and `handler_name` as additional event handler metadata ([#396](https://github.com/commanded/commanded/pull/396)).
+- Allow `GenServer` start options to be provided when starting event handlers and process managers ([#398](https://github.com/commanded/commanded/pull/398)).
 
 ## v1.1.1
 

--- a/lib/commanded/registration.ex
+++ b/lib/commanded/registration.ex
@@ -16,10 +16,10 @@ defmodule Commanded.Registration do
   end
 
   @doc false
-  def start_link(application, name, module, args) do
+  def start_link(application, name, module, args, start_opts) do
     {adapter, adapter_meta} = Application.registry_adapter(application)
 
-    adapter.start_link(adapter_meta, name, module, args)
+    adapter.start_link(adapter_meta, name, module, args, start_opts)
   end
 
   @doc false

--- a/lib/commanded/registration/adapter.ex
+++ b/lib/commanded/registration/adapter.ex
@@ -10,10 +10,10 @@ defmodule Commanded.Registration.Adapter do
   cluster of nodes.
   """
 
-  @type adapter_meta :: map
+  @type adapter_meta :: map()
   @type application :: Commanded.Application.t()
   @type config :: Keyword.t()
-  @type start_child_arg :: {module(), keyword} | module()
+  @type start_child_arg :: {module(), Keyword.t()} | module()
 
   @doc """
   Return an optional supervisor spec for the registry
@@ -46,8 +46,13 @@ defmodule Commanded.Registration.Adapter do
 
   Registers the pid with the given name.
   """
-  @callback start_link(adapter_meta, name :: term(), module :: module(), args :: any()) ::
-              {:ok, pid} | {:error, term}
+  @callback start_link(
+              adapter_meta,
+              name :: term(),
+              module :: module(),
+              args :: any(),
+              start_options :: GenServer.options()
+            ) :: {:ok, pid} | {:error, term}
 
   @doc """
   Get the pid of a registered name.

--- a/lib/commanded/registration/global_registry.ex
+++ b/lib/commanded/registration/global_registry.ex
@@ -60,10 +60,11 @@ defmodule Commanded.Registration.GlobalRegistry do
   Registers the pid with the given name.
   """
   @impl Commanded.Registration.Adapter
-  def start_link(adapter_meta, name, module, args) do
+  def start_link(adapter_meta, name, module, args, start_opts) do
     via_name = via_tuple(adapter_meta, name)
+    start_opts = Keyword.put(start_opts, :name, via_name)
 
-    case GenServer.start_link(module, args, name: via_name) do
+    case GenServer.start_link(module, args, start_opts) do
       {:error, {:already_started, pid}} ->
         true = Process.link(pid)
 
@@ -72,7 +73,7 @@ defmodule Commanded.Registration.GlobalRegistry do
       {:error, :killed} ->
         # Process may be killed due to `:global` name registation when another node connects.
         # Attempting to start again should link to the other named existing process.
-        start_link(adapter_meta, name, module, args)
+        start_link(adapter_meta, name, module, args, start_opts)
 
       reply ->
         reply

--- a/lib/commanded/registration/local_registry.ex
+++ b/lib/commanded/registration/local_registry.ex
@@ -68,10 +68,11 @@ defmodule Commanded.Registration.LocalRegistry do
   Registers the pid with the given name.
   """
   @impl Commanded.Registration.Adapter
-  def start_link(adapter_meta, name, module, args) do
+  def start_link(adapter_meta, name, module, args, start_opts) do
     via_name = via_tuple(adapter_meta, name)
+    start_opts = Keyword.put(start_opts, :name, via_name)
 
-    case GenServer.start_link(module, args, name: via_name) do
+    case GenServer.start_link(module, args, start_opts) do
       {:error, {:already_started, pid}} -> {:ok, pid}
       reply -> reply
     end

--- a/test/registration/support/registration_test_case.ex
+++ b/test/registration/support/registration_test_case.ex
@@ -83,7 +83,7 @@ defmodule Commanded.RegistrationTestCase do
     end
 
     defp start_link(registry, registry_meta, name) do
-      registry.start_link(registry_meta, name, RegisteredServer, [])
+      registry.start_link(registry_meta, name, RegisteredServer, [], [])
     end
   end
 end


### PR DESCRIPTION
Allow `:timeout`, `:debug`, `:spawn_opt`, and `:hibernate_after` options to be passed through to [`GenServer.start_link/3`](https://hexdocs.pm/elixir/GenServer.html#start_link/3) when starting event handlers and process managers.

#### Examples

```elixir
{:ok, pid} = MyEventHandler.start_link(hibernate_after: :timer.seconds(15))
```

Or supervised:

```elixir
Supervisor.start_link(
  [
    {ExampleHandler, hibernate_after: :timer.seconds(15)}
  ],
  strategy: :one_for_one
)
```