### PR TITLE
Support custom state for event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow `GenServer` start options to be provided when starting event handlers and process managers ([#398](https://github.com/commanded/commanded/pull/398)).
 - Add `hibernate_after` option to application config ([#399](https://github.com/commanded/commanded/pull/399)).
 - Add support for providing adapter-specific event store subscription options ([#391](https://github.com/commanded/commanded/pull/391)).
+- Support custom state for event handlers ([#400](https://github.com/commanded/commanded/pull/400)).
 
 ## v1.1.1
 

--- a/lib/commanded/event/failure_context.ex
+++ b/lib/commanded/event/failure_context.ex
@@ -4,19 +4,27 @@ defmodule Commanded.Event.FailureContext do
 
   The available fields are:
 
-    - `application` - the associated `Commanded.Application`.
-    - `handler_name` - the name of the event handler.
-    - `context` - a map that is passed between each failure. Use it to store any
-      transient state between failures. As an example it could be used to count
-      error failures and stop or skip the problematic event after too many.
-    - `metadata` - the metadata associated with the failed event.
-    - `stacktrace` - the stacktrace if the error was an unhandled exception.
+    - `:application` - the associated `Commanded.Application`.
+
+    - `:handler_name` - the name of the event handler.
+
+    - `:handler_state` - optional event handler state.
+
+    - `:context` - a map that is passed between each failure. Use it to store
+      any transient state between failures. As an example it could be used to
+      count error failures and stop or skip the problematic event after too
+      many.
+
+    - `:metadata` - the metadata associated with the failed event.
+
+    - `:stacktrace` - the stacktrace if the error was an unhandled exception.
 
   """
 
   @type t :: %__MODULE__{
           application: Commanded.Application.t(),
           handler_name: String.t(),
+          handler_state: nil | any(),
           context: map(),
           metadata: map(),
           stacktrace: Exception.stacktrace() | nil
@@ -25,6 +33,7 @@ defmodule Commanded.Event.FailureContext do
   defstruct [
     :application,
     :handler_name,
+    :handler_state,
     :context,
     :metadata,
     :stacktrace

--- a/lib/commanded/process_managers/failure_context.ex
+++ b/lib/commanded/process_managers/failure_context.ex
@@ -6,10 +6,14 @@ defmodule Commanded.ProcessManagers.FailureContext do
 
     - `context` - the context map passed between each failure and may be used
       to track state between retries, such as to count failures.
-    - `last_event` - the last event the process manager received
-    - `pending_commands` - the pending commands that were not executed yet
+
+    - `last_event` - the last event the process manager received.
+
+    - `pending_commands` - the pending commands that were not executed yet.
+
     - `process_manager_state` - the state the process manager would be in
       if the command would not fail.
+
     - `stacktrace` - the stacktrace if the error was an unhandled exception.
 
   """

--- a/test/event/event_handler_state_test.exs
+++ b/test/event/event_handler_state_test.exs
@@ -1,0 +1,99 @@
+defmodule Commanded.Event.EventHandlerStateTest do
+  use ExUnit.Case
+
+  alias Commanded.Event.StatefulEventHandler
+  alias Commanded.DefaultApp
+  alias Commanded.Helpers.EventFactory
+
+  defmodule AnEvent do
+    @derive Jason.Encoder
+    defstruct [:reply_to, :update_state?]
+  end
+
+  describe "event handler state" do
+    setup do
+      start_supervised!(DefaultApp)
+      :ok
+    end
+
+    test "initially set in `init/1` function" do
+      handler = start_supervised!(StatefulEventHandler)
+
+      event = %AnEvent{reply_to: self(), update_state?: true}
+      send_events_to_handler(handler, [event])
+
+      assert_receive {:event, ^event, metadata}
+      assert match?(%{state: 0}, metadata)
+    end
+
+    test "initially set as runtime option" do
+      handler = start_supervised!({StatefulEventHandler, state: 1})
+
+      event = %AnEvent{reply_to: self(), update_state?: true}
+      send_events_to_handler(handler, [event])
+
+      assert_receive {:event, ^event, metadata}
+      assert match?(%{state: 1}, metadata)
+    end
+
+    test "updated by returning `{:ok, new_state}` from `handle/2` function" do
+      handler = start_supervised!(StatefulEventHandler)
+
+      event1 = %AnEvent{reply_to: self(), update_state?: true}
+      event2 = %AnEvent{reply_to: self(), update_state?: true}
+      send_events_to_handler(handler, [event1, event2])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 0}, metadata)
+
+      assert_receive {:event, ^event2, metadata}
+      assert match?(%{state: 1}, metadata)
+    end
+
+    test "not updated when returning `:ok` from `handle/2` function" do
+      handler = start_supervised!(StatefulEventHandler)
+
+      event1 = %AnEvent{reply_to: self(), update_state?: false}
+      event2 = %AnEvent{reply_to: self(), update_state?: false}
+      send_events_to_handler(handler, [event1, event2])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 0}, metadata)
+
+      assert_receive {:event, ^event2, metadata}
+      assert match?(%{state: 0}, metadata)
+    end
+
+    test "state is reset when process restarts" do
+      handler = start_supervised!({StatefulEventHandler, state: 10})
+
+      event1 = %AnEvent{reply_to: self(), update_state?: true}
+      event2 = %AnEvent{reply_to: self(), update_state?: true}
+      send_events_to_handler(handler, [event1, event2])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 10}, metadata)
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 11}, metadata)
+
+      %{id: id} = StatefulEventHandler.child_spec([])
+
+      stop_supervised!(id)
+
+      handler = start_supervised!({StatefulEventHandler, state: 10})
+
+      event3 = %AnEvent{reply_to: self(), update_state?: true}
+      send_events_to_handler(handler, [event3], 3)
+
+      assert_receive {:event, ^event3, metadata}
+      assert match?(%{state: 10}, metadata)
+    end
+  end
+
+  defp send_events_to_handler(handler, events, initial_event_number \\ 1) do
+    recorded_events = EventFactory.map_to_recorded_events(events, initial_event_number)
+
+    send(handler, {:events, recorded_events})
+  end
+end

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -41,6 +41,7 @@ defmodule Commanded.Event.HandleEventTest do
       assert_enriched_metadata(metadata1, Enum.at(recorded_events, 0),
         additional_metadata: %{
           application: DefaultApp,
+          state: nil,
           handler_name: "Commanded.Event.EchoHandler"
         }
       )
@@ -50,6 +51,7 @@ defmodule Commanded.Event.HandleEventTest do
       assert_enriched_metadata(metadata2, Enum.at(recorded_events, 1),
         additional_metadata: %{
           application: DefaultApp,
+          state: nil,
           handler_name: "Commanded.Event.EchoHandler"
         }
       )
@@ -125,6 +127,7 @@ defmodule Commanded.Event.HandleEventTest do
       assert_enriched_metadata(metadata1, Enum.at(recorded_events1, 0),
         additional_metadata: %{
           application: :app1,
+          state: nil,
           handler_name: "handler1"
         }
       )
@@ -137,6 +140,7 @@ defmodule Commanded.Event.HandleEventTest do
       assert_enriched_metadata(metadata2, Enum.at(recorded_events2, 0),
         additional_metadata: %{
           application: :app2,
+          state: nil,
           handler_name: "handler2"
         }
       )

--- a/test/event/support/state/stateful_event_handler.ex
+++ b/test/event/support/state/stateful_event_handler.ex
@@ -1,0 +1,28 @@
+defmodule Commanded.Event.StatefulEventHandler do
+  use Commanded.Event.Handler,
+    application: Commanded.DefaultApp,
+    name: __MODULE__
+
+  def init(config) do
+    config = Keyword.put_new(config, :state, 0)
+
+    {:ok, config}
+  end
+
+  def handle(%{update_state?: true} = event, metadata) do
+    %{reply_to: reply_to} = event
+    %{state: state} = metadata
+
+    send(reply_to, {:event, event, metadata})
+
+    {:ok, state + 1}
+  end
+
+  def handle(%{update_state?: false} = event, metadata) do
+    %{reply_to: reply_to} = event
+
+    send(reply_to, {:event, event, metadata})
+
+    :ok
+  end
+end

--- a/test/helpers/process_helper.ex
+++ b/test/helpers/process_helper.ex
@@ -9,28 +9,20 @@ defmodule Commanded.Helpers.ProcessHelper do
   @doc """
   Stop the given process with a non-normal exit reason.
   """
-  def shutdown(pid) when is_pid(pid) do
+  def shutdown(pid, reason \\ :shutdown)
+
+  def shutdown(pid, reason) when is_pid(pid) do
     Process.unlink(pid)
-    Process.exit(pid, :shutdown)
+    Process.exit(pid, reason)
 
     ref = Process.monitor(pid)
     assert_receive {:DOWN, ^ref, _, _, _}, 5_000
   end
 
-  def shutdown(name) when is_atom(name) do
+  def shutdown(name, reason) when is_atom(name) do
     case Process.whereis(name) do
       nil -> :ok
-      pid -> shutdown(pid)
-    end
-  end
-
-  @doc """
-  Shutdown a named process.
-  """
-  def shutdown(name) when is_atom(name) do
-    case Process.whereis(name) do
-      nil -> :ok
-      pid -> shutdown(pid)
+      pid -> shutdown(pid, reason)
     end
   end
 


### PR DESCRIPTION
An event handler can define and update custom state which is held in the `GenServer` process' memory. It is passed to the `handle/2` function as part of the metadata using the `:state` key. The state is transient and will be lost whenever the process restarts. 

Initial state can be set in the `init/1` callback function by adding a `:state` key to the config. It can also be provided when starting the handler process:

```elixir
ExampleHandler.start_link(state: initial_state)
```

Or when supervised:

```elixir
Supervisor.start_link([
  {ExampleHandler, state: initial_state}
], strategy: :one_for_one)
```

State can be updated by returning `{:ok, new_state}` from any `handle/2` function. Returning an `:ok` reply will keep the state unchanged.

Handler state is also included in the `Commanded.Event.FailureContext` struct passed to the `error/3` callback function.

### Example

```elixir
defmodule StatefulEventHandler do
  use Commanded.Event.Handler,
    application: ExampleApp,
    name: __MODULE__

  def init(config) do
    config = Keyword.put_new(config, :state, %{})

    {:ok, config}
  end

  def handle(event, metadata) do
    %{state: state} = metadata

    new_state = mutate_state(state)

    {:ok, new_state}
  end
end
```

Closes #366.