### PR TITLE
add compile-time config option to globally set aggregate lifespan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add configuration option `:aggregate_default_lifespan` to change the default lifespan module globally at compile-time (link-forthcoming).
+
 ## v1.4.2
 
 -  Record aggregate state while processing `Commanded.Aggregate.Multi` ([#507](https://github.com/commanded/commanded/pull/507)).

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,3 +31,5 @@ config :commanded, Commanded.ProcessManagers.ExampleApp, default_app_config
 config :commanded, Commanded.ProcessManagers.ResumeApp, default_app_config
 config :commanded, Commanded.ProcessManagers.TodoApp, default_app_config
 config :commanded, Commanded.TestApplication, default_app_config
+
+config :commanded, :aggregate_default_lifespan, Commanded.Aggregates.DefaultLifespan

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -415,6 +415,8 @@ Return `:stop` or `{:stop, reason}` to immediately shutdown the aggregate proces
 
 You can also return `:hibernate` and the process is hibernated, it will continue its loop once a message is in its message queue. Hibernating an aggregate causes garbage collection and minimises the memory used by the process. Hibernating should not be used aggressively as too much time could be spent garbage collecting.
 
+If you wish to change the default, set the `:aggregate_default_lifespan` option for the `:commanded` application.  This must be done at compile-time.  It cannot be changed at runtime.
+
 ## Middleware
 
 Allows a command router to define middleware modules that are executed before and after success or failure of each command dispatch.

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -33,7 +33,9 @@ defmodule Commanded.Aggregates.ExecutionContext do
     - `lifespan` - a module implementing the `Commanded.Aggregates.AggregateLifespan`
       behaviour to control the aggregate instance process lifespan. The default
       value, `Commanded.Aggregates.DefaultLifespan`, keeps the process running
-      indefinitely.
+      indefinitely.  The default can be overridden by setting the
+      `:aggregate_default_lifespan` configuration for the `:commanded` application
+      at compile-time.  Cannot be reconfigured at run-time.
 
   """
 
@@ -41,6 +43,12 @@ defmodule Commanded.Aggregates.ExecutionContext do
   alias Commanded.Aggregates.DefaultLifespan
   alias Commanded.Aggregates.ExecutionContext
   alias Commanded.Commands.ExecutionResult
+
+  @default_lifespan Application.compile_env(
+                      :commanded,
+                      :aggregate_default_lifespan,
+                      DefaultLifespan
+                    )
 
   defstruct [
     :command,
@@ -51,7 +59,7 @@ defmodule Commanded.Aggregates.ExecutionContext do
     before_execute: nil,
     retry_attempts: 0,
     returning: false,
-    lifespan: DefaultLifespan,
+    lifespan: @default_lifespan,
     metadata: %{}
   ]
 


### PR DESCRIPTION
The default behavior of "aggregate processes stay around forever" can present difficulty in a production environment.  For any system that creates a steady stream of new aggregates, memory creeps up slowly until exhausted.

It is currently possible to override this on a per-router basis, but that only creates a situation where forgetting to specify it one place creates an even more subtle "memory leak".

This commit allows changing the default globally at compile-time.  It does not allow changing it at run-time, as this seemed like it would cause unpredictable behavior and possibly negatively impact performance.

Testing this is difficult since it's a compile-time change.  As a compromise, I set the value to the default explicitly in the testing config.  While this doesn't fully test the functionality, it does at least work-out the code.