### PR TITLE
add missing timeout for aggregates (gen_server) callback

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.0
-elixir 1.17.1-otp-27
+elixir 1.15.7-otp-25
+erlang 25.3.2.8

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-25
-erlang 25.3.2.8
+erlang 27.0
+elixir 1.17.1-otp-27

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -347,7 +347,7 @@ defmodule Commanded.Aggregates.Aggregate do
   def handle_call(:aggregate_state, _from, %Aggregate{} = state) do
     %Aggregate{aggregate_state: aggregate_state} = state
 
-    {:reply, aggregate_state, state}
+    {:reply, aggregate_state, state, Map.get(state, :lifespan_timeout, :infinity)}
   end
 
   @doc false
@@ -355,7 +355,7 @@ defmodule Commanded.Aggregates.Aggregate do
   def handle_call(:aggregate_version, _from, %Aggregate{} = state) do
     %Aggregate{aggregate_version: aggregate_version} = state
 
-    {:reply, aggregate_version, state}
+    {:reply, aggregate_version, state, Map.get(state, :lifespan_timeout, :infinity)}
   end
 
   @doc false

--- a/lib/commanded/registration/local_registry.ex
+++ b/lib/commanded/registration/local_registry.ex
@@ -111,9 +111,13 @@ defmodule Commanded.Registration.LocalRegistry do
   end
 
   @doc false
+  def handle_info(message, %Commanded.Aggregates.Aggregate{} = state) do
+    Logger.debug("received unexpected message in handle_info/2: " <> inspect(message))
+    {:noreply, state, Map.get(state, :lifespan_timeout, :infinity)}
+  end
+
   def handle_info(message, state) do
     Logger.debug("received unexpected message in handle_info/2: " <> inspect(message))
-
     {:noreply, state}
   end
 


### PR DESCRIPTION
commanded 1.4.6
Linux 6.8.0-48-generic #48-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 27 14:04:52 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
erlang 27.0
elixir 1.17.1-otp-27

Some aggregates never finish despite a lifespan_timeout set to an integer.
 I chased all aggregates callbacks and complete the ones with a missing timeout.