### PR TITLE
Retry command execution when the aggregate process is down

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -189,6 +189,9 @@ defmodule Commanded.Aggregates.Aggregate do
     try do
       GenServer.call(name, {:execute_command, context}, timeout)
     catch
+      :exit, {:noproc, {GenServer, :call, [^name, {:execute_command, ^context}, ^timeout]}} ->
+        {:exit, {:normal, :aggregate_stopped}}
+
       :exit, {:normal, {GenServer, :call, [^name, {:execute_command, ^context}, ^timeout]}} ->
         {:exit, {:normal, :aggregate_stopped}}
     end


### PR DESCRIPTION
## The issue

We found that there may be occasional `:noproc` errors raised during the function call in `Commanded.Commands.Dispatcher.execute/3`

The error looks like this:

```elixir
Erlang error:
  {:noproc,
    {
      GenServer,
      :call,
      [
        {:via, Registry, {MyApp.EventApp.LocalRegistry, {MyApp.EventApp, MyApp.Aggregators.MyAggregator, "my-stream-id"}}},
        {
          :execute_command,
          %Commanded.Aggregates.ExecutionContext{
            before_execute: nil,
            causation_id: "...",
            command: %MyApp.Commands.SomeCommand{},
            correlation_id: "...",
            function: :execute,
            handler: MyApp.Aggregators.MyAggregator,
            lifespan: MyApp.Lifespans.MyLifeSpan,
            metadata: %{},
            retry_attempts: 10,
            returning: false
          }
        },
        5000
      ]
    }
  }
```

> **Note**
> we're using a lifespan so the aggregator can terminate itself after some idle.

## The cause

Looking at the code, I think it could be related to currency.

In file [lib/commanded/commands/dispatcher.ex](https://github.com/commanded/commanded/blob/master/lib/commanded/commands/dispatcher.ex) we have the following code:

```
  defp execute(%Pipeline{} = pipeline, %Payload{} = payload, %ExecutionContext{} = context) do
    %Pipeline{application: application, assigns: %{aggregate_uuid: aggregate_uuid}} = pipeline
    %Payload{aggregate_module: aggregate_module, timeout: timeout} = payload

    #--------------------------------- point 1
    {:ok, ^aggregate_uuid} =
      Commanded.Aggregates.Supervisor.open_aggregate(
        application,
        aggregate_module,
        aggregate_uuid
      )

    task_dispatcher_name = Module.concat([application, Commanded.Commands.TaskDispatcher])

    task = 
      Task.Supervisor.async_nolink(task_dispatcher_name, Aggregate, :execute, [
        application,
        aggregate_module,
        aggregate_uuid,
        context,
        timeout
      ])

    #--------------------------------- point 2
    result = 
      case Task.yield(task, timeout) || Task.shutdown(task) do
        {:ok, result} ->
          result

        {:exit, {:normal, :aggregate_stopped}} = result ->
          result
    ...
```

The aggregator may have exited during points 1 and 2.

## The fix

So we just catch this `:noproc` error and let the dispatcher retry with the [`maybe_retry/3`](https://github.com/commanded/commanded/blob/master/lib/commanded/commands/dispatcher.ex#L240-L248) function which we already have.

This tiny fix works well for us, so I think it could be helpful to others too.
Please let me know your thoughts. Thanks!