### PR TITLE
Use `Logger.warning` to fix deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can use Commanded with one of the following event stores for persistence:
 
 Please refer to the [CHANGELOG](CHANGELOG.md) for features, bug fixes, and any upgrade advice included for each release.
 
-Requires Erlang/OTP v21.0 and Elixir v1.9 or later.
+Requires Erlang/OTP v21.0 and Elixir v1.11 or later.
 
 ---
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -444,7 +444,7 @@ defmodule Commanded.Aggregates.Aggregate do
         timeout
 
       invalid ->
-        Logger.warn(
+        Logger.warning(
           "Invalid timeout for aggregate lifespan " <>
             inspect(lifespan) <>
             ", expected a non-negative integer, `:infinity`, `:hibernate`, `:stop`, or `{:stop, reason}` but got: " <>
@@ -594,7 +594,7 @@ defmodule Commanded.Aggregates.Aggregate do
           %Aggregate{state | snapshotting: snapshotting}
 
         {:error, error} ->
-          Logger.warn(describe(state) <> " snapshot failed due to: " <> inspect(error))
+          Logger.warning(describe(state) <> " snapshot failed due to: " <> inspect(error))
 
           state
       end

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -481,7 +481,7 @@ defmodule Commanded.Event.Handler do
           case Map.get(context, :failures) do
             too_many when too_many >= 3 ->
               # skip bad event after third failure
-              Logger.warn(fn -> "Skipping bad event, too many failures: " <> inspect(event) end)
+              Logger.warning(fn -> "Skipping bad event, too many failures: " <> inspect(event) end)
 
               :skip
 
@@ -1045,13 +1045,13 @@ defmodule Commanded.Event.Handler do
         confirm_receipt(failed_event, state)
 
       {:stop, reason} ->
-        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(reason)}" end)
+        Logger.warning(fn -> describe(state) <> " has requested to stop: #{inspect(reason)}" end)
 
         # Stop event handler with given reason
         throw({:error, reason})
 
       invalid ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 

--- a/lib/commanded/middleware/consistency_guarantee.ex
+++ b/lib/commanded/middleware/consistency_guarantee.ex
@@ -44,7 +44,7 @@ defmodule Commanded.Middleware.ConsistencyGuarantee do
         pipeline
 
       {:error, :timeout} ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           "Consistency timeout waiting for aggregate #{inspect(aggregate_uuid)} at version #{inspect(aggregate_version)}"
         end)
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -326,12 +326,12 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       {:stop, error} ->
         # Stop the process manager instance
-        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(error)}" end)
+        Logger.warning(fn -> describe(state) <> " has requested to stop: #{inspect(error)}" end)
 
         {:stop, error, state}
 
       invalid ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 
@@ -412,7 +412,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
         dispatch_commands(pending_commands, opts, state, last_event)
 
       {:error, _error} = error ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           describe(state) <>
             " failed to dispatch command " <> inspect(command) <> " due to: " <> inspect(error)
         end)
@@ -508,12 +508,12 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
 
       {:stop, reason} = reply ->
         # Stop process manager
-        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(reason)}" end)
+        Logger.warning(fn -> describe(state) <> " has requested to stop: #{inspect(reason)}" end)
 
         reply
 
       invalid ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -257,7 +257,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
   # Stop process router when a process manager instance terminates abnormally.
   @impl GenServer
   def handle_info({:DOWN, _ref, :process, _pid, reason}, %State{} = state) do
-    Logger.warn(fn -> describe(state) <> " is stopping due to: #{inspect(reason)}" end)
+    Logger.warning(fn -> describe(state) <> " is stopping due to: #{inspect(reason)}" end)
 
     {:stop, reason, state}
   end
@@ -417,12 +417,12 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
         ack_and_continue(failed_event, state)
 
       {:stop, reason} ->
-        Logger.warn(fn -> describe(state) <> " has requested to stop: #{inspect(error)}" end)
+        Logger.warning(fn -> describe(state) <> " has requested to stop: #{inspect(error)}" end)
 
         {:stop, reason, state}
 
       invalid ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           describe(state) <> " returned an invalid error response: #{inspect(invalid)}"
         end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Commanded.Mixfile do
     [
       app: :commanded,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),


### PR DESCRIPTION
When using commanded with Elixir 1.15, we currently see a lot deprecation warnings for `Logger.warn/1`:

```
warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead                                                                                                                                                   
  lib/commanded/middleware/consistency_guarantee.ex:47: Commanded.Middleware.ConsistencyGuarantee.after_dispatch/1
```

It should be fine to change `Logger.warn/1` to `Logger.warning/1` because the _new_ function already exists since Elixir 1.11.

FYI: `eventstore` already has already been updated to use `Logger.warning/1`: https://github.com/commanded/eventstore/pull/278

---

@slashdotdash What about this? :arrow_down_small: 

https://github.com/commanded/commanded/blob/e20fddd01f46a6668ce7360761c7136e5e3bc497/mix.exs#L10

and

https://github.com/commanded/commanded/blob/e20fddd01f46a6668ce7360761c7136e5e3bc497/README.md?plain=1#L22

Can we just increase these to at least 1.11? :thinking: