### PR TITLE
Dispatch returning resultant events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Graceful shutdown of event handlers ([#431](https://github.com/commanded/commanded/pull/431)).
 - Ensure command dispatch metadata is a map ([#432](https://github.com/commanded/commanded/pull/432)).
 - Retry command execution on node down ([#429](https://github.com/commanded/commanded/pull/429)).
+- Dispatch returning resultant events ([#444](https://github.com/commanded/commanded/pull/444)).
 
 ## v1.2.0
 

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -86,6 +86,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
         :aggregate_version ->
           {:ok, aggregate_version, events, aggregate_version}
 
+        :events ->
+          {:ok, aggregate_version, events, events}
+
         :execution_result ->
           result = %ExecutionResult{
             aggregate_uuid: aggregate_uuid,

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -145,6 +145,9 @@ defmodule Commanded.Commands.Router do
 
     - `:aggregate_version` - to return only the aggregate version.
 
+    - `:events` - to return the resultant domain events. An empty list will be
+      returned if no events were produced.
+
     - `:execution_result` - to return a `Commanded.Commands.ExecutionResult`
       struct containing the aggregate's identity, state, version, and any events
       produced from the command along with their associated metadata.
@@ -436,6 +439,9 @@ defmodule Commanded.Commands.Router do
             - `:aggregate_version` - to include the aggregate stream version
               in the successful response: `{:ok, aggregate_version}`.
 
+            - `:events` - to return the resultant domain events. An empty list
+              will be returned if no events were produced.
+
             - `:execution_result` - to return a `Commanded.Commands.ExecutionResult`
               struct containing the aggregate's identity, version, and any
               events produced from the command along with their associated
@@ -535,6 +541,7 @@ defmodule Commanded.Commands.Router do
               (returning = Keyword.get(opts, :returning)) in [
                 :aggregate_state,
                 :aggregate_version,
+                :events,
                 :execution_result,
                 false
               ] ->
@@ -607,6 +614,7 @@ defmodule Commanded.Commands.Router do
       (default_dispatch_return = get_opt(opts, :default_dispatch_return)) in [
         :aggregate_state,
         :aggregate_version,
+        :events,
         :execution_result,
         false
       ] ->

--- a/test/example_domain/bank_router.ex
+++ b/test/example_domain/bank_router.ex
@@ -4,6 +4,7 @@ defmodule Commanded.ExampleDomain.BankRouter do
   use Commanded.Commands.Router
 
   alias Commanded.ExampleDomain.BankAccount
+  alias Commanded.ExampleDomain.BankAccount.Commands.CloseAccount
   alias Commanded.ExampleDomain.BankAccount.Commands.DepositMoney
   alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
   alias Commanded.ExampleDomain.BankAccount.Commands.WithdrawMoney
@@ -22,6 +23,7 @@ defmodule Commanded.ExampleDomain.BankRouter do
   dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount
   dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount
   dispatch WithdrawMoney, to: WithdrawMoneyHandler, aggregate: BankAccount
+  dispatch CloseAccount, to: OpenAccountHandler, aggregate: BankAccount
 
   # Money transfer
   identify MoneyTransfer, by: :transfer_uuid


### PR DESCRIPTION
Extend command dispatch `returning` option to support `:events` to return the resultant domain events.

### Example usage

```elixir
{:ok, events} = BankApp.dispatch(command, returning: :events)
```