### PR TITLE
Incorrect aggregate_version when linking events

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -407,7 +407,7 @@ defmodule Commanded.Aggregates.Aggregate do
   # Handle events appended to the aggregate's stream, received by its
   # event store subscription, by applying any missed events to its state.
   defp handle_event(%RecordedEvent{} = event, %Aggregate{} = state) do
-    %RecordedEvent{data: data, stream_version: stream_version} = event
+    %RecordedEvent{data: data, event_number: event_number} = event
 
     %Aggregate{
       aggregate_module: aggregate_module,
@@ -417,12 +417,12 @@ defmodule Commanded.Aggregates.Aggregate do
 
     expected_version = aggregate_version + 1
 
-    case stream_version do
+    case event_number do
       ^expected_version ->
         # apply event to aggregate's state
         %Aggregate{
           state
-          | aggregate_version: stream_version,
+          | aggregate_version: event_number,
             aggregate_state: aggregate_module.apply(aggregate_state, data)
         }
 

--- a/lib/commanded/aggregates/aggregate_state_builder.ex
+++ b/lib/commanded/aggregates/aggregate_state_builder.ex
@@ -64,12 +64,12 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
   # Rebuild aggregate state from a `Stream` of its events.
   defp rebuild_from_event_stream(event_stream, %Aggregate{} = state) do
     Enum.reduce(event_stream, state, fn event, state ->
-      %RecordedEvent{data: data, stream_version: stream_version} = event
+      %RecordedEvent{data: data, event_number: event_number} = event
       %Aggregate{aggregate_module: aggregate_module, aggregate_state: aggregate_state} = state
 
       %Aggregate{
         state
-        | aggregate_version: stream_version,
+        | aggregate_version: event_number,
           aggregate_state: aggregate_module.apply(aggregate_state, data)
       }
     end)

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -310,7 +310,7 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
       events = [
         %RecordedEvent{
           event_id: UUID.uuid4(),
-          stream_version: 1,
+          event_number: 1,
           data: %Event{uuid: aggregate_uuid}
         }
       ]

--- a/test/aggregates/aggregate_subscription_test.exs
+++ b/test/aggregates/aggregate_subscription_test.exs
@@ -63,7 +63,7 @@ defmodule Commanded.Aggregates.AggregateSubscriptionTest do
           # specify invalid stream version
           %EventStore.RecordedEvent{
             recorded_event
-            | stream_version: 999
+            | event_number: 999
           }
         end)
 


### PR DESCRIPTION
When linking the events from one stream to another stream following this guide https://github.com/commanded/recipes/issues/16, the aggregate in another stream shows wrong expected version when dispatch a command because it uses original_stream_version instead of stream_version.