### PR TITLE
Make sure the metadata must be map type.

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -519,7 +519,8 @@ defmodule Commanded.Commands.Router do
           command_uuid = Keyword.get(opts, :command_uuid, UUID.uuid4())
           consistency = Keyword.fetch!(opts, :consistency)
           correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-          metadata = Keyword.fetch!(opts, :metadata)
+          metadata = opts |> Keyword.fetch!(:metadata) |> validate_metadata()
+
           retry_attempts = Keyword.get(opts, :retry_attempts)
           timeout = Keyword.fetch!(opts, :timeout)
 
@@ -588,6 +589,10 @@ defmodule Commanded.Commands.Router do
 
         {:error, :unregistered_command}
       end
+
+      # Make sure the metadata must be Map.t()
+      defp validate_metadata(value) when is_map(value), do: value
+      defp validate_metadata(_), do: raise(ArgumentError, message: "metadata must be an map")
     end
   end
 

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -322,4 +322,16 @@ defmodule Commanded.Commands.RoutingCommandsTest do
       assert event.metadata == metadata
     end)
   end
+
+  test "make sure metadata must be map" do
+    metadata = [ip_address: "127.0.0.1"]
+
+    assert_raise ArgumentError, "metadata must be an map", fn ->
+      MultiCommandHandlerRouter.dispatch(
+        %OpenAccount{account_number: "ACC123", initial_balance: 1_000},
+        application: DefaultApp,
+        metadata: metadata
+      )
+    end
+  end
 end


### PR DESCRIPTION
When a non-map type metadata is entered, Raise an exception.