### PR TITLE
Fix EventData typespec

### DIFF
--- a/lib/commanded/event_store/event_data.ex
+++ b/lib/commanded/event_store/event_data.ex
@@ -8,7 +8,7 @@ defmodule Commanded.EventStore.EventData do
 
   @type t :: %Commanded.EventStore.EventData{
           causation_id: uuid() | nil,
-          correlation_id: uuid() | nil,
+          correlation_id: uuid(),
           event_type: String.t(),
           data: struct(),
           metadata: map()

--- a/lib/commanded/event_store/event_data.ex
+++ b/lib/commanded/event_store/event_data.ex
@@ -7,8 +7,8 @@ defmodule Commanded.EventStore.EventData do
   @type uuid :: String.t()
 
   @type t :: %Commanded.EventStore.EventData{
-          causation_id: uuid(),
-          correlation_id: uuid(),
+          causation_id: uuid() | nil,
+          correlation_id: uuid() | nil,
           event_type: String.t(),
           data: struct(),
           metadata: map()


### PR DESCRIPTION
I believe `causation_id` and `correlation_id` are optional fields (for example `lib/commanded/event/mapper.ex:55` sets to a value that can be nil), updated the typespec accordingly.