### PR TITLE
feat: put aggregate_state into assigns of the pipeline

### DIFF
--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -80,13 +80,13 @@ defmodule Commanded.Aggregates.ExecutionContext do
 
     case returning do
       :aggregate_state ->
-        {:ok, aggregate_version, events, aggregate_state}
+        {:ok, aggregate_version, events, aggregate_state, aggregate_state}
 
       :aggregate_version ->
-        {:ok, aggregate_version, events, aggregate_version}
+        {:ok, aggregate_version, events, aggregate_state, aggregate_version}
 
       :events ->
-        {:ok, aggregate_version, events, events}
+        {:ok, aggregate_version, events, aggregate_state, events}
 
       :execution_result ->
         result = %ExecutionResult{
@@ -97,10 +97,10 @@ defmodule Commanded.Aggregates.ExecutionContext do
           metadata: metadata
         }
 
-        {:ok, aggregate_version, events, result}
+        {:ok, aggregate_version, events, aggregate_state, result}
 
       false ->
-        {:ok, aggregate_version, events}
+        {:ok, aggregate_version, events, aggregate_state}
     end
   end
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -111,17 +111,19 @@ defmodule Commanded.Commands.Dispatcher do
       end
 
     case result do
-      {:ok, aggregate_version, events} ->
+      {:ok, aggregate_version, events, aggregate_state} ->
         pipeline
         |> Pipeline.assign(:aggregate_version, aggregate_version)
         |> Pipeline.assign(:events, events)
+        |> Pipeline.assign(:aggregate_state, aggregate_state)
         |> after_dispatch(payload)
         |> Pipeline.respond(:ok)
 
-      {:ok, aggregate_version, events, reply} ->
+      {:ok, aggregate_version, events, aggregate_state, reply} ->
         pipeline
         |> Pipeline.assign(:aggregate_version, aggregate_version)
         |> Pipeline.assign(:events, events)
+        |> Pipeline.assign(:aggregate_state, aggregate_state)
         |> after_dispatch(payload)
         |> Pipeline.respond({:ok, reply})
 

--- a/test/aggregates/aggregate_concurrency_test.exs
+++ b/test/aggregates/aggregate_concurrency_test.exs
@@ -85,7 +85,7 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         :ok
       end)
 
-      assert {:ok, 3, _events} =
+      assert {:ok, 3, _events, _aggregate_state} =
                Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       assert Aggregate.aggregate_version(MockedApp, BankAccount, account_number) == 3
@@ -159,7 +159,8 @@ defmodule Commanded.Aggregates.AggregateConcurrencyTest do
         retry_attempts: 1
       }
 
-      {:ok, 1, _events} = Aggregate.execute(MockedApp, BankAccount, account_number, context)
+      {:ok, 1, _events, _aggregate_state} =
+        Aggregate.execute(MockedApp, BankAccount, account_number, context)
 
       [
         account_number: account_number

--- a/test/aggregates/aggregate_state_test.exs
+++ b/test/aggregates/aggregate_state_test.exs
@@ -89,7 +89,7 @@ defmodule Commanded.Aggregates.AggregateStateTest do
     {:ok, ^aggregate_uuid} =
       Supervisor.open_aggregate(DefaultApp, @aggregate_module, aggregate_uuid)
 
-    {:ok, _count, _events} =
+    {:ok, _count, _events, _aggregate_state} =
       Aggregate.execute(DefaultApp, @aggregate_module, aggregate_uuid, execution_context)
   end
 end

--- a/test/aggregates/aggregate_subscription_test.exs
+++ b/test/aggregates/aggregate_subscription_test.exs
@@ -88,7 +88,8 @@ defmodule Commanded.Aggregates.AggregateSubscriptionTest do
       retry_attempts: 1
     }
 
-    {:ok, 1, _events} = Aggregate.execute(DefaultApp, BankAccount, account_number, context)
+    {:ok, 1, _events, _aggregate_state} =
+      Aggregate.execute(DefaultApp, BankAccount, account_number, context)
 
     [
       account_number: account_number

--- a/test/aggregates/aggregate_telemetry_test.exs
+++ b/test/aggregates/aggregate_telemetry_test.exs
@@ -63,7 +63,7 @@ defmodule Commanded.Aggregates.AggregateTelemetryTest do
 
       self = self()
 
-      {:ok, 1, _events} = GenServer.call(pid, {:execute_command, context})
+      {:ok, 1, _events, _aggregate_state} = GenServer.call(pid, {:execute_command, context})
 
       assert_receive {[:commanded, :aggregate, :execute, :start], measurements, metadata}
 
@@ -96,7 +96,7 @@ defmodule Commanded.Aggregates.AggregateTelemetryTest do
 
       self = self()
 
-      {:ok, 1, events} = GenServer.call(pid, {:execute_command, context})
+      {:ok, 1, events, _aggregate_state} = GenServer.call(pid, {:execute_command, context})
 
       assert_receive {[:commanded, :aggregate, :execute, :start], _measurements, _metadata}
       assert_receive {[:commanded, :aggregate, :execute, :stop], measurements, metadata}

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -20,7 +20,7 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
     {:ok, ^aggregate_uuid} =
       Commanded.Aggregates.Supervisor.open_aggregate(DefaultApp, ExampleAggregate, aggregate_uuid)
 
-    {:ok, 10, events} =
+    {:ok, 10, events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 10},
         handler: AppendItemsHandler,
@@ -45,7 +45,7 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
     {:ok, ^aggregate_uuid} =
       Commanded.Aggregates.Supervisor.open_aggregate(DefaultApp, ExampleAggregate, aggregate_uuid)
 
-    {:ok, 1, events} =
+    {:ok, 1, events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 1},
         handler: AppendItemsHandler,
@@ -54,7 +54,7 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
 
     assert length(events) == 1
 
-    {:ok, 1, events} =
+    {:ok, 1, events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %NoOp{},
         handler: ExampleAggregate,
@@ -82,7 +82,9 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
       function: :handle
     }
 
-    {:ok, 10, events} = Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, context)
+    {:ok, 10, events, _aggregate_state} =
+      Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, context)
+
     assert length(events) == 10
 
     recorded_events = EventStore.stream_forward(DefaultApp, aggregate_uuid, 0) |> Enum.to_list()
@@ -98,7 +100,7 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
     {:ok, ^aggregate_uuid} =
       Commanded.Aggregates.Supervisor.open_aggregate(DefaultApp, ExampleAggregate, aggregate_uuid)
 
-    {:ok, 10, events} =
+    {:ok, 10, events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 10},
         handler: AppendItemsHandler,
@@ -127,21 +129,21 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
     {:ok, ^aggregate_uuid} =
       Commanded.Aggregates.Supervisor.open_aggregate(DefaultApp, ExampleAggregate, aggregate_uuid)
 
-    {:ok, 100, _events} =
+    {:ok, 100, _events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 100},
         handler: AppendItemsHandler,
         function: :handle
       })
 
-    {:ok, 200, _events} =
+    {:ok, 200, _events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 100},
         handler: AppendItemsHandler,
         function: :handle
       })
 
-    {:ok, 201, _events} =
+    {:ok, 201, _events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, %ExecutionContext{
         command: %AppendItems{count: 1},
         handler: AppendItemsHandler,
@@ -180,7 +182,7 @@ defmodule Commanded.Aggregates.EventPersistenceTest do
       function: :handle
     }
 
-    {:ok, 1, events} =
+    {:ok, 1, events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, prefixed_aggregate_uuid, context)
 
     assert length(events) == 1

--- a/test/aggregates/execute_command_test.exs
+++ b/test/aggregates/execute_command_test.exs
@@ -24,7 +24,8 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: BankAccount, function: :open_account}
 
-    {:ok, 1, events} = Aggregate.execute(BankApp, BankAccount, account_number, context)
+    {:ok, 1, events, _aggregate_state} =
+      Aggregate.execute(BankApp, BankAccount, account_number, context)
 
     assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1_000}]
 
@@ -50,7 +51,8 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: OpenAccountHandler, function: :handle}
 
-    {:ok, 1, events} = Aggregate.execute(BankApp, BankAccount, account_number, context)
+    {:ok, 1, events, _aggregate_state} =
+      Aggregate.execute(BankApp, BankAccount, account_number, context)
 
     assert events == [%BankAccountOpened{account_number: account_number, initial_balance: 1_000}]
 
@@ -76,7 +78,8 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: OpenAccountHandler, function: :handle}
 
-    {:ok, 1, _events} = Aggregate.execute(BankApp, BankAccount, account_number, context)
+    {:ok, 1, _events, _aggregate_state} =
+      Aggregate.execute(BankApp, BankAccount, account_number, context)
 
     state_before = Aggregate.aggregate_state(BankApp, BankAccount, account_number)
 
@@ -133,7 +136,7 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
   defp assert_no_events(command_fun) do
     id = UUID.uuid4()
 
-    assert {:ok, 0, []} = execute_aggregate_command(id, command_fun)
+    assert {:ok, 0, [], _aggregate_state} = execute_aggregate_command(id, command_fun)
   end
 
   defp assert_event_result(command_fun) do
@@ -141,7 +144,8 @@ defmodule Commanded.Aggregates.ExecuteCommandTest do
 
     id = UUID.uuid4()
 
-    assert {:ok, 1, [%Event{id: ^id}]} = execute_aggregate_command(id, command_fun)
+    assert {:ok, 1, [%Event{id: ^id}], _aggregate_state} =
+             execute_aggregate_command(id, command_fun)
   end
 
   defp execute_aggregate_command(id, command_fun) do

--- a/test/aggregates/snapshotting_test.exs
+++ b/test/aggregates/snapshotting_test.exs
@@ -280,7 +280,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
       {:ok, ^aggregate_uuid} =
         Supervisor.open_aggregate(DefaultApp, SnapshotAggregate, aggregate_uuid)
 
-      {:ok, _count, _events} =
+      {:ok, _count, _events, _aggregate_state} =
         Aggregate.execute(DefaultApp, SnapshotAggregate, aggregate_uuid, execution_context)
     end
   end
@@ -315,7 +315,7 @@ defmodule Commanded.Aggregates.SnapshottingTest do
     {:ok, ^aggregate_uuid} =
       Supervisor.open_aggregate(DefaultApp, ExampleAggregate, aggregate_uuid)
 
-    {:ok, _count, _events} =
+    {:ok, _count, _events, _aggregate_state} =
       Aggregate.execute(DefaultApp, ExampleAggregate, aggregate_uuid, execution_context)
   end
 


### PR DESCRIPTION
Assign `aggregate_state`, so that we can write middlewares to do more things about the `aggregate_state` in the `after_dispatch` stage.