### PR TITLE
Define `Commanded.Telemetry` module to emit consistent telemetry events

### DIFF
--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -69,7 +69,7 @@ defmodule Commanded.Aggregates.ExecutionContext do
     {:ok, context}
   end
 
-  def format_reply(reply, %ExecutionContext{} = context, %Aggregate{} = aggregate) do
+  def format_reply(result, %ExecutionContext{} = context, %Aggregate{} = aggregate) do
     %Aggregate{
       aggregate_uuid: aggregate_uuid,
       aggregate_state: aggregate_state,
@@ -78,7 +78,7 @@ defmodule Commanded.Aggregates.ExecutionContext do
 
     %ExecutionContext{metadata: metadata, returning: returning} = context
 
-    with {:ok, events} <- reply do
+    with {:ok, events} <- result do
       case returning do
         :aggregate_state ->
           {:ok, aggregate_version, events, aggregate_state}
@@ -100,6 +100,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
         false ->
           {:ok, aggregate_version, events}
       end
+    else
+      {:error, _error} = reply -> reply
+      {:error, error, _stacktrace} -> {:error, error}
     end
   end
 end

--- a/lib/commanded/telemetry.ex
+++ b/lib/commanded/telemetry.ex
@@ -1,0 +1,39 @@
+defmodule Commanded.Telemetry do
+  @moduledoc false
+
+  def start(event_prefix, metadata \\ %{}, additional_measurements \\ %{}) do
+    start_time = System.monotonic_time()
+    measurements = Map.put(additional_measurements, :system_time, System.system_time())
+
+    :telemetry.execute(event_prefix ++ [:start], measurements, metadata)
+
+    start_time
+  end
+
+  def stop(event_prefix, start_time, metadata \\ %{}, additional_measurements \\ %{}) do
+    measurements = include_duration(start_time, additional_measurements)
+
+    :telemetry.execute(event_prefix ++ [:stop], measurements, metadata)
+  end
+
+  def exception(
+        event_prefix,
+        start_time,
+        kind,
+        reason,
+        stacktrace,
+        metadata \\ %{},
+        additional_measurements \\ %{}
+      ) do
+    measurements = include_duration(start_time, additional_measurements)
+    metadata = Map.merge(metadata, %{kind: kind, reason: reason, stacktrace: stacktrace})
+
+    :telemetry.execute(event_prefix ++ [:exception], measurements, metadata)
+  end
+
+  defp include_duration(start_time, measurements) do
+    end_time = System.monotonic_time()
+
+    Map.put(measurements, :duration, end_time - start_time)
+  end
+end

--- a/test/aggregates/aggregate_telemetry_test.exs
+++ b/test/aggregates/aggregate_telemetry_test.exs
@@ -1,0 +1,223 @@
+defmodule Commanded.Aggregates.AggregateTelemetryTest do
+  use ExUnit.Case
+
+  alias Commanded.Aggregates.Aggregate
+  alias Commanded.Aggregates.ExecutionContext
+  alias Commanded.DefaultApp
+
+  defmodule Commands do
+    defmodule Ok do
+      defstruct [:message]
+    end
+
+    defmodule Error do
+      defstruct [:message]
+    end
+
+    defmodule RaiseException do
+      defstruct [:message]
+    end
+  end
+
+  defmodule Event do
+    @derive Jason.Encoder
+    defstruct [:message]
+  end
+
+  defmodule ExampleAggregate do
+    alias Commands.{Ok, Error, RaiseException}
+
+    defstruct [:message]
+
+    def execute(%ExampleAggregate{}, %Ok{message: message}), do: %Event{message: message}
+    def execute(%ExampleAggregate{}, %Error{message: message}), do: {:error, message}
+    def execute(%ExampleAggregate{}, %RaiseException{message: message}), do: raise(message)
+
+    def apply(%ExampleAggregate{}, %Event{message: message}),
+      do: %ExampleAggregate{message: message}
+  end
+
+  alias Commands.{Ok, Error, RaiseException}
+
+  setup do
+    start_supervised!(DefaultApp)
+    attach_telemetry()
+    :ok
+  end
+
+  describe "aggregate telemetry" do
+    setup do
+      aggregate_uuid = UUID.uuid4()
+
+      {:ok, pid} = start_aggregate(aggregate_uuid)
+
+      [aggregate_uuid: aggregate_uuid, pid: pid]
+    end
+
+    test "emit `[:commanded, :aggregate, :execute, :start]` event",
+         %{aggregate_uuid: aggregate_uuid, pid: pid} do
+      context = %ExecutionContext{
+        command: %Ok{message: "ok"},
+        function: :execute,
+        handler: ExampleAggregate
+      }
+
+      self = self()
+
+      {:ok, 1, _events} = GenServer.call(pid, {:execute_command, context})
+
+      assert_receive {[:commanded, :aggregate, :execute, :start], measurements, metadata}
+
+      assert match?(%{system_time: _system_time}, measurements)
+      assert is_number(measurements.system_time)
+
+      assert match?(
+               %{
+                 aggregate_state: %ExampleAggregate{},
+                 aggregate_uuid: ^aggregate_uuid,
+                 aggregate_version: 0,
+                 application: Commanded.DefaultApp,
+                 caller: ^self,
+                 execution_context: ^context
+               },
+               metadata
+             )
+
+      assert_receive {[:commanded, :aggregate, :execute, :stop], _measurements, _metadata}
+      refute_received {[:commanded, :aggregate, :execute, :exception], _measurements, _metadata}
+    end
+
+    test "emit `[:commanded, :aggregate, :execute, :stop]` event",
+         %{aggregate_uuid: aggregate_uuid, pid: pid} do
+      context = %ExecutionContext{
+        command: %Ok{message: "ok"},
+        function: :execute,
+        handler: ExampleAggregate
+      }
+
+      self = self()
+
+      {:ok, 1, events} = GenServer.call(pid, {:execute_command, context})
+
+      assert_receive {[:commanded, :aggregate, :execute, :start], _measurements, _metadata}
+      assert_receive {[:commanded, :aggregate, :execute, :stop], measurements, metadata}
+
+      assert match?(%{duration: _duration}, measurements)
+      assert is_number(measurements.duration)
+
+      assert match?(
+               %{
+                 aggregate_state: %ExampleAggregate{message: "ok"},
+                 aggregate_uuid: ^aggregate_uuid,
+                 aggregate_version: 1,
+                 application: Commanded.DefaultApp,
+                 caller: ^self,
+                 execution_context: ^context,
+                 events: ^events
+               },
+               metadata
+             )
+
+      refute_received {[:commanded, :aggregate, :execute, :exception], _measurements, _metadata}
+    end
+
+    test "emit `[:commanded, :aggregate, :execute, :stop]` with error event",
+         %{aggregate_uuid: aggregate_uuid, pid: pid} do
+      context = %ExecutionContext{
+        command: %Error{message: "an error"},
+        function: :execute,
+        handler: ExampleAggregate
+      }
+
+      self = self()
+
+      {:error, "an error"} = GenServer.call(pid, {:execute_command, context})
+
+      assert_receive {[:commanded, :aggregate, :execute, :start], _measurements, _metadata}
+      assert_receive {[:commanded, :aggregate, :execute, :stop], measurements, metadata}
+
+      assert match?(%{duration: _duration}, measurements)
+      assert is_number(measurements.duration)
+
+      assert match?(
+               %{
+                 aggregate_state: %ExampleAggregate{},
+                 aggregate_uuid: ^aggregate_uuid,
+                 aggregate_version: 0,
+                 application: Commanded.DefaultApp,
+                 caller: ^self,
+                 execution_context: ^context,
+                 error: "an error"
+               },
+               metadata
+             )
+
+      refute_received {[:commanded, :aggregate, :execute, :exception], _measurements, _metadata}
+    end
+
+    test "emit `[:commanded, :aggregate, :execute, :exception]` event",
+         %{aggregate_uuid: aggregate_uuid, pid: pid} do
+      context = %ExecutionContext{
+        command: %RaiseException{message: "an exception"},
+        function: :execute,
+        handler: ExampleAggregate
+      }
+
+      self = self()
+
+      Process.unlink(pid)
+
+      {:error, %RuntimeError{message: "an exception"}} =
+        GenServer.call(pid, {:execute_command, context})
+
+      assert_receive {[:commanded, :aggregate, :execute, :start], _measurements, _metadata}
+      assert_receive {[:commanded, :aggregate, :execute, :exception], measurements, metadata}
+
+      assert match?(%{duration: _duration}, measurements)
+      assert is_number(measurements.duration)
+
+      assert match?(
+               %{
+                 aggregate_state: %ExampleAggregate{},
+                 aggregate_uuid: ^aggregate_uuid,
+                 aggregate_version: 0,
+                 application: Commanded.DefaultApp,
+                 caller: ^self,
+                 execution_context: ^context,
+                 kind: :error,
+                 reason: %RuntimeError{message: "an exception"},
+                 stacktrace: _stacktrace
+               },
+               metadata
+             )
+
+      refute_received {[:commanded, :aggregate, :execute, :stop], _measurements, _metadata}
+    end
+  end
+
+  def start_aggregate(aggregate_uuid) do
+    Aggregate.start_link([application: DefaultApp],
+      aggregate_module: ExampleAggregate,
+      aggregate_uuid: aggregate_uuid
+    )
+  end
+
+  defp attach_telemetry do
+    :telemetry.attach_many(
+      "test-handler",
+      [
+        [:commanded, :aggregate, :execute, :start],
+        [:commanded, :aggregate, :execute, :stop],
+        [:commanded, :aggregate, :execute, :exception]
+      ],
+      fn event_name, measurements, metadata, reply_to ->
+        send(reply_to, {event_name, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn ->
+      :telemetry.detach("test-handler")
+    end)
+  end
+end


### PR DESCRIPTION
Follow the conventions defined in the [telemetry](https://hexdocs.pm/telemetry/) library's `span/3` function for naming convention (`:start`, `:stop`, `:exception`) and the structure of measurements and metadata.