### PR TITLE
Retry on timeouts

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -130,6 +130,11 @@ defmodule Commanded.Commands.Dispatcher do
         # Maybe retry command when aggregate process not found on a remote node
         maybe_retry(pipeline, payload, context)
 
+      {:error, :aggregate_execution_timeout} ->
+        # The main reason for a timeout is that aggregate loading is slow, so retrying
+        # is expected to help.
+        maybe_retry(pipeline, payload, context)
+
       {:error, error} ->
         pipeline
         |> Pipeline.respond({:error, error})
@@ -239,8 +244,10 @@ defmodule Commanded.Commands.Dispatcher do
       {:ok, context} ->
         execute(pipeline, payload, context)
 
-      reply ->
-        reply
+      {:error, :too_many_attempts} = error ->
+        pipeline
+        |> Pipeline.respond(error)
+        |> after_failure(payload)
     end
   end
 end

--- a/test/commands/command_timeout_test.exs
+++ b/test/commands/command_timeout_test.exs
@@ -16,7 +16,7 @@ defmodule Commanded.Commands.CommandTimeoutTest do
     # Handler is set to take longer than the configured timeout
     case TimeoutRouter.dispatch(command, application: DefaultApp) do
       {:error, :aggregate_execution_failed} -> :ok
-      {:error, :aggregate_execution_timeout} -> :ok
+      {:error, :too_many_attempts} -> :ok
       reply -> flunk("received an unexpected response: #{inspect(reply)}")
     end
   end

--- a/test/middleware/middleware_test.exs
+++ b/test/middleware/middleware_test.exs
@@ -136,7 +136,7 @@ defmodule Commanded.Middleware.MiddlewareTest do
     # Force command handling to timeout so the aggregate process is terminated
     :ok =
       case Router.dispatch(command, application: DefaultApp, timeout: 50) do
-        {:error, :aggregate_execution_timeout} -> :ok
+        {:error, :too_many_attempts} -> :ok
         {:error, :aggregate_execution_failed} -> :ok
       end
 


### PR DESCRIPTION
We saw some aggregate execution timeouts which we still need to dig into, but what is most likely happening is that a "big" aggregate is started and starts rehydration, then the command gets queued up and it times out after five seconds because the rehydration is still going on. 

Timeouts in this spot should be retryable, which is what this patch implements. 

Also fixed `maybe_retry` as it just returned the error instead of properly doing the Pipeline.respond thing; this was, as far as I can tell, a latent bug.