### PR TITLE
Allow for telemetry 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Commanded.Mixfile do
       {:elixir_uuid, "~> 1.2"},
 
       # Telemetry
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:telemetry_registry, "~> 0.2"},
 
       # Optional dependencies


### PR DESCRIPTION
The bump to 1.0 only solidifies the public API. It's the same as the 0.4 series, just with a guarantee of a stable API. Since there are libraries that have not updated yet, accepting both for now seems reasonable.