### PR TITLE
Allow registration handle_call/cast callbacks to be called

### DIFF
--- a/lib/commanded/registration.ex
+++ b/lib/commanded/registration.ex
@@ -83,15 +83,7 @@ defmodule Commanded.Registration do
       @before_compile unquote(__MODULE__)
 
       alias unquote(__MODULE__)
-    end
-  end
 
-  @doc """
-  Allow a registry adapter to handle the standard `GenServer` callback
-  functions.
-  """
-  defmacro __before_compile__(_env) do
-    quote generated: true, location: :keep do
       @doc false
       def handle_call(request, from, state) do
         adapter = registry_adapter(state)
@@ -106,6 +98,16 @@ defmodule Commanded.Registration do
         adapter.handle_cast(request, state)
       end
 
+      defoverridable(handle_call: 3, handle_cast: 2)
+    end
+  end
+
+  @doc """
+  Allow a registry adapter to handle the standard `GenServer` callback
+  functions.
+  """
+  defmacro __before_compile__(_env) do
+    quote generated: true, location: :keep do
       @doc false
       def handle_info(msg, state) do
         adapter = registry_adapter(state)


### PR DESCRIPTION
Commanded modules ProcessRouter, Aggregate, and Event.Handler all `use` both `GenServer` and `Commanded.Registration` macros.

While the code as written with handle_call/cast/info callbacks allowed for Registration.handle_info/2 to be called by sending the process a message, the other two handlers were not reachable.

By moving those two into the `__using__` block, we get what we're after.

Should resolve https://github.com/commanded/commanded-swarm-registry/issues/2

Big thanks to @predrag-rakic for finding, reporting and proposing the fix.