### PR TITLE
chore: improve typespec for router dispatch resp

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -286,14 +286,7 @@ defmodule Commanded.Application do
       `Commanded.Commands.Router` and included in the application.
 
   """
-  @callback dispatch(command :: struct()) ::
-              :ok
-              | {:ok, aggregate_state :: struct()}
-              | {:ok, aggregate_version :: non_neg_integer()}
-              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
-              | {:error, :unregistered_command}
-              | {:error, :consistency_timeout}
-              | {:error, reason :: term()}
+  @callback dispatch(command :: struct()) :: Commanded.Commands.Router.dispatch_resp()
 
   @doc """
   Dispatch a registered command.
@@ -364,14 +357,7 @@ defmodule Commanded.Application do
   @callback dispatch(
               command :: struct(),
               timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
-            ) ::
-              :ok
-              | {:ok, aggregate_state :: struct()}
-              | {:ok, aggregate_version :: non_neg_integer()}
-              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
-              | {:error, :unregistered_command}
-              | {:error, :consistency_timeout}
-              | {:error, reason :: term()}
+            ) :: Commanded.Commands.Router.dispatch_resp()
 
   @doc false
   def dispatch(application, command, opts \\ [])

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -365,6 +365,15 @@ defmodule Commanded.Commands.Router do
     end
   end
 
+  @type dispatch_resp ::
+          :ok
+          | {:ok, aggregate_state :: struct()}
+          | {:ok, aggregate_version :: non_neg_integer()}
+          | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
+          | {:error, :unregistered_command}
+          | {:error, :consistency_timeout}
+          | {:error, reason :: term()}
+
   @doc """
   Dispatch the given command to the registered handler.
 
@@ -377,14 +386,7 @@ defmodule Commanded.Commands.Router do
       :ok = BankRouter.dispatch(command)
 
   """
-  @callback dispatch(command :: struct()) ::
-              :ok
-              | {:ok, aggregate_state :: struct()}
-              | {:ok, aggregate_version :: non_neg_integer()}
-              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
-              | {:error, :unregistered_command}
-              | {:error, :consistency_timeout}
-              | {:error, reason :: term()}
+  @callback dispatch(command :: struct()) :: dispatch_resp
 
   @doc """
   Dispatch the given command to the registered handler providing a timeout.
@@ -460,14 +462,7 @@ defmodule Commanded.Commands.Router do
   @callback dispatch(
               command :: struct(),
               timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
-            ) ::
-              :ok
-              | {:ok, aggregate_state :: struct()}
-              | {:ok, aggregate_version :: non_neg_integer()}
-              | {:ok, execution_result :: Commanded.Commands.ExecutionResult.t()}
-              | {:error, :unregistered_command}
-              | {:error, :consistency_timeout}
-              | {:error, reason :: term()}
+            ) :: dispatch_resp
 
   defmacro __before_compile__(_env) do
     quote generated: true do


### PR DESCRIPTION
I had to copy over such typespec https://github.com/straw-hat-team/beam-monorepo/blob/a4b2551aa29171e4d73cfbef9319b8013e6318a7/apps/one_piece_commanded/lib/one_piece/commanded/helpers.ex#L8-L15

I tried to clean up a bit to allow packages around Commanded to be more in line with the spec, and also, consequently, the code base is more cohesive, I think, less copy-pasta.