### PR TITLE
Aggregate.handle_* now properly handles lifespans

### DIFF
--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -1,7 +1,7 @@
 defmodule Commanded.Aggregates.AggregateLifespanTest do
   use ExUnit.Case
 
-  alias Commanded.Aggregates.{DefaultLifespanRouter, LifespanAggregate, LifespanRouter}
+  alias Commanded.Aggregates.{Aggregate, DefaultLifespanRouter, LifespanAggregate, LifespanRouter}
   alias Commanded.Aggregates.LifespanAggregate.{Command, Event}
   alias Commanded.{DefaultApp, EventStore}
   alias Commanded.EventStore.RecordedEvent
@@ -95,6 +95,64 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
       }
 
       :ok = LifespanRouter.dispatch(command, application: DefaultApp)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, :normal}
+    end
+
+    test "honours lifespan after a call to aggregate_state", %{
+      aggregate_uuid: aggregate_uuid,
+      ref: ref,
+      reply_to: reply_to
+    } do
+      command = %Command{
+        uuid: aggregate_uuid,
+        reply_to: reply_to,
+        action: :event,
+        lifespan: 500
+      }
+
+      :ok = LifespanRouter.dispatch(command, application: DefaultApp)
+
+      %{lifespan: 500} = Aggregate.aggregate_state(DefaultApp, LifespanAggregate, aggregate_uuid)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, :normal}
+    end
+
+    test "honours lifespan after a call to aggregate_version", %{
+      aggregate_uuid: aggregate_uuid,
+      ref: ref,
+      reply_to: reply_to
+    } do
+      command = %Command{
+        uuid: aggregate_uuid,
+        reply_to: reply_to,
+        action: :event,
+        lifespan: 500
+      }
+
+      :ok = LifespanRouter.dispatch(command, application: DefaultApp)
+
+      1 = Aggregate.aggregate_version(DefaultApp, LifespanAggregate, aggregate_uuid)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, :normal}
+    end
+
+    test "honours lifespan after an info message is handled", %{
+      aggregate_uuid: aggregate_uuid,
+      pid: pid,
+      ref: ref,
+      reply_to: reply_to
+    } do
+      command = %Command{
+        uuid: aggregate_uuid,
+        reply_to: reply_to,
+        action: :event,
+        lifespan: 500
+      }
+
+      :ok = LifespanRouter.dispatch(command, application: DefaultApp)
+
+      send(pid, :unexpected_message)
 
       assert_receive {:DOWN, ^ref, :process, _pid, :normal}
     end


### PR DESCRIPTION
Based on @bougueil's issue and work here:
https://github.com/commanded/commanded/pull/600

He found 3 cases where an agggregate's lifespan would be cancelled unintentionally.

Specifically
1) Calling `Aggregate.aggregate_state/3`
2) Calling `Aggregate.aggregate_version/3`
3) If the aggregate process receives any unhandled message

The work here is to add tests and provide a unified way of sending `:reply` or `:noreply` along with the lifetime info.