### PR TITLE
fix: expose dispatch/2 in order to remove ex_doc warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   MIX_ENV: test
-  
+
 jobs:
   build:
     name: Build and test
@@ -61,6 +61,10 @@ jobs:
       run: |
         mkdir -p priv/plts
         mix dialyzer --plt
+      env:
+        MIX_ENV: dev
 
     - name: Run Dialyzer
       run: mix dialyzer --no-check
+      env:
+        MIX_ENV: dev

--- a/lib/commanded/commands/composite_router.ex
+++ b/lib/commanded/commands/composite_router.ex
@@ -91,18 +91,21 @@ defmodule Commanded.Commands.CompositeRouter do
         Enum.map(@registered_commands, fn {command_module, _router} -> command_module end)
       end
 
-      @doc false
+      @doc """
+      Dispatch a registered command.
+      """
+      @spec dispatch(
+              command :: struct(),
+              timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
+            ) :: Commanded.Commands.Router.dispatch_resp()
       def dispatch(command, opts \\ [])
 
-      @doc false
       def dispatch(command, :infinity),
         do: do_dispatch(command, timeout: :infinity)
 
-      @doc false
       def dispatch(command, timeout) when is_integer(timeout),
         do: do_dispatch(command, timeout: timeout)
 
-      @doc false
       def dispatch(command, opts),
         do: do_dispatch(command, opts)
 

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule Commanded.Mixfile do
       # Build and test tools
       {:benchfella, "~> 0.3", only: :bench},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.3", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.3", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:local_cluster, "~> 1.2", only: :test, runtime: false},
       {:mix_test_watch, "~> 1.1", only: :dev},


### PR DESCRIPTION
Given the following code:

```
defmodule Umbrella do
  @command_router Application.compile_env(:umbrella, :command_router, Umbrella.CommandedApp)

  defdelegate dispatch_command(command), to: @command_router, as: :dispatch
  defdelegate dispatch_command(command, opts), to: @command_router, as: :dispatch

  # ....
end
```

I got an warning when generating the docs:

```
mix docs                   
Compiling 1 file (.ex)
Generating docs...
warning: documentation references function "Umbrella.CommandRouter.dispatch/1" but it is hidden
  lib/umbrella.ex:4: Umbrella.dispatch_command/1

warning: documentation references function "Umbrella.CommandRouter.dispatch/2" but it is hidden
  lib/umbrella.ex:5: Umbrella.dispatch_command/2

```