### PR TITLE
Rebuild examples in docs for better line ending rendered output in HTML docs.

### DIFF
--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -109,8 +109,10 @@ defmodule Commanded.Commands.Router do
     - `:eventual` (default) - don't block command dispatch while waiting for
       event handlers
 
-          :ok = BankApp.dispatch(command)
-          :ok = BankApp.dispatch(command, consistency: :eventual)
+      ```elixir
+      :ok = BankApp.dispatch(command)
+      :ok = BankApp.dispatch(command, consistency: :eventual)
+      ```
 
     - `:strong` - block command dispatch until all strongly
       consistent event handlers and process managers have successfully processed
@@ -119,7 +121,9 @@ defmodule Commanded.Commands.Router do
       Use this when you have event handlers that update read models you need to
       query immediately after dispatching the command.
 
-          :ok = BankApp.dispatch(command, consistency: :strong)
+      ```elixir
+      :ok = BankApp.dispatch(command, consistency: :strong)
+      ```
 
     - Provide an explicit list of event handler and process manager modules (or
       their configured names), containing only those handlers you'd like to wait


### PR DESCRIPTION
While reading the HTML documentation, I observed the code not presenting as nice as it could. 

I think this should fix the issue but can not get the asdf elixir version on my M1 Macbook to verify. Please do so before merging.

What I saw:

![Screenshot 2022-08-20 at 12-10-10 Commanded Commands Router — Commanded v1 3 1](https://user-images.githubusercontent.com/52168/185756207-e117cec0-5e73-4365-9c24-6da1f6c7cfa6.png)

