### PR TITLE
Set read event batch size to a somewhat saner value

### DIFF
--- a/lib/commanded/aggregates/aggregate_state_builder.ex
+++ b/lib/commanded/aggregates/aggregate_state_builder.ex
@@ -5,7 +5,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
   alias Commanded.EventStore.SnapshotData
   alias Commanded.Snapshotting
 
-  @read_event_batch_size 100
+  @read_event_batch_size 1_000
 
   @doc """
   Populate the aggregate's state from a snapshot, if present, and it's events.


### PR DESCRIPTION
100 is fairly small, and 1_000 is used elsewhere (event_store.ex) as a default. 