### PR TITLE
EventStore telemetry events

### DIFF
--- a/lib/commanded/event_store.ex
+++ b/lib/commanded/event_store.ex
@@ -1,6 +1,4 @@
 defmodule Commanded.EventStore do
-  use TelemetryRegistry
-
   @moduledoc """
   Use the event store configured for a Commanded application.
 

--- a/test/event_store/telemetry_test.exs
+++ b/test/event_store/telemetry_test.exs
@@ -3,6 +3,7 @@ defmodule Commanded.EventStore.TelemetryTest do
 
   alias Commanded.DefaultApp
   alias Commanded.EventStore
+  alias Commanded.EventStore.EventData
   alias Commanded.EventStore.RecordedEvent
   alias Commanded.EventStore.SnapshotData
   alias Commanded.Middleware.Commands.IncrementCount
@@ -34,59 +35,98 @@ defmodule Commanded.EventStore.TelemetryTest do
 
   describe "snapshotting telemetry events" do
     test "emit `[:commanded, :event_store, :record_snapshot, :start | :stop]` event" do
-      assert :ok = EventStore.record_snapshot(DefaultApp, %SnapshotData{})
+      snapshot = %SnapshotData{}
+      assert :ok = EventStore.record_snapshot(DefaultApp, snapshot)
 
       assert_receive {[:commanded, :event_store, :record_snapshot, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :record_snapshot, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :record_snapshot, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, snapshot: ^snapshot} = meta
     end
 
     test "emit `[:commanded, :event_store, :read_snapshot, :start | :stop]` event" do
-      assert {:error, :snapshot_not_found} = EventStore.read_snapshot(DefaultApp, UUID.uuid4())
+      uuid = UUID.uuid4()
+      assert {:error, :snapshot_not_found} = EventStore.read_snapshot(DefaultApp, uuid)
 
       assert_receive {[:commanded, :event_store, :read_snapshot, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :read_snapshot, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :read_snapshot, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, source_uuid: ^uuid} = meta
     end
 
     test "emit `[:commanded, :event_store, :delete_snapshot, :start | :stop]` event" do
-      assert :ok = EventStore.delete_snapshot(DefaultApp, UUID.uuid4())
+      uuid = UUID.uuid4()
+      assert :ok = EventStore.delete_snapshot(DefaultApp, uuid)
 
       assert_receive {[:commanded, :event_store, :delete_snapshot, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :delete_snapshot, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :delete_snapshot, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, source_uuid: ^uuid} = meta
     end
   end
 
   describe "streaming telemetry events" do
     test "emit `[:commanded, :event_store, :stream_forward, :start | :stop]` event" do
-      assert {:error, :stream_not_found} = EventStore.stream_forward(DefaultApp, UUID.uuid4())
+      uuid = UUID.uuid4()
+      assert {:error, :stream_not_found} = EventStore.stream_forward(DefaultApp, uuid)
 
       assert_receive {[:commanded, :event_store, :stream_forward, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :stream_forward, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :stream_forward, :stop], 2, _meas, meta}
+
+      assert %{
+               application: DefaultApp,
+               stream_uuid: ^uuid,
+               start_version: 0,
+               read_batch_size: 1_000
+             } = meta
     end
   end
 
   describe "ack_event telemetry events" do
     test "emit `[:commanded, :event_store, :ack_event, :start | :stop]` event" do
-      assert :ok = EventStore.ack_event(DefaultApp, self(), %RecordedEvent{})
+      pid = self()
+      event = %RecordedEvent{}
+      assert :ok = EventStore.ack_event(DefaultApp, pid, event)
 
       assert_receive {[:commanded, :event_store, :ack_event, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :ack_event, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :ack_event, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, subscription: ^pid, event: ^event} = meta
+    end
+  end
+
+  describe "append_to_stream telemetry events" do
+    test "emit `[:commanded, :event_store, :append_to_stream, :start | :stop]` event" do
+      uuid = UUID.uuid4()
+      assert :ok = EventStore.append_to_stream(DefaultApp, uuid, 0, [%EventData{}])
+
+      assert_receive {[:commanded, :event_store, :append_to_stream, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :append_to_stream, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, expected_version: 0, stream_uuid: ^uuid} = meta
     end
   end
 
   describe "subscription telemetry events" do
     test "emit `[:commanded, :event_store, :subscribe, :start | :stop]` event" do
-      assert :ok = EventStore.subscribe(DefaultApp, UUID.uuid4())
+      uuid = UUID.uuid4()
+      assert :ok = EventStore.subscribe(DefaultApp, uuid)
 
       assert_receive {[:commanded, :event_store, :subscribe, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :subscribe, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :subscribe, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, stream_uuid: ^uuid} = meta
     end
 
     test "emit `[:commanded, :event_store, :subscribe_to, :start | :stop]` event" do
-      assert {:ok, pid} = EventStore.subscribe_to(DefaultApp, :all, "Test", self(), :current)
+      subscriber = self()
+      assert {:ok, pid} = EventStore.subscribe_to(DefaultApp, :all, "Test", subscriber, :current)
 
       assert_receive {:subscribed, ^pid}
       assert_receive {[:commanded, :event_store, :subscribe_to, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :subscribe_to, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :subscribe_to, :stop], 2, _meas, meta}
+
+      assert %{
+               application: DefaultApp,
+               stream_uuid: :all,
+               subscription_name: "Test",
+               subscriber: ^subscriber,
+               start_from: :current
+             } = meta
     end
 
     test "emit `[:commanded, :event_store, :unsubscribe, :start | :stop]` event" do
@@ -100,7 +140,8 @@ defmodule Commanded.EventStore.TelemetryTest do
       assert :ok = EventStore.unsubscribe(DefaultApp, pid)
 
       assert_receive {[:commanded, :event_store, :unsubscribe, :start], 3, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :unsubscribe, :stop], 4, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :unsubscribe, :stop], 4, _meas, meta}
+      assert %{application: DefaultApp, subscription: ^pid} = meta
     end
 
     test "emit `[:commanded, :event_store, :delete_subscription, :start | :stop]` event" do
@@ -108,7 +149,8 @@ defmodule Commanded.EventStore.TelemetryTest do
                EventStore.delete_subscription(DefaultApp, :all, "Test")
 
       assert_receive {[:commanded, :event_store, :delete_subscription, :start], 1, _meas, _meta}
-      assert_receive {[:commanded, :event_store, :delete_subscription, :stop], 2, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :delete_subscription, :stop], 2, _meas, meta}
+      assert %{application: DefaultApp, subscribe_to: :all, handler_name: "Test"} = meta
     end
   end
 
@@ -117,15 +159,16 @@ defmodule Commanded.EventStore.TelemetryTest do
     handler = :"#{__MODULE__}-handler"
 
     events = [
+      :ack_event,
+      :append_to_stream,
+      :delete_snapshot,
+      :delete_subscription,
       :record_snapshot,
       :read_snapshot,
-      :delete_snapshot,
       :stream_forward,
       :subscribe,
       :subscribe_to,
-      :unsubscribe,
-      :delete_subscription,
-      :ack_event
+      :unsubscribe
     ]
 
     :telemetry.attach_many(

--- a/test/event_store/telemetry_test.exs
+++ b/test/event_store/telemetry_test.exs
@@ -1,0 +1,150 @@
+defmodule Commanded.EventStore.TelemetryTest do
+  use ExUnit.Case
+
+  alias Commanded.DefaultApp
+  alias Commanded.EventStore
+  alias Commanded.EventStore.RecordedEvent
+  alias Commanded.EventStore.SnapshotData
+  alias Commanded.Middleware.Commands.IncrementCount
+  alias Commanded.Middleware.Commands.RaiseError
+
+  setup do
+    start_supervised!(DefaultApp)
+    attach_telemetry()
+
+    :ok
+  end
+
+  defmodule TestRouter do
+    use Commanded.Commands.Router
+
+    alias Commanded.Middleware.Commands.CommandHandler
+    alias Commanded.Middleware.Commands.CounterAggregateRoot
+
+    dispatch IncrementCount,
+      to: CommandHandler,
+      aggregate: CounterAggregateRoot,
+      identity: :aggregate_uuid
+
+    dispatch RaiseError,
+      to: CommandHandler,
+      aggregate: CounterAggregateRoot,
+      identity: :aggregate_uuid
+  end
+
+  describe "snapshotting telemetry events" do
+    test "emit `[:commanded, :event_store, :record_snapshot, :start | :stop]` event" do
+      assert :ok = EventStore.record_snapshot(DefaultApp, %SnapshotData{})
+
+      assert_receive {[:commanded, :event_store, :record_snapshot, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :record_snapshot, :stop], 2, _meas, _meta}
+    end
+
+    test "emit `[:commanded, :event_store, :read_snapshot, :start | :stop]` event" do
+      assert {:error, :snapshot_not_found} = EventStore.read_snapshot(DefaultApp, UUID.uuid4())
+
+      assert_receive {[:commanded, :event_store, :read_snapshot, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :read_snapshot, :stop], 2, _meas, _meta}
+    end
+
+    test "emit `[:commanded, :event_store, :delete_snapshot, :start | :stop]` event" do
+      assert :ok = EventStore.delete_snapshot(DefaultApp, UUID.uuid4())
+
+      assert_receive {[:commanded, :event_store, :delete_snapshot, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :delete_snapshot, :stop], 2, _meas, _meta}
+    end
+  end
+
+  describe "streaming telemetry events" do
+    test "emit `[:commanded, :event_store, :stream_forward, :start | :stop]` event" do
+      assert {:error, :stream_not_found} = EventStore.stream_forward(DefaultApp, UUID.uuid4())
+
+      assert_receive {[:commanded, :event_store, :stream_forward, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :stream_forward, :stop], 2, _meas, _meta}
+    end
+  end
+
+  describe "ack_event telemetry events" do
+    test "emit `[:commanded, :event_store, :ack_event, :start | :stop]` event" do
+      assert :ok = EventStore.ack_event(DefaultApp, self(), %RecordedEvent{})
+
+      assert_receive {[:commanded, :event_store, :ack_event, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :ack_event, :stop], 2, _meas, _meta}
+    end
+  end
+
+  describe "subscription telemetry events" do
+    test "emit `[:commanded, :event_store, :subscribe, :start | :stop]` event" do
+      assert :ok = EventStore.subscribe(DefaultApp, UUID.uuid4())
+
+      assert_receive {[:commanded, :event_store, :subscribe, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :subscribe, :stop], 2, _meas, _meta}
+    end
+
+    test "emit `[:commanded, :event_store, :subscribe_to, :start | :stop]` event" do
+      assert {:ok, pid} = EventStore.subscribe_to(DefaultApp, :all, "Test", self(), :current)
+
+      assert_receive {:subscribed, ^pid}
+      assert_receive {[:commanded, :event_store, :subscribe_to, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :subscribe_to, :stop], 2, _meas, _meta}
+    end
+
+    test "emit `[:commanded, :event_store, :unsubscribe, :start | :stop]` event" do
+      assert {:ok, pid} = EventStore.subscribe_to(DefaultApp, :all, "Test", self(), :current)
+
+      assert_receive {:subscribed, ^pid}
+
+      assert_receive {[:commanded, :event_store, :subscribe_to, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :subscribe_to, :stop], 2, _meas, _meta}
+
+      assert :ok = EventStore.unsubscribe(DefaultApp, pid)
+
+      assert_receive {[:commanded, :event_store, :unsubscribe, :start], 3, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :unsubscribe, :stop], 4, _meas, _meta}
+    end
+
+    test "emit `[:commanded, :event_store, :delete_subscription, :start | :stop]` event" do
+      assert {:error, :subscription_not_found} =
+               EventStore.delete_subscription(DefaultApp, :all, "Test")
+
+      assert_receive {[:commanded, :event_store, :delete_subscription, :start], 1, _meas, _meta}
+      assert_receive {[:commanded, :event_store, :delete_subscription, :stop], 2, _meas, _meta}
+    end
+  end
+
+  defp attach_telemetry do
+    agent = start_supervised!({Agent, fn -> 1 end})
+    handler = :"#{__MODULE__}-handler"
+
+    events = [
+      :record_snapshot,
+      :read_snapshot,
+      :delete_snapshot,
+      :stream_forward,
+      :subscribe,
+      :subscribe_to,
+      :unsubscribe,
+      :delete_subscription,
+      :ack_event
+    ]
+
+    :telemetry.attach_many(
+      handler,
+      Enum.flat_map(events, fn event ->
+        [
+          [:commanded, :event_store, event, :start],
+          [:commanded, :event_store, event, :stop]
+        ]
+      end),
+      fn event_name, measurements, metadata, reply_to ->
+        num = Agent.get_and_update(agent, fn n -> {n, n + 1} end)
+        send(reply_to, {event_name, num, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn ->
+      :telemetry.detach(handler)
+    end)
+  end
+end


### PR DESCRIPTION
Adds telemetry events to the `Commanded.EventStore` adapter

- [x] ~~Determine API coverage that we want (I'm starting with the functions that the aggregate uses)~~
- [x] Tests
- [x] Pass relevant metadata
- [x] Documentation

I am going to avoid using the TelemetryRegistry for documenmting these events until it has better support for generating span documentation, otherwise, it will overtake this module. If you're ok with that @slashdotdash then I'm happy to convert to `telemetry_event` definitions

### API To cover
- [x] ack_event/3
- [ ] adapter/2
- [x] append_to_stream/4
- [x] delete_snapshot/2
- [x] delete_subscription/3
- [x] read_snapshot/2
- [x] record_snapshot/2
- [x] stream_forward/2
- [x] stream_forward/3
- [x] stream_forward/4
- [x] subscribe/2
- [x] subscribe_to/5
- [x] subscribe_to/6
- [x] unsubscribe/2