### PR TITLE
Fix docs layout issue

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -62,7 +62,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   - `c:interested?/1`
   - `c:handle/2`
   - `c:apply/2`
-  - `c:after_command/2
+  - `c:after_command/2`
   - `c:error/3`
 
   Please read the [Process managers](process-managers.html) guide for more


### PR DESCRIPTION
The docs for `1.4.0-rc.0` are missing a backtick:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/1214337/182033241-2c8c52fb-bc83-43c7-ac35-168a41c5ef53.png">
