### PR TITLE
 start/stop Aggregate telemetry events

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,6 +8,7 @@ locals_without_parens = [
 ]
 
 [
+  import_deps: [:telemetry_registry],
   inputs: [
     "{mix,.formatter}.exs",
     "{config,lib,test}/**/*.{ex,exs}"

--- a/mix.exs
+++ b/mix.exs
@@ -58,6 +58,10 @@ defmodule Commanded.Mixfile do
       {:backoff, "~> 1.1"},
       {:elixir_uuid, "~> 1.2"},
 
+      # Telemetry
+      {:telemetry, "~> 0.4.2"},
+      {:telemetry_registry, "~> 0.2.0"},
+
       # Optional dependencies
       {:jason, "~> 1.2", optional: true},
       {:phoenix_pubsub, "~> 2.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -16,4 +16,6 @@
   "mox": {:hex, :mox, "0.5.2", "55a0a5ba9ccc671518d068c8dddd20eeb436909ea79d1799e2209df7eaa98b6c", [:mix], [], "hexpm", "df4310628cd628ee181df93f50ddfd07be3e5ecc30232d3b6aadf30bdfe6092b"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "2.0.0", "a1ae76717bb168cdeb10ec9d92d1480fec99e3080f011402c0a2d68d47395ffb", [:mix], [], "hexpm", "c52d948c4f261577b9c6fa804be91884b381a7f8f18450c5045975435350f771"},
+  "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
+  "telemetry_registry": {:hex, :telemetry_registry, "0.2.0", "201820aadd05d4162287583adbffe3b1b046183750d66f650894b55e6d363f95", [:mix, :rebar3], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "1311bcc021e2a2ef71941327bab3d410c6652245231e59a19210b606ecfb76f1"},
 }


### PR DESCRIPTION
<img width="888" alt="Screen Shot 2020-10-29 at 2 44 18 PM" src="https://user-images.githubusercontent.com/1019721/97618477-7117d000-19f5-11eb-81d6-497e9446ad25.png">

Contributes to #387

Adds two telemetry events to the Aggregate GenServer

1. [:commanded, :aggregate, :execute, :start]
2. [:commanded, :aggregate, :execute, :stop]

Each provide the `%ExecutionContext{}` and `%Aggregate{}` as metadata.
This allows metrics and tracing instrumentation elsewhere.

As an example of how this can be useful, I have built a small working
prototype here.

https://github.com/davydog187/foosball