### PR TITLE
Add sponsorship information to mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -233,7 +233,8 @@ defmodule Commanded.Mixfile do
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/commanded/commanded",
-        "Docs" => "https://hexdocs.pm/commanded/"
+        "Docs" => "https://hexdocs.pm/commanded/",
+        "Sponsor" => "https://opencollective.com/commanded"
       }
     ]
   end


### PR DESCRIPTION
Hex has a nice mix task called `hex.sponsor` which shows all packages with a "Sponsor" link. You only need to add a URL in the `links` map called `Sponsor` and Hex will show it whenever anyone runs `mix hex.sponsor`. Can't hurt to add it.

Info on the mix task: https://hexdocs.pm/hex/Mix.Tasks.Hex.Sponsor.html#content