### PR TITLE
Mark ProcessManager callbacks as optional

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -370,6 +370,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | {:skip, :continue_pending}
               | {:stop, reason :: term()}
 
+  @optional_callbacks init: 1, handle: 2, apply: 2, error: 3, interested?: 1
+
   alias Commanded.ProcessManagers.ProcessManager
   alias Commanded.ProcessManagers.ProcessRouter
 


### PR DESCRIPTION
- `init/1`
- `handle/2`
- `apply/2`
- `error/3`
- `interested?/1`

This will improve the documentation, see https://hexdocs.pm/elixir/GenServer.html#c:handle_info/2 for an example 

<img width="858" alt="Screen Shot 2020-12-30 at 6 27 15 PM" src="https://user-images.githubusercontent.com/1019721/103386401-a5c70700-4acc-11eb-9599-ca125948d39d.png">
