### PR TITLE
Fix typespec typo in Commanded.Application

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -188,7 +188,7 @@ defmodule Commanded.Application do
         config
       end
 
-      @spec child_spec(opts :: Commanded.options()) :: Supervisor.child_spec()
+      @spec child_spec(opts :: Commanded.Application.options()) :: Supervisor.child_spec()
       def child_spec(opts) do
         %{
           id: name(opts),


### PR DESCRIPTION
I think dialyzer did not catch this one because it ignores test files and that's the only place this macro is called? This was introduced in #484 