### PR TITLE
Migrate to erlef/setup-beam

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{matrix.elixir}}
         otp-version: ${{matrix.otp}}
-        experimental-otp: true
 
     - name: Restore dependencies cache
       uses: actions/cache@v2


### PR DESCRIPTION
The EEF has taken ownership over the GHA for setting up Elixir/Erlang. The previous action is now archived. https://github.com/erlef/setup-beam