### PR TITLE
Allow setting supervising options such as `max_restarts` for aggregate supervisor.

### DIFF
--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -58,7 +58,24 @@ defmodule Commanded.Aggregates.Supervisor do
   def open_aggregate(_application, _aggregate_module, aggregate_uuid),
     do: {:error, {:unsupported_aggregate_identity_type, aggregate_uuid}}
 
-  def init(args) do
-    DynamicSupervisor.init(strategy: :one_for_one, extra_arguments: [args])
+  def init(init_opts) do
+    init_opts
+    |> supervisor_init_args()
+    |> DynamicSupervisor.init()
+  end
+
+  defp supervisor_init_args(init_opts) do
+    {supervisor_init_args, extra_args} =
+      Keyword.split(init_opts, [
+        :max_restarts,
+        :max_children,
+        :max_seconds
+      ])
+
+    supervisor_init_args
+    |> Keyword.merge(
+      strategy: :one_for_one,
+      extra_arguments: [extra_args]
+    )
   end
 end

--- a/lib/commanded/application/supervisor.ex
+++ b/lib/commanded/application/supervisor.ex
@@ -74,13 +74,18 @@ defmodule Commanded.Application.Supervisor do
     snapshotting = Keyword.get(config, :snapshotting, %{})
     hibernate_after = Keyword.get(config, :hibernate_after, :infinity)
 
+    aggregate_supervisor_options =
+      Keyword.get(config, :aggregate_supervisor_options, [])
+      |> Keyword.merge(
+        name: aggregates_supervisor_name,
+        application: name,
+        snapshotting: snapshotting,
+        hibernate_after: hibernate_after
+      )
+
     [
       {Task.Supervisor, name: task_dispatcher_name, hibernate_after: hibernate_after},
-      {Commanded.Aggregates.Supervisor,
-       name: aggregates_supervisor_name,
-       application: name,
-       snapshotting: snapshotting,
-       hibernate_after: hibernate_after},
+      {Commanded.Aggregates.Supervisor, aggregate_supervisor_options},
       {Commanded.Subscriptions.Registry,
        application: name, name: registry_name, hibernate_after: hibernate_after},
       {Commanded.Subscriptions,


### PR DESCRIPTION
Hi, this is a PR to support custom supervisor options for aggregates.

## Context

Our application has many aggregates, each of which listens to a stream, so we want to set a higher `max_restarts` option for the dynamic supervisor `Commanded.Aggregates.Supervisor`, so that a few failures won't crash the whole supervision tree.

This patch allows applications to specify custom supervising options, as the following example shows:

```elixir
config :my_app, MyApp.EventApplication,
  aggregate_supervisor_options: [
    max_restarts: 1_000,
    max_seconds: 10
  ]
```

Your feedback is welcome!
