### PR TITLE
Reduce compile-time dependencies

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -517,11 +517,10 @@ defmodule Commanded.Event.Handler do
 
   @optional_callbacks init: 0, init: 1, error: 3, partition_by: 2
 
-  defmacro __using__(opts) do
+  defmacro __using__(using_opts) do
     quote location: :keep do
       @before_compile unquote(__MODULE__)
       @behaviour Handler
-      @opts unquote(opts)
 
       @doc """
       Start an event handler `GenServer` process linked to the current process.
@@ -549,7 +548,7 @@ defmodule Commanded.Event.Handler do
       into hibernation after a period of inactivity.
       """
       def start_link(opts \\ []) do
-        opts = Keyword.merge(@opts, opts)
+        opts = Keyword.merge(unquote(using_opts), opts)
 
         {application, name, config} = Handler.parse_config!(__MODULE__, opts)
 
@@ -574,7 +573,7 @@ defmodule Commanded.Event.Handler do
 
       """
       def child_spec(opts) do
-        opts = Keyword.merge(@opts, opts)
+        opts = Keyword.merge(unquote(using_opts), opts)
 
         spec =
           case Keyword.get(opts, :concurrency, 1) do

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -444,14 +444,13 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   alias Commanded.ProcessManagers.ProcessRouter
 
   @doc false
-  defmacro __using__(opts) do
+  defmacro __using__(using_opts) do
     quote location: :keep do
       @before_compile unquote(__MODULE__)
       @behaviour ProcessManager
-      @opts unquote(opts)
 
       def start_link(opts \\ []) do
-        opts = Keyword.merge(@opts, opts)
+        opts = Keyword.merge(unquote(using_opts), opts)
 
         {application, name, config} = ProcessManager.parse_config!(__MODULE__, opts)
 


### PR DESCRIPTION
Moves opts out of module attributes for process managers and event handlers. The opts can reference modules which will cause [compile-time dependencies](https://hexdocs.pm/elixir/1.14/Kernel.html#@/1-attention-compile-time-dependencies) if they are in module attributes. 