### PR TITLE
Pass execution context to aggregates before execution

### DIFF
--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -20,10 +20,15 @@ defmodule Commanded.Aggregates.ExecutionContext do
     - `handler` - the module that handles the command. It may be either the
       aggregate module itself or a separate command handler module.
 
-    - `function` - the name of function, as an atom, that handles the command.
+    - `function` - the name of the function, as an atom, that handles the command.
       The default value is `:execute`, used to support command dispatch directly
       to the aggregate module. For command handlers the `:handle` function is
       used.
+
+    - `before_execute` - the name of the function, as an atom, that prepares the
+      command before execution, called just before `function`. The default value
+      is `nil`, disabling it. It should return `:ok` on success or `{:error, any()}`
+      to cancel the dispatch.
 
     - `lifespan` - a module implementing the `Commanded.Aggregates.AggregateLifespan`
       behaviour to control the aggregate instance process lifespan. The default
@@ -41,8 +46,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
     :command,
     :causation_id,
     :correlation_id,
-    :function,
     :handler,
+    :function,
+    before_execute: nil,
     retry_attempts: 0,
     returning: false,
     lifespan: DefaultLifespan,

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -19,6 +19,7 @@ defmodule Commanded.Commands.Dispatcher do
       :consistency,
       :handler_module,
       :handler_function,
+      :handler_before_execute,
       :aggregate_module,
       :identity,
       :identity_prefix,
@@ -141,6 +142,7 @@ defmodule Commanded.Commands.Dispatcher do
       correlation_id: correlation_id,
       handler_module: handler_module,
       handler_function: handler_function,
+      handler_before_execute: handler_before_execute,
       lifespan: lifespan,
       retry_attempts: retry_attempts,
       returning: returning
@@ -153,6 +155,7 @@ defmodule Commanded.Commands.Dispatcher do
       metadata: metadata,
       handler: handler_module,
       function: handler_function,
+      before_execute: handler_before_execute,
       lifespan: lifespan,
       retry_attempts: retry_attempts,
       returning: returning

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -497,6 +497,7 @@ defmodule Commanded.Commands.Router do
         @aggregate Keyword.fetch!(command_opts, :aggregate)
         @handler Keyword.fetch!(command_opts, :to)
         @function Keyword.fetch!(command_opts, :function)
+        @before_execute Keyword.get(command_opts, :before_execute)
         @lifespan Keyword.get(command_opts, :lifespan)
         @identity Keyword.get(command_opts, :identity)
         @identity_prefix Keyword.get(command_opts, :identity_prefix)
@@ -559,6 +560,7 @@ defmodule Commanded.Commands.Router do
             consistency: consistency,
             handler_module: @handler,
             handler_function: @function,
+            handler_before_execute: @before_execute,
             aggregate_module: @aggregate,
             identity: identity,
             identity_prefix: identity_prefix,
@@ -615,6 +617,7 @@ defmodule Commanded.Commands.Router do
   @register_params [
     :to,
     :function,
+    :before_execute,
     :aggregate,
     :identity,
     :identity_prefix,

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -220,7 +220,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     assert_raise RuntimeError,
                  """
                  unexpected dispatch parameter "id"
-                 available params are: to, function, aggregate, identity, identity_prefix, timeout, lifespan, consistency
+                 available params are: to, function, before_execute, aggregate, identity, identity_prefix, timeout, lifespan, consistency
                  """,
                  fn ->
                    Code.eval_string("""


### PR DESCRIPTION
Add an optional `before_execute/2` callback to Aggregates, called just before the `execute/2` callback, with the user-defined aggregate state and the current execution context. This is particularly useful to do some setup in the context of the aggregate process (e.g. set the aggregate's own logger's metadata).

See issue https://github.com/commanded/commanded/issues/403