### PR TITLE
feat: return nil aggregate state when the aggregate does not exist

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -208,7 +208,8 @@ defmodule Commanded.Application do
       end
 
       @doc """
-      Retrieve aggregate state of an aggregate.
+      Retrieve aggregate state of an aggregate,
+      return `nil` if the aggregate does not exist.
 
       Retrieving aggregate state is done by calling to the opened aggregate,
       or querying the event store for an optional state snapshot
@@ -218,7 +219,7 @@ defmodule Commanded.Application do
               aggregate_module :: module(),
               aggregate_uuid :: Aggregate.uuid(),
               timeout :: integer
-            ) :: Aggregate.state()
+            ) :: Aggregate.state() | nil
       def aggregate_state(aggregate_module, aggregate_uuid, timeout \\ 5000) do
         Aggregate.aggregate_state(
           __MODULE__,

--- a/lib/commanded.ex
+++ b/lib/commanded.ex
@@ -34,7 +34,8 @@ defmodule Commanded do
   end
 
   @doc """
-  Retrieve aggregate state of an aggregate.
+  Retrieve aggregate state of an aggregate,
+  return `nil` if the aggregate does not exist.
 
   Retrieving aggregate state is done by calling to the opened aggregate,
   or querying the event store for an optional state snapshot
@@ -45,7 +46,7 @@ defmodule Commanded do
           aggregate_module :: module(),
           aggregate_uuid :: Aggregate.uuid(),
           timeout :: integer
-        ) :: Aggregate.state()
+        ) :: Aggregate.state() | nil
   def aggregate_state(application, aggregate_module, aggregate_uuid, timeout \\ 5_000) do
     Aggregate.aggregate_state(
       application,

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -225,7 +225,10 @@ defmodule Commanded.Aggregates.Aggregate do
               snapshotting: Snapshotting.new(application, aggregate_uuid, snapshot_options)
             }
             |> AggregateStateBuilder.populate()
-            |> Map.fetch!(:aggregate_state)
+            |> case do
+              %Aggregate{aggregate_version: 0} -> nil
+              %Aggregate{} = state -> Map.fetch!(state, :aggregate_state)
+            end
           end)
 
         case Task.yield(task, timeout) || Task.shutdown(task) do

--- a/test/aggregates/aggregate_state_test.exs
+++ b/test/aggregates/aggregate_state_test.exs
@@ -22,6 +22,19 @@ defmodule Commanded.Aggregates.AggregateStateTest do
     :ok
   end
 
+  test "query a non-existing aggregate_state" do
+    aggregate_uuid = UUID.uuid4()
+
+    assert match?(
+             {:noproc, {GenServer, :call, _request}},
+             catch_exit(
+               Aggregate.aggregate_version(DefaultApp, @aggregate_module, aggregate_uuid)
+             )
+           )
+
+    assert Aggregate.aggregate_state(DefaultApp, @aggregate_module, aggregate_uuid) == nil
+  end
+
   test "query aggregate_state from the running aggregate gen_server" do
     aggregate_uuid = UUID.uuid4()
     append_items(aggregate_uuid, 9)


### PR DESCRIPTION
I think it is more appropriate to return `nil` aggregate state when the aggregate does not exist. We can also build the initial aggregate state with `struct(aggregate_module)` easily.