### PR TITLE
feat: snapshot event handler state

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -335,8 +335,8 @@ defmodule Commanded.Event.Handler do
   alias Commanded.Event.Handler
   alias Commanded.Event.Upcast
   alias Commanded.EventStore
-  alias Commanded.EventStore.SnapshotData
   alias Commanded.EventStore.RecordedEvent
+  alias Commanded.EventStore.SnapshotData
   alias Commanded.EventStore.Subscription
   alias Commanded.Subscriptions
   alias Commanded.Telemetry

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -166,8 +166,8 @@ defmodule Commanded.Event.Handler do
 
   An event handler can define and update state which is held in the `GenServer`
   process memory. It is passed to the `handle/2` function as part of the
-  metadata using the `:state` key. The state is transient and will be lost
-  whenever the process restarts.
+  metadata using the `:state` key. By default the state is transient and will be lost
+  whenever the process restarts but it can be persisted with the `persistence: :permanent` option.
 
   Initial state can be set in the `init/1` callback function by adding a
   `:state` key to the config. It can also be provided when starting the handler
@@ -542,8 +542,11 @@ defmodule Commanded.Event.Handler do
         - `:start_from` - where to start the event store subscription from when
           first created (default: `:origin`).
 
-        - :subscribe_to - which stream to subscribe to can be either `:all` to
+        - `:subscribe_to` - which stream to subscribe to can be either `:all` to
           subscribe to all events or a named stream (default: `:all`).
+
+        - `persistence` - whether to persist handler state between restarts, one
+        of either `:ephemeral` (default) or `:permanent`.
 
       The default options supported by `GenServer.start_link/3` are supported,
       including the `:hibernate_after` option which allows the process to go

--- a/test/event/event_handler_persistent_state_test.exs
+++ b/test/event/event_handler_persistent_state_test.exs
@@ -1,0 +1,169 @@
+defmodule Commanded.Event.EventHandlerPersistentStateTest do
+  use Commanded.MockEventStoreCase
+
+  alias Commanded.Event.StatefulEventHandler
+  alias Commanded.EventStore.SnapshotData
+  alias Commanded.Helpers.EventFactory
+  alias Commanded.MockedApp
+
+  defmodule AnEvent do
+    @derive Jason.Encoder
+    defstruct [:reply_to, :update_state?]
+  end
+
+  describe "event handler state with permanent persistence" do
+    alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
+
+    test "initially set in `init/1` function without previous snapshot" do
+      {:ok, subscription} = start_subscription()
+
+      MockEventStore
+      |> stub(:subscribe_to, fn _, _, _, _, _, _ -> {:ok, subscription} end)
+      |> expect(:record_snapshot, fn _, _ -> :ok end)
+      |> expect(:read_snapshot, fn _, _ -> {:error, :snapshot_not_found} end)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp
+        })
+
+      event = %AnEvent{reply_to: reply_to(), update_state?: true}
+      send_events_to_handler(handler, [event])
+
+      assert_receive {:event, ^event, metadata}
+      assert match?(%{state: 0}, metadata)
+    end
+
+    test "initially set in `init/1` function wit previous snapshot" do
+      {:ok, subscription} = start_subscription()
+
+      MockEventStore
+      |> stub(:subscribe_to, fn _event_store, _snapshot, _, _, _, _ -> {:ok, subscription} end)
+      |> expect(:record_snapshot, fn _, _ -> :ok end)
+      |> expect(:read_snapshot, fn _, _ -> {:ok, %SnapshotData{data: 3}} end)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp
+        })
+
+      event = %AnEvent{reply_to: reply_to(), update_state?: true}
+      send_events_to_handler(handler, [event])
+
+      assert_receive {:event, ^event, metadata}
+      assert match?(%{state: 3}, metadata)
+    end
+
+    test "updated by returning `{:ok, new_state}` from `handle/2` function" do
+      {:ok, subscription} = start_subscription()
+
+      MockEventStore
+      |> stub(:subscribe_to, fn _, _, _, _, _, _ -> {:ok, subscription} end)
+      |> expect(:read_snapshot, fn _, _ -> {:error, :snapshot_not_found} end)
+      |> expect(:record_snapshot, fn _, %_{data: 1} -> :ok end)
+      |> expect(:record_snapshot, fn _, %_{data: 2} -> :ok end)
+      |> expect(:ack_event, 2, fn _, _, _ -> :ok end)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp
+        })
+
+      event1 = %AnEvent{reply_to: reply_to(), update_state?: true}
+      event2 = %AnEvent{reply_to: reply_to(), update_state?: true}
+      send_events_to_handler(handler, [event1, event2])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 0}, metadata)
+
+      assert_receive {:event, ^event2, metadata}
+      assert match?(%{state: 1}, metadata)
+    end
+
+    test "not updated when returning `:ok` from `handle/2` function" do
+      {:ok, subscription} = start_subscription()
+
+      MockEventStore
+      |> stub(:subscribe_to, fn _, _, _, _, _, _ -> {:ok, subscription} end)
+      |> expect(:record_snapshot, fn _, _ -> :ok end)
+      |> expect(:read_snapshot, fn _, _ -> {:error, :snapshot_not_found} end)
+      |> expect(:ack_event, 2, fn _, _, _ -> :ok end)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp
+        })
+
+      event1 = %AnEvent{reply_to: reply_to(), update_state?: false}
+      event2 = %AnEvent{reply_to: reply_to(), update_state?: false}
+      send_events_to_handler(handler, [event1, event2])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 0}, metadata)
+
+      assert_receive {:event, ^event2, metadata}
+      assert match?(%{state: 0}, metadata)
+    end
+
+    test "state is NOT reset when process restarts" do
+      {:ok, subscription} = start_subscription()
+
+      MockEventStore
+      |> stub(:subscribe_to, fn _, _, _, _, _, _ -> {:ok, subscription} end)
+      |> expect(:read_snapshot, 1, fn _, _ -> {:ok, %SnapshotData{data: 10}} end)
+      |> expect(:record_snapshot, 1, fn _, _ -> :ok end)
+      |> expect(:read_snapshot, 1, fn _, _ -> {:ok, %SnapshotData{data: 11}} end)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp, state: 10
+        })
+
+      event1 = %AnEvent{reply_to: reply_to(), update_state?: true}
+      send_events_to_handler(handler, [event1])
+
+      assert_receive {:event, ^event1, metadata}
+      assert match?(%{state: 10}, metadata)
+
+      # Restart app
+      stop_supervised!(MockedApp)
+      start_supervised!(MockedApp)
+
+      handler =
+        start_supervised!({
+          StatefulEventHandler,
+          persistence: :permanent, application: MockedApp
+        })
+
+      event2 = %AnEvent{reply_to: reply_to(), update_state?: false}
+      send_events_to_handler(handler, [event2])
+
+      assert_receive {:event, ^event2, metadata}
+      assert match?(%{state: 11}, metadata)
+    end
+  end
+
+  defp reply_to, do: :erlang.pid_to_list(self())
+
+  defp send_events_to_handler(handler, events, initial_event_number \\ 1) do
+    recorded_events = EventFactory.map_to_recorded_events(events, initial_event_number)
+
+    send(handler, {:events, recorded_events})
+  end
+
+  defp start_subscription do
+    pid =
+      spawn_link(fn ->
+        receive do
+          :shutdown -> :ok
+        end
+      end)
+
+    {:ok, pid}
+  end
+end

--- a/test/event/handler_config_test.exs
+++ b/test/event/handler_config_test.exs
@@ -14,7 +14,7 @@ defmodule Commanded.Event.HandlerConfigTest do
     :ok
   end
 
-  test "should default to `:eventual` consistency and start from `:origin`" do
+  test "should default to `:eventual` consistency, `:ephemeral` persistence and start from `:origin`" do
     {:ok, handler} = DefaultConfigHandler.start_link()
 
     assert_config(handler,
@@ -23,7 +23,8 @@ defmodule Commanded.Event.HandlerConfigTest do
       concurrency: 1,
       consistency: :eventual,
       start_from: :origin,
-      subscribe_to: :all
+      subscribe_to: :all,
+      persistence: :ephemeral
     )
   end
 
@@ -39,7 +40,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :origin,
-        subscribe_to: :all
+        subscribe_to: :all,
+        persistence: :ephemeral
       )
 
       Application.put_env(:commanded, :default_consistency, :eventual)
@@ -65,7 +67,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :current,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :ephemeral
       )
     end
 
@@ -76,7 +79,8 @@ defmodule Commanded.Event.HandlerConfigTest do
           consistency: :eventual,
           index: 0,
           start_from: :origin,
-          subscribe_to: "stream2"
+          subscribe_to: "stream2",
+          persistence: :permanent
         )
 
       assert_config(handler,
@@ -85,7 +89,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 10,
         consistency: :eventual,
         start_from: :origin,
-        subscribe_to: "stream2"
+        subscribe_to: "stream2",
+        persistence: :permanent
       )
     end
 
@@ -98,7 +103,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :origin,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :ephemeral
       )
     end
 
@@ -111,7 +117,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :current,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :ephemeral
       )
     end
 
@@ -126,7 +133,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :current,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :ephemeral
       )
     end
   end
@@ -141,7 +149,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :strong,
         start_from: :current,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :ephemeral
       )
     end
 
@@ -154,7 +163,8 @@ defmodule Commanded.Event.HandlerConfigTest do
            application: :dynamic_app,
            name: "handler_name",
            consistency: :eventual,
-           start_from: :origin}
+           start_from: :origin,
+           persistence: :permanent}
         )
 
       assert_config(handler,
@@ -163,7 +173,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: 1,
         consistency: :eventual,
         start_from: :origin,
-        subscribe_to: "stream1"
+        subscribe_to: "stream1",
+        persistence: :permanent
       )
     end
   end
@@ -233,7 +244,8 @@ defmodule Commanded.Event.HandlerConfigTest do
         concurrency: concurrency,
         subscribe_from: subscribe_from,
         subscribe_to: subscribe_to
-      }
+      },
+      persistence: persistence
     } = :sys.get_state(handler)
 
     actual_config = [
@@ -242,7 +254,8 @@ defmodule Commanded.Event.HandlerConfigTest do
       concurrency: concurrency,
       consistency: consistency,
       start_from: subscribe_from,
-      subscribe_to: subscribe_to
+      subscribe_to: subscribe_to,
+      persistence: persistence
     ]
 
     assert actual_config == expected_config

--- a/test/event/reset_event_handler_test.exs
+++ b/test/event/reset_event_handler_test.exs
@@ -45,7 +45,8 @@ defmodule Commanded.Event.ResetEventHandlerTest do
       initial_events = [%BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}]
       :ok = EventStore.append_to_stream(BankApp, stream_uuid, 0, to_event_data(initial_events))
 
-      handler = start_supervised!({BankAccountHandler, start_from: :current})
+      handler =
+        start_supervised!({BankAccountHandler, start_from: :current, persistence: :ephemeral})
 
       Wait.until(fn ->
         assert BankAccountHandler.current_accounts() == []


### PR DESCRIPTION
Snapshot the Event Handler state when `persistence: :permanent`

Configurable with the `persistence` option (`:ephemeral` by default)

Related issue #461 

Credits to @lucazulian 🙌 