### PR TITLE
Call process manager `init/1` function on process restart

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -455,13 +455,9 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
       """
       def child_spec(opts) do
-        opts = Keyword.merge(@opts, opts)
-
-        {application, name, config} = ProcessManager.parse_config!(__MODULE__, opts)
-
         default = %{
-          id: {__MODULE__, application, name},
-          start: {ProcessRouter, :start_link, [application, name, __MODULE__, config]},
+          id: {__MODULE__, opts},
+          start: {__MODULE__, :start_link, [opts]},
           restart: :permanent,
           type: :worker
         }

--- a/test/process_managers/process_manager_init_test.exs
+++ b/test/process_managers/process_manager_init_test.exs
@@ -22,5 +22,15 @@ defmodule Commanded.ProcessManager.ProcessManagerInitTest do
       assert_receive {:init, :tenant2}
       assert_receive {:init, :tenant3}
     end
+
+    test "should be called on restart if the process crashes" do
+      pm = start_supervised!({RuntimeConfigProcessManager, tenant: :tenant1, reply_to: self()})
+
+      Process.exit(pm, :kill)
+
+      assert_receive {:init, :tenant1}
+      assert_receive {:init, :tenant1}
+      refute_receive {:init, :tenant1}
+    end
   end
 end


### PR DESCRIPTION
Ensure the `init/1` callback function is called whenever a process manager restarts.