### PR TITLE
Process Managers: mutate state before handling event

### DIFF
--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -223,6 +223,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
                 :ok = persist_state(event_number, state)
                 :ok = ack_event(event, state)
                 {:noreply, state, idle_timeout}
+
               {:stop, reason} ->
                 {:stop, reason, state}
             end


### PR DESCRIPTION
The handle-first behavior is awkward to work with, and seems confusing to others (see #176).
This change flips around the two calls, so a process manager's state is mutated before the event is handled.

I made sure not to ack the current event or serialize the new state until we're sure the handler function
has succeeded and commands have been dispatched.
That way, if the handler blows up, we aren't storing a corrupt state and can retry the apply & handle with no worries.

Fixes #176 .