### PR TITLE
Fix refute_receive_event examples

### DIFF
--- a/lib/commanded/assertions/event_assertions.ex
+++ b/lib/commanded/assertions/event_assertions.ex
@@ -91,13 +91,13 @@ defmodule Commanded.Assertions.EventAssertions do
 
   Refute that `ExampleEvent` is produced by given anonymous function:
 
-    refute_receive_event(ExampleApp, ExampleEvent, fn ->
-      :ok = MyApp.dispatch(command)
-    end)
+      refute_receive_event(ExampleApp, ExampleEvent, fn ->
+        :ok = MyApp.dispatch(command)
+      end)
 
   Refute that `ExampleEvent` is produced by `some_func/0` function:
 
-    refute_receive_event(ExampleApp, ExampleEvent, &some_func/0)
+      refute_receive_event(ExampleApp, ExampleEvent, &some_func/0)
 
   Refute that `ExampleEvent` matching given `event_matches?/1` predicate function
   is produced by `some_func/0` function:


### PR DESCRIPTION
Some of the code examples for `refute_receive_event` are not rendering correctly:

![image](https://github.com/commanded/commanded/assets/4924153/4462725a-398e-4f09-91a9-af628106a499)

This PR fixes the indentation, which should fix the problem.