### PR TITLE
Event Handler not calling init on restart

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -517,10 +517,8 @@ defmodule Commanded.Event.Handler do
       def child_spec(opts) do
         opts = Keyword.merge(@opts, opts)
 
-        {application, name, _config} = Handler.parse_config!(__MODULE__, opts)
-
         default = %{
-          id: {__MODULE__, application, name},
+          id: {__MODULE__, opts},
           start: {__MODULE__, :start_link, [opts]},
           restart: :permanent,
           type: :worker

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -517,11 +517,11 @@ defmodule Commanded.Event.Handler do
       def child_spec(opts) do
         opts = Keyword.merge(@opts, opts)
 
-        {application, name, config} = Handler.parse_config!(__MODULE__, opts)
+        {application, name, _config} = Handler.parse_config!(__MODULE__, opts)
 
         default = %{
           id: {__MODULE__, application, name},
-          start: {Handler, :start_link, [application, name, __MODULE__, config]},
+          start: {__MODULE__, :start_link, [opts]},
           restart: :permanent,
           type: :worker
         }

--- a/test/event/event_handler_state_test.exs
+++ b/test/event/event_handler_state_test.exs
@@ -77,7 +77,7 @@ defmodule Commanded.Event.EventHandlerStateTest do
       assert_receive {:event, ^event1, metadata}
       assert match?(%{state: 11}, metadata)
 
-      %{id: id} = StatefulEventHandler.child_spec([])
+      %{id: id} = StatefulEventHandler.child_spec([state: 10])
 
       stop_supervised!(id)
 

--- a/test/event/event_handler_state_test.exs
+++ b/test/event/event_handler_state_test.exs
@@ -77,7 +77,7 @@ defmodule Commanded.Event.EventHandlerStateTest do
       assert_receive {:event, ^event1, metadata}
       assert match?(%{state: 11}, metadata)
 
-      %{id: id} = StatefulEventHandler.child_spec([state: 10])
+      %{id: id} = StatefulEventHandler.child_spec(state: 10)
 
       stop_supervised!(id)
 

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -34,6 +34,15 @@ defmodule Commanded.Event.HandlerInitTest do
       assert_handler_name(handler2, "Commanded.Event.RuntimeConfigHandler.tenant2")
       assert_handler_name(handler3, "Commanded.Event.RuntimeConfigHandler.tenant3")
     end
+
+    test "should be called on restart if the process crashes" do
+      handler = start_supervised!({RuntimeConfigHandler, tenant: :tenant1, reply_to: self()})
+
+      Process.exit(handler, :kill)
+
+      assert_receive {:init, :tenant1}
+      assert_receive {:init, :tenant1}
+    end
   end
 
   describe "event handler `init/0` callback" do

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -42,6 +42,7 @@ defmodule Commanded.Event.HandlerInitTest do
 
       assert_receive {:init, :tenant1}
       assert_receive {:init, :tenant1}
+      refute_receive {:init, :tenant1}
     end
   end
 


### PR DESCRIPTION
Hello!

I've experience the following issues that I don't think its the intended behaviour.

Im using and Event Handler state for saving dynamic information and restoring on the `init/1` callback.
Last week a EH crashed to my surprise the EH process, the new one that the supervisor started, did not run the `init/1`
The reason for this is that `init/1` was called once in the `child_spec` definition and it was not calling the module start link.
So what end up happening is that the init/1 is called only once at the first start of the Event Handler

With this change the only downside that im seeing is that `parse_config!` is called in the `child_spec` and also in the `start_link`

I haven't found a way to get around that, because in the `init/1` callback you can define the application and the name, so calling it in the child_spec is needed in the same way is needed to be called in the `start_link/1`



