### PR TITLE
Process manager metadata read access

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -62,6 +62,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   - `c:interested?/1`
   - `c:interested?/2`
   - `c:handle/2`
+  - `c:handle/3`
   - `c:apply/2`
   - `c:after_command/2`
   - `c:after_command/3`
@@ -85,6 +86,12 @@ defmodule Commanded.ProcessManagers.ProcessManager do
         def handle(%ExampleProcessManager{}, %ExampleEvent{}) do
           [
             %ExampleCommand{}
+          ]
+        end
+
+        def handle(%ExampleProcessManager{}, %AnotherExampleEvent{}, _metadata) do
+          [
+            %AnotherExampleCommand{}
           ]
         end
 
@@ -386,15 +393,26 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   Process manager instance handles a domain event, returning any commands to
   dispatch.
 
-  A `c:handle/2` function can be defined for each `:start` and `:continue`
+  Version without metadata access.
+
+  Check `c:handle/3` function for details.
+  """
+  @callback handle(process_manager, domain_event) :: command | list(command) | {:error, term}
+
+  @doc """
+  Process manager instance handles a domain event, returning any commands to
+  dispatch.
+
+  A `c:handle/3` function can be defined for each `:start` and `:continue`
   tagged event previously specified. It receives the process manager's state and
   the event to be handled. It must return the commands to be dispatched. This
   may be none, a single command, or many commands.
 
-  The `c:handle/2` function can be omitted if you do not need to dispatch a
+  The `c:handle/3` function can be omitted if you do not need to dispatch a
   command and are only mutating the process manager's state.
   """
-  @callback handle(process_manager, domain_event) :: command | list(command) | {:error, term}
+  @callback handle(process_manager, domain_event, metadata) ::
+              command | list(command) | {:error, term}
 
   @doc """
   Mutate the process manager's state by applying the domain event.
@@ -543,6 +561,10 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
       @doc false
       def interested?(_event), do: false
+
+      @doc false
+      def handle(process_manager, event, _metadata),
+        do: handle(process_manager, event)
 
       @doc false
       def handle(_process_manager, _event), do: []

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -293,8 +293,8 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
   """
 
-  alias Commanded.ProcessManagers.FailureContext
   alias Commanded.EventStore.RecordedEvent
+  alias Commanded.ProcessManagers.FailureContext
 
   @type domain_event :: struct
   @type enriched_metadata :: RecordedEvent.enriched_metadata()

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -403,8 +403,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
       process_state: process_state
     } = state
 
+    enriched_metadata = enrich_metadata(event, state)
+
     try do
-      process_manager_module.apply(process_state, data)
+      process_manager_module.apply(process_state, data, enriched_metadata)
     rescue
       error ->
         stacktrace = __STACKTRACE__

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -295,8 +295,13 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     %RecordedEvent{data: data} = event
     %State{process_manager_module: process_manager_module} = state
 
+    additional_metadata = Map.take(state, [:application])
+
+    enriched_metadata =
+      RecordedEvent.enrich_metadata(event, additional_metadata: additional_metadata)
+
     try do
-      case process_manager_module.interested?(data) do
+      case process_manager_module.interested?(data, enriched_metadata) do
         {:start, []} ->
           ack_and_continue(event, state)
 

--- a/test/event_store/recorded_event_test.exs
+++ b/test/event_store/recorded_event_test.exs
@@ -1,8 +1,8 @@
 defmodule Commanded.EventStore.RecordedEventTest do
   use ExUnit.Case
 
-  alias Commanded.Helpers.EventFactory
   alias Commanded.EventStore.RecordedEvent
+  alias Commanded.Helpers.EventFactory
 
   defmodule BankAccountOpened do
     @derive Jason.Encoder

--- a/test/event_store/recorded_event_test.exs
+++ b/test/event_store/recorded_event_test.exs
@@ -1,0 +1,74 @@
+defmodule Commanded.EventStore.RecordedEventTest do
+  use ExUnit.Case
+
+  alias Commanded.Helpers.EventFactory
+  alias Commanded.EventStore.RecordedEvent
+
+  defmodule BankAccountOpened do
+    @derive Jason.Encoder
+    defstruct [:account_number, :initial_balance]
+  end
+
+  setup do
+    metadata = %{"key" => "value"}
+
+    [event] =
+      EventFactory.map_to_recorded_events(
+        [%BankAccountOpened{account_number: "123", initial_balance: 1_000}],
+        1,
+        metadata: metadata
+      )
+
+    enriched_metadata =
+      RecordedEvent.enrich_metadata(event,
+        additional_metadata: %{application: ExampleApplication}
+      )
+
+    [event: event, enriched_metadata: enriched_metadata]
+  end
+
+  test "enrich_metadata/2 should add a number of fields to the metadata",
+       %{
+         event: event,
+         enriched_metadata: enriched_metadata
+       } do
+    %RecordedEvent{
+      event_id: event_id,
+      event_number: event_number,
+      stream_id: stream_id,
+      stream_version: stream_version,
+      correlation_id: correlation_id,
+      causation_id: causation_id,
+      created_at: created_at,
+      metadata: metadata
+    } = event
+
+    expected_enriched_metadata =
+      Map.merge(
+        metadata,
+        %{
+          # standard fields
+          event_id: event_id,
+          event_number: event_number,
+          stream_id: stream_id,
+          stream_version: stream_version,
+          correlation_id: correlation_id,
+          causation_id: causation_id,
+          created_at: created_at,
+          #
+          # additional field
+          application: ExampleApplication
+        }
+      )
+
+    assert expected_enriched_metadata == enriched_metadata
+  end
+
+  test "deplete_metadata/2 should stip additional fields out of enriched_metadata map",
+       %{
+         event: %{metadata: metadata} = _event,
+         enriched_metadata: enriched_metadata
+       } do
+    assert metadata == RecordedEvent.deplete_metadata(enriched_metadata, [:application])
+  end
+end

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -16,7 +16,7 @@ defmodule Commanded.ExampleDomain.BankAccount do
     end
 
     defmodule WithdrawMoney do
-      defstruct [:account_number, :transfer_uuid, :amount]
+      defstruct [:account_number, :transfer_uuid, :amount, :by_user]
     end
 
     defmodule CloseAccount do

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -22,6 +22,25 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}),
     do: {:continue, transfer_uuid}
 
+  def handle(
+        %TransferMoneyProcessManager{},
+        %MoneyTransferRequested{} = event,
+        %{"user_uuid" => by_user} = _metadata
+      ) do
+    %MoneyTransferRequested{
+      transfer_uuid: transfer_uuid,
+      debit_account: debit_account,
+      amount: amount
+    } = event
+
+    %WithdrawMoney{
+      account_number: debit_account,
+      transfer_uuid: transfer_uuid,
+      amount: amount,
+      by_user: by_user
+    }
+  end
+
   def handle(%TransferMoneyProcessManager{}, %MoneyTransferRequested{} = event) do
     %MoneyTransferRequested{
       transfer_uuid: transfer_uuid,
@@ -29,7 +48,11 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
       amount: amount
     } = event
 
-    %WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount}
+    %WithdrawMoney{
+      account_number: debit_account,
+      transfer_uuid: transfer_uuid,
+      amount: amount
+    }
   end
 
   def handle(%TransferMoneyProcessManager{} = pm, %MoneyWithdrawn{}) do

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -11,7 +11,7 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   alias Commanded.ExampleDomain.TransferMoneyProcessManager
 
   @derive Jason.Encoder
-  defstruct [:transfer_uuid, :debit_account, :credit_account, :amount, :status]
+  defstruct [:transfer_uuid, :debit_account, :credit_account, :amount, :status, :user_uuid]
 
   def interested?(%MoneyTransferRequested{transfer_uuid: transfer_uuid}),
     do: {:start, transfer_uuid}
@@ -66,6 +66,29 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   end
 
   ## State mutators
+
+  def apply(
+        %TransferMoneyProcessManager{} = transfer,
+        %MoneyTransferRequested{} = event,
+        %{"user_uuid" => user_uuid} = _metadata
+      ) do
+    %MoneyTransferRequested{
+      transfer_uuid: transfer_uuid,
+      debit_account: debit_account,
+      credit_account: credit_account,
+      amount: amount
+    } = event
+
+    %TransferMoneyProcessManager{
+      transfer
+      | transfer_uuid: transfer_uuid,
+        debit_account: debit_account,
+        credit_account: credit_account,
+        amount: amount,
+        status: :withdraw_money_from_debit_account,
+        user_uuid: user_uuid
+    }
+  end
 
   def apply(%TransferMoneyProcessManager{} = transfer, %MoneyTransferRequested{} = event) do
     %MoneyTransferRequested{

--- a/test/process_managers/process_manager_after_command_test.exs
+++ b/test/process_managers/process_manager_after_command_test.exs
@@ -28,9 +28,9 @@ defmodule Commanded.ProcessManagers.ProcessManagerAfterCommandTest do
     aggregate_uuid = UUID.uuid4()
     source_uuid = "\"AfterCommandProcessManager\"-\"#{aggregate_uuid}\""
 
-    self_pid_as_base64 = self() |> :erlang.term_to_binary() |> Base.encode64()
+    notify_to = self() |> :erlang.pid_to_list()
 
-    metadata = %{"notify_to" => self_pid_as_base64}
+    metadata = %{"notify_to" => notify_to}
 
     {:ok, process_router} = AfterCommandProcessManager.start_link()
 

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -53,7 +53,8 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
                    credit_account: ^credit_account,
                    debit_account: ^debit_account,
                    status: :withdraw_money_from_debit_account,
-                   transfer_uuid: ^transfer_uuid
+                   transfer_uuid: ^transfer_uuid,
+                   user_uuid: ^user_uuid
                  },
                  source_type: "Elixir.Commanded.ExampleDomain.TransferMoneyProcessManager",
                  source_uuid: ^expected_source_uuid,

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -33,11 +33,14 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
   end
 
   describe "process manager instance" do
-    test "handles an event and dispatches a command" do
+    test "handles an event and dispatches a command copying existing metadata" do
       transfer_uuid = UUID.uuid4()
       debit_account = UUID.uuid4()
       credit_account = UUID.uuid4()
       expected_source_uuid = "\"TransferMoneyProcessManager\"-\"#{transfer_uuid}\""
+      user_uuid = UUID.uuid4()
+
+      metadata = %{"user_uuid" => user_uuid}
 
       expect(MockEventStore, :read_snapshot, fn _adapter_meta, ^expected_source_uuid ->
         {:error, :snapshot_not_found}
@@ -60,12 +63,15 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
         :ok
       end)
 
-      expect(MockApplication, :dispatch, fn command, _opts ->
+      expect(MockApplication, :dispatch, fn command, opts ->
         assert %WithdrawMoney{
                  account_number: ^debit_account,
                  transfer_uuid: ^transfer_uuid,
-                 amount: 100
+                 amount: 100,
+                 by_user: ^user_uuid
                } = command
+
+        assert metadata == Keyword.get(opts, :metadata)
 
         :ok
       end)
@@ -73,12 +79,15 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
       {:ok, instance} = start_process_manager_instance(transfer_uuid)
 
       event =
-        to_recorded_event(%MoneyTransferRequested{
-          transfer_uuid: transfer_uuid,
-          debit_account: debit_account,
-          credit_account: credit_account,
-          amount: 100
-        })
+        to_recorded_event(
+          %MoneyTransferRequested{
+            transfer_uuid: transfer_uuid,
+            debit_account: debit_account,
+            credit_account: credit_account,
+            amount: 100
+          },
+          metadata
+        )
 
       :ok = ProcessManagerInstance.process_event(instance, event)
 
@@ -188,6 +197,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstanceTest do
 
   defp to_recorded_event(event) do
     %RecordedEvent{event_number: 1, stream_id: "stream-id", stream_version: 1, data: event}
+  end
+
+  defp to_recorded_event(event, metadata) do
+    %{to_recorded_event(event) | metadata: metadata}
   end
 
   defp mock_event_store do

--- a/test/process_managers/support/after_command_process_manager.ex
+++ b/test/process_managers/support/after_command_process_manager.ex
@@ -2,7 +2,7 @@ defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
   @moduledoc false
 
   alias Commanded.ProcessManagers.AfterCommandProcessManager
-  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Stop, Continue}
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Continue, Stop}
   alias Commanded.ProcessManagers.ExampleAggregate.Events.{Interested, Started}
   alias Commanded.ProcessManagers.ExampleApp
 

--- a/test/process_managers/support/after_command_process_manager.ex
+++ b/test/process_managers/support/after_command_process_manager.ex
@@ -2,7 +2,7 @@ defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
   @moduledoc false
 
   alias Commanded.ProcessManagers.AfterCommandProcessManager
-  alias Commanded.ProcessManagers.ExampleAggregate.Commands.Stop
+  alias Commanded.ProcessManagers.ExampleAggregate.Commands.{Stop, Continue}
   alias Commanded.ProcessManagers.ExampleAggregate.Events.{Interested, Started}
   alias Commanded.ProcessManagers.ExampleApp
 
@@ -13,8 +13,15 @@ defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
   @derive Jason.Encoder
   defstruct [:status, items: []]
 
-  def interested?(%Started{aggregate_uuid: aggregate_uuid}), do: {:start, aggregate_uuid}
-  def interested?(%Interested{aggregate_uuid: aggregate_uuid}), do: {:continue, aggregate_uuid}
+  def interested?(%Started{aggregate_uuid: aggregate_uuid}, _metadata),
+    do: {:start, aggregate_uuid}
+
+  def interested?(%Interested{aggregate_uuid: aggregate_uuid}, _metadata),
+    do: {:continue, aggregate_uuid}
+
+  def handle(%AfterCommandProcessManager{}, %Interested{index: 1, aggregate_uuid: aggregate_uuid}) do
+    %Continue{aggregate_uuid: aggregate_uuid}
+  end
 
   def handle(%AfterCommandProcessManager{}, %Interested{index: 10, aggregate_uuid: aggregate_uuid}) do
     %Stop{aggregate_uuid: aggregate_uuid}
@@ -30,7 +37,22 @@ defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
     %AfterCommandProcessManager{process_manager | items: items ++ [index]}
   end
 
+  # after_command/2 callback
   def after_command(%AfterCommandProcessManager{}, %Stop{}) do
     :stop
+  end
+
+  # after_command/3 callback
+  def after_command(%AfterCommandProcessManager{}, %Continue{}, metadata) do
+    %{"notify_to" => notify_to_pid_as_bse64} = metadata
+
+    pid =
+      notify_to_pid_as_bse64
+      |> Base.decode64!()
+      |> :erlang.binary_to_term()
+
+    Process.send(pid, :metadata_available, [])
+
+    :continue
   end
 end

--- a/test/process_managers/support/after_command_process_manager.ex
+++ b/test/process_managers/support/after_command_process_manager.ex
@@ -44,14 +44,11 @@ defmodule Commanded.ProcessManagers.AfterCommandProcessManager do
 
   # after_command/3 callback
   def after_command(%AfterCommandProcessManager{}, %Continue{}, metadata) do
-    %{"notify_to" => notify_to_pid_as_bse64} = metadata
+    %{"notify_to" => notify_to} = metadata
 
-    pid =
-      notify_to_pid_as_bse64
-      |> Base.decode64!()
-      |> :erlang.binary_to_term()
-
-    Process.send(pid, :metadata_available, [])
+    notify_to
+    |> :erlang.list_to_pid()
+    |> Process.send(:metadata_available, [])
 
     :continue
   end

--- a/test/process_managers/support/example_aggregate.ex
+++ b/test/process_managers/support/example_aggregate.ex
@@ -10,6 +10,7 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
     defmodule(Start, do: defstruct([:aggregate_uuid]))
     defmodule(Publish, do: defstruct([:aggregate_uuid, :interesting, :uninteresting]))
     defmodule(Pause, do: defstruct([:aggregate_uuid]))
+    defmodule(Continue, do: defstruct([:aggregate_uuid]))
     defmodule(Stop, do: defstruct([:aggregate_uuid]))
     defmodule(Error, do: defstruct([:aggregate_uuid]))
     defmodule(Raise, do: defstruct([:aggregate_uuid]))
@@ -69,6 +70,10 @@ defmodule Commanded.ProcessManagers.ExampleAggregate do
 
   def stop(%ExampleAggregate{uuid: aggregate_uuid}) do
     %Events.Stopped{aggregate_uuid: aggregate_uuid}
+  end
+
+  def continue(%ExampleAggregate{}) do
+    []
   end
 
   def error(%ExampleAggregate{uuid: aggregate_uuid}) do

--- a/test/process_managers/support/example_command_handler.ex
+++ b/test/process_managers/support/example_command_handler.ex
@@ -5,13 +5,13 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
   alias Commanded.ProcessManagers.ExampleAggregate
 
   alias Commanded.ProcessManagers.ExampleAggregate.Commands.{
+    Continue,
     Error,
     Pause,
     Publish,
     Raise,
     Start,
-    Stop,
-    Continue
+    Stop
   }
 
   def handle(%ExampleAggregate{} = aggregate, %Start{aggregate_uuid: aggregate_uuid}),

--- a/test/process_managers/support/example_command_handler.ex
+++ b/test/process_managers/support/example_command_handler.ex
@@ -10,7 +10,8 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
     Publish,
     Raise,
     Start,
-    Stop
+    Stop,
+    Continue
   }
 
   def handle(%ExampleAggregate{} = aggregate, %Start{aggregate_uuid: aggregate_uuid}),
@@ -27,6 +28,9 @@ defmodule Commanded.ProcessManagers.ExampleCommandHandler do
 
   def handle(%ExampleAggregate{} = aggregate, %Stop{}),
     do: ExampleAggregate.stop(aggregate)
+
+  def handle(%ExampleAggregate{} = aggregate, %Continue{}),
+    do: ExampleAggregate.continue(aggregate)
 
   def handle(%ExampleAggregate{} = aggregate, %Error{}),
     do: ExampleAggregate.error(aggregate)

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -6,13 +6,13 @@ defmodule Commanded.ProcessManagers.ExampleRouter do
   alias Commanded.ProcessManagers.{ExampleAggregate, ExampleCommandHandler}
 
   alias Commanded.ProcessManagers.ExampleAggregate.Commands.{
+    Continue,
     Error,
     Pause,
     Publish,
     Raise,
     Start,
-    Stop,
-    Continue
+    Stop
   }
 
   dispatch [Error, Pause, Publish, Raise, Start, Stop, Continue],

--- a/test/process_managers/support/example_router.ex
+++ b/test/process_managers/support/example_router.ex
@@ -11,10 +11,11 @@ defmodule Commanded.ProcessManagers.ExampleRouter do
     Publish,
     Raise,
     Start,
-    Stop
+    Stop,
+    Continue
   }
 
-  dispatch [Error, Pause, Publish, Raise, Start, Stop],
+  dispatch [Error, Pause, Publish, Raise, Start, Stop, Continue],
     to: ExampleCommandHandler,
     aggregate: ExampleAggregate,
     identity: :aggregate_uuid

--- a/test/process_managers/support/routing/routing_process_manager.ex
+++ b/test/process_managers/support/routing/routing_process_manager.ex
@@ -8,6 +8,10 @@ defmodule Commanded.ProcessManagers.RoutingProcessManager do
     defstruct [:process_uuid, :reply_to, strict?: false]
   end
 
+  defmodule StartedFromMetadata do
+    defstruct [:process_uuid, :reply_to, strict?: false]
+  end
+
   defmodule Continued do
     @enforce_keys [:process_uuid]
     defstruct [:process_uuid, :reply_to, strict?: false]
@@ -28,6 +32,9 @@ defmodule Commanded.ProcessManagers.RoutingProcessManager do
 
   defstruct [:processes]
 
+  def interested?(%StartedFromMetadata{}, %{"process_uuid" => process_uuid} = _metadata),
+    do: {:start, process_uuid}
+
   def interested?(%Started{process_uuid: process_uuid, strict?: true}),
     do: {:start!, process_uuid}
 
@@ -42,6 +49,14 @@ defmodule Commanded.ProcessManagers.RoutingProcessManager do
   def interested?(%Stopped{process_uuid: process_uuid}), do: {:stop, process_uuid}
 
   def interested?(%Errored{}), do: raise("error")
+
+  def handle(%RoutingProcessManager{}, %StartedFromMetadata{} = event) do
+    %StartedFromMetadata{reply_to: reply_to} = event
+
+    send(reply_to, {:started, self()})
+
+    []
+  end
 
   def handle(%RoutingProcessManager{}, %Started{} = event) do
     %Started{reply_to: reply_to} = event


### PR DESCRIPTION
The PR addresses #440 and allows metadata read access from all callbacks except `error/3` (as the last one already has access to full RecordedEvent struct).

Supports both old and new callback versions (with and without metadata as the last parameter)

Also adds copying metadata from processed events to new commands by default. 

Modification of the metadata inside the process manager `handle/3` and `handle/2` callbacks are subject of the possible next PR.