### PR TITLE
Retry command execution on node down

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -94,11 +94,20 @@ defmodule Commanded.Commands.Dispatcher do
 
     result =
       case Task.yield(task, timeout) || Task.shutdown(task) do
-        {:ok, result} -> result
-        {:exit, {:normal, :aggregate_stopped}} = result -> result
-        {:exit, {{:nodedown, _node_name}, {GenServer, :call, _}}} -> {:error, :remote_aggregate_not_found}
-        {:exit, _reason} -> {:error, :aggregate_execution_failed}
-        nil -> {:error, :aggregate_execution_timeout}
+        {:ok, result} ->
+          result
+
+        {:exit, {:normal, :aggregate_stopped}} = result ->
+          result
+
+        {:exit, {{:nodedown, _node_name}, {GenServer, :call, _}}} ->
+          {:error, :remote_aggregate_not_found}
+
+        {:exit, _reason} ->
+          {:error, :aggregate_execution_failed}
+
+        nil ->
+          {:error, :aggregate_execution_timeout}
       end
 
     case result do

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -101,7 +101,7 @@ defmodule Commanded.Commands.Dispatcher do
           result
 
         {:exit, {{:nodedown, _node_name}, {GenServer, :call, _}}} ->
-          {:error, :remote_aggregate_not_found}
+          {:error, :remote_node_down}
 
         {:exit, _reason} ->
           {:error, :aggregate_execution_failed}
@@ -129,7 +129,7 @@ defmodule Commanded.Commands.Dispatcher do
         # Maybe retry command when aggregate process stopped by lifespan timeout
         maybe_retry(pipeline, payload, context)
 
-      {:error, :remote_aggregate_not_found} ->
+      {:error, :remote_node_down} ->
         # Maybe retry command when aggregate process not found on a remote node
         maybe_retry(pipeline, payload, context)
 


### PR DESCRIPTION
Retry failed command dispatch due to the registered node for an aggregate being down when we try to execute against it.

Given an Aggregate A that was spawned on Node X and a command for A is
received on Node Y. If X is shutdown/killed after Y has
located the process for A on X, then the command will fail.

This PR allows the command to be retried, which will result in a new process
for A being opened on Node Y and the command will succeed from the
caller's perspective.