### PR TITLE
Make the documentation sidebar more readable

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -159,6 +159,7 @@ defmodule Commanded.Mixfile do
         ],
         "Event Store": [
           Commanded.EventStore,
+          Commanded.EventStore.Adapter,
           Commanded.EventStore.Adapters.InMemory,
           Commanded.EventStore.EventData,
           Commanded.EventStore.RecordedEvent,
@@ -167,12 +168,15 @@ defmodule Commanded.Mixfile do
         ],
         "Pub Sub": [
           Commanded.PubSub,
+          Commanded.PubSub.Adapter,
           Commanded.PubSub.LocalPubSub,
           Commanded.PubSub.PhoenixPubSub
         ],
         Registry: [
           Commanded.Registration,
-          Commanded.Registration.LocalRegistry
+          Commanded.Registration.Adapter,
+          Commanded.Registration.LocalRegistry,
+          Commanded.Registration.GlobalRegistry
         ],
         Serialization: [
           Commanded.Serialization.JsonDecoder,
@@ -193,6 +197,18 @@ defmodule Commanded.Mixfile do
           Commanded.AggregateCase,
           Commanded.Assertions.EventAssertions
         ]
+      ],
+      nest_modules_by_prefix: [
+        Commanded.Aggregate,
+        Commanded.Aggregates,
+        Commanded.Commands,
+        Commanded.Event,
+        Commanded.ProcessManagers,
+        Commanded.EventStore,
+        Commanded.PubSub,
+        Commanded.Registration,
+        Commanded.Serialization,
+        Commanded.Middleware
       ]
     ]
   end


### PR DESCRIPTION
This PR should hopefully make the documentation sidebar massively easier to read and navigate. This one has been bugging me for a while, luckily https://github.com/elixir-lang/ex_doc has a great solution with `:nest_modules_by_prefix`! 

<img width="266" alt="Screen Shot 2020-12-03 at 7 23 44 PM" src="https://user-images.githubusercontent.com/1019721/101106053-30374c00-359d-11eb-8f9a-a705bfb67d10.png">
