### PR TITLE
Correct callback parameter type in after_command process_manager.ex

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -347,7 +347,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
   after a specific command or if you would instead use the `c:interested?/1`
   stop mechanism.
   """
-  @callback after_command(process_manager, domain_event) :: :continue | :stop
+  @callback after_command(process_manager, command) :: :continue | :stop
 
   @doc """
   Process manager instance handles a domain event, returning any commands to


### PR DESCRIPTION
Looking at the documentation, i expected this to work by putting in the domain event resulting in the command dispatches, but this is taking the command type.