### PR TITLE
Allow a process manager to stop after dispatching a command

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -62,6 +62,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   - `c:interested?/1`
   - `c:handle/2`
   - `c:apply/2`
+  - `c:after_command/2
   - `c:error/3`
 
   Please read the [Process managers](process-managers.html) guide for more
@@ -82,6 +83,10 @@ defmodule Commanded.ProcessManagers.ProcessManager do
           [
             %ExampleCommand{}
           ]
+        end
+
+        def after_command(%ExampleProcessManager{}, %ExampleCommand{}) do
+          :stop
         end
 
         def error({:error, failure}, %ExampleEvent{}, _failure_context) do
@@ -335,6 +340,10 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | false
 
   @doc """
+  """
+  @callback after_command(process_manager, domain_event) :: :continue | :stop
+
+  @doc """
   Process manager instance handles a domain event, returning any commands to
   dispatch.
 
@@ -423,7 +432,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | {:skip, :continue_pending}
               | {:stop, reason :: term()}
 
-  @optional_callbacks init: 1, handle: 2, apply: 2, error: 3, interested?: 1
+  @optional_callbacks init: 1, handle: 2, apply: 2, error: 3, interested?: 1, after_command: 2
 
   alias Commanded.ProcessManagers.ProcessManager
   alias Commanded.ProcessManagers.ProcessRouter
@@ -480,6 +489,9 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   defmacro __before_compile__(_env) do
     # Include default fallback functions at end, with lowest precedence
     quote generated: true do
+      @doc false
+      def after_command(_process_manager, _event), do: :continue
+
       @doc false
       def interested?(_event), do: false
 

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -340,6 +340,12 @@ defmodule Commanded.ProcessManagers.ProcessManager do
               | false
 
   @doc """
+  Stop the process manager instance after a command is successfully
+  dispatched.
+
+  The `c:after_command/2` function can be omitted if you do not need to stop
+  after a specific command or if you would instead use the `c:interested?/1`
+  stop mechanism.
   """
   @callback after_command(process_manager, domain_event) :: :continue | :stop
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -184,8 +184,6 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     %RecordedEvent{correlation_id: correlation_id, event_id: event_id, event_number: event_number} =
       event
 
-    %State{idle_timeout: idle_timeout} = state
-
     telemetry_metadata = telemetry_metadata(event, state)
     start_time = telemetry_start(telemetry_metadata)
 
@@ -243,7 +241,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
               :ok = persist_state(event_number, state)
               :ok = ack_event(event, state)
 
-              {:noreply, state, idle_timeout}
+              handle_after_command(commands, state)
           end
         else
           {:stop, reason} ->
@@ -347,6 +345,31 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
         # Stop process manager with original error
         {:stop, error, state}
+    end
+  end
+
+  defp handle_after_command([], %State{} = state) do
+    %State{idle_timeout: idle_timeout} = state
+
+    {:noreply, state, idle_timeout}
+  end
+
+  defp handle_after_command([command | commands], %State{} = state) do
+    %State{
+      process_manager_module: process_manager_module,
+      process_state: process_state
+    } = state
+
+    case process_manager_module.after_command(process_state, command) do
+      :stop ->
+        Logger.debug(fn ->
+          describe(state) <> " has been stopped by command " <> describe(command)
+        end)
+
+        {:stop, :normal, :ok, state}
+
+      _ ->
+        handle_after_command(commands, state)
     end
   end
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -363,10 +363,12 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
     case process_manager_module.after_command(process_state, command) do
       :stop ->
         Logger.debug(fn ->
-          describe(state) <> " has been stopped by command " <> describe(command)
+          describe(state) <> " has been stopped by command " <> inspect(command)
         end)
 
-        {:stop, :normal, :ok, state}
+        :ok = delete_state(state)
+
+        {:stop, :normal, state}
 
       _ ->
         handle_after_command(commands, state)

--- a/test/process_managers/process_manager_after_command_text.exs
+++ b/test/process_managers/process_manager_after_command_text.exs
@@ -1,0 +1,79 @@
+defmodule Commanded.ProcessManagers.ProcessManagerAfterCommandTest do
+  use ExUnit.Case
+
+  import Commanded.Assertions.EventAssertions
+  import Commanded.Enumerable
+
+  alias Commanded.EventStore
+  alias Commanded.Helpers.Wait
+  alias Commanded.ProcessManagers.AfterCommandProcessManager
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Publish
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Start
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Interested
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Started
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Stopped
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.Uninterested
+  alias Commanded.ProcessManagers.ExampleApp
+  alias Commanded.ProcessManagers.ExampleRouter
+  alias Commanded.ProcessManagers.ProcessRouter
+
+  setup do
+    start_supervised!(ExampleApp)
+
+    :ok
+  end
+
+  test "should stop process manager instance after specified command" do
+    aggregate_uuid = UUID.uuid4()
+    source_uuid = "\"AfterCommandProcessManager\"-\"#{aggregate_uuid}\""
+
+    {:ok, process_router} = AfterCommandProcessManager.start_link()
+
+    :ok = ExampleRouter.dispatch(%Start{aggregate_uuid: aggregate_uuid}, application: ExampleApp)
+
+    # Dispatch command to publish multiple events and trigger dispatch of the stop command
+    :ok =
+      ExampleRouter.dispatch(
+        %Publish{
+          aggregate_uuid: aggregate_uuid,
+          interesting: 10,
+          uninteresting: 1
+        },
+        application: ExampleApp
+      )
+
+    # Process state snapshot should be created
+    assert {:ok, _} = EventStore.read_snapshot(ExampleApp, source_uuid)
+
+    assert_receive_event(ExampleApp, Stopped, fn event ->
+      assert event.aggregate_uuid == aggregate_uuid
+    end)
+
+    events = EventStore.stream_forward(ExampleApp, aggregate_uuid) |> Enum.to_list()
+
+    assert pluck(events, :data) == [
+             %Started{aggregate_uuid: aggregate_uuid},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 2},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 3},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 4},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 5},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 6},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 7},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 8},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 9},
+             %Interested{aggregate_uuid: aggregate_uuid, index: 10},
+             %Uninterested{aggregate_uuid: aggregate_uuid, index: 1},
+             %Stopped{aggregate_uuid: aggregate_uuid}
+           ]
+
+    Wait.until(fn ->
+      # Process instance should be stopped
+      assert ProcessRouter.process_instance(process_router, aggregate_uuid) ==
+               {:error, :process_manager_not_found}
+
+      # Process state snapshot should be deleted
+      assert EventStore.read_snapshot(ExampleApp, source_uuid) == {:error, :snapshot_not_found}
+    end)
+  end
+end

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -69,7 +69,10 @@ defmodule Commanded.ProcessManagers.ProcessRouterProcessPendingEventsTest do
                {:error, :process_manager_not_found}
 
       # Process state snapshot should be deleted
-      assert EventStore.read_snapshot(ExampleApp, "example_process_manager-#{aggregate_uuid}") ==
+      assert EventStore.read_snapshot(
+               ExampleApp,
+               "\"ExampleProcessManager\"-\"#{aggregate_uuid}\""
+             ) ==
                {:error, :snapshot_not_found}
     end)
   end

--- a/test/process_managers/support/after_command_process_manager.ex
+++ b/test/process_managers/support/after_command_process_manager.ex
@@ -1,0 +1,44 @@
+defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
+  @moduledoc false
+
+  alias Commanded.ProcessManagers.ExampleApp
+  alias Commanded.ProcessManagers.AfterCommandProcessManager
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Stop
+
+  alias Commanded.ProcessManagers.ExampleAggregate.Events.{
+    Errored,
+    Interested,
+    Paused,
+    Raised,
+    Started,
+    Stopped
+  }
+
+  use Commanded.ProcessManagers.ProcessManager,
+    application: ExampleApp,
+    name: "AfterCommandProcessManager"
+
+  @derive Jason.Encoder
+  defstruct [:status, items: []]
+
+  def interested?(%Started{aggregate_uuid: aggregate_uuid}), do: {:start, aggregate_uuid}
+  def interested?(%Interested{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
+
+  def handle(%AfterCommandProcessManager{}, %Interested{index: 10, aggregate_uuid: aggregate_uuid}) do
+    %Stop{aggregate_uuid: aggregate_uuid}
+  end
+
+  # State mutators
+
+  def apply(%AfterCommandProcessManager{} = process_manager, %Started{}) do
+    %AfterCommandProcessManager{process_manager | status: :started}
+  end
+
+  def apply(%AfterCommandProcessManager{items: items} = process_manager, %Interested{index: index}) do
+    %AfterCommandProcessManager{process_manager | items: items ++ [index]}
+  end
+
+  def after_command(%AfterCommandProcessManager{}, %Stop{}) do
+    :stop
+  end
+end


### PR DESCRIPTION
fixes https://github.com/commanded/commanded/issues/441

This PR allow a process manager instance to be stopped through `after_command/1` callback function.
The`after_command/1` callback function can have two return values, `:stop` that would stop with specific command and `:continue` that would ignore the command.
The callback function would only be called after the command is successfully dispatched. 
After commands are successfully dispatched the Process state snapshot would be deleted as it would be in the `interested?/1` callback implementation.