### PR TITLE
Fix the telemetry event ordering

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Commanded.Mixfile do
 
       # Telemetry
       {:telemetry, "~> 0.4.2"},
-      {:telemetry_registry, "~> 0.2.0"},
+      {:telemetry_registry, "~> 0.2.1"},
 
       # Optional dependencies
       {:jason, "~> 1.2", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -17,5 +17,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "2.0.0", "a1ae76717bb168cdeb10ec9d92d1480fec99e3080f011402c0a2d68d47395ffb", [:mix], [], "hexpm", "c52d948c4f261577b9c6fa804be91884b381a7f8f18450c5045975435350f771"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
-  "telemetry_registry": {:hex, :telemetry_registry, "0.2.0", "201820aadd05d4162287583adbffe3b1b046183750d66f650894b55e6d363f95", [:mix, :rebar3], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "1311bcc021e2a2ef71941327bab3d410c6652245231e59a19210b606ecfb76f1"},
+  "telemetry_registry": {:hex, :telemetry_registry, "0.2.1", "fe648a691f2128e4279d993cd010994c67f282354dc061e697bf070d4b87b480", [:mix, :rebar3], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "4221cefbcadd0b3e7076960339223742d973f1371bc20f3826af640257bc3690"},
 }


### PR DESCRIPTION
Pulls in my PR to `telemetry_registry`, which fixes the ordering of generated telemetry event documentation 

https://github.com/beam-telemetry/telemetry_registry/pull/9

<img width="916" alt="Screen Shot 2020-12-03 at 7 04 44 PM" src="https://user-images.githubusercontent.com/1019721/101105078-a8504280-359a-11eb-8027-da5d85ecb266.png">
