### PR TITLE
Add tag to partition test case

### DIFF
--- a/test/event_store/support/subscription_test_case.ex
+++ b/test/event_store/support/subscription_test_case.ex
@@ -399,6 +399,7 @@ defmodule Commanded.EventStore.SubscriptionTestCase do
         assert length(subscribers) == 3
       end
 
+      @tag :partition
       test "should distribute events to subscribers using optional partition by function", %{
         event_store: event_store,
         event_store_meta: event_store_meta


### PR DESCRIPTION
[commanded-spear-adapter](https://github.com/fabriziosestito/commanded-spear-adapter) does not support partitioning.

Adding a test tag to partitioning related test to skip the test completely.