### PR TITLE
Fix the Process Manager example

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -28,6 +28,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
           application: ExampleApp,
           name: "ExampleProcessManager"
 
+        defstruct []
+
         def interested?(%AnEvent{uuid: uuid}), do: {:start, uuid}
 
         def handle(%ExampleProcessManager{}, %ExampleEvent{}) do


### PR DESCRIPTION
The macro doesn't define a struct for you. This makes it closer to making the example "compile" if it were real code.