### PR TITLE
Add aggregate behaviour

### DIFF
--- a/guides/Aggregates.md
+++ b/guides/Aggregates.md
@@ -141,12 +141,14 @@ defmodule BankAccount do
     %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
   end
 
+  @impl Aggregate
   def execute(%BankAccount{}, %OpenAccount{initial_balance: initial_balance})
     when initial_balance <= 0
   do
     {:error, :initial_balance_must_be_above_zero}
   end
 
+  @impl Aggregate
   def execute(%BankAccount{}, %OpenAccount{}) do
     {:error, :account_already_opened}
   end

--- a/guides/Aggregates.md
+++ b/guides/Aggregates.md
@@ -117,7 +117,7 @@ defmodule Commanded.ExampleDomain.OpenAccountHandler do
 end
 ```
 
-An alternative approach is to expose one or more public command functions, `execute/2`, and use pattern matching on the command argument. With this approach you can route your commands directly to the aggregate.
+An alternative approach is to expose one or more public command functions, `execute/2`, and use pattern matching on the command argument. With this approach you can route your commands directly to the aggregate. To make this more explicit, you can implement the `Commanded.Aggregates.Aggregate` behaviour.
 
 In this example the `execute/2` function pattern matches on the `OpenAccount` command module:
 
@@ -125,8 +125,12 @@ In this example the `execute/2` function pattern matches on the `OpenAccount` co
 defmodule BankAccount do
   defstruct [:account_number, :balance]
 
+  alias Commanded.Aggregates.Aggregate
+  @behaviour Aggregate
+
   # Public API
 
+  @impl Aggregate
   def execute(
     %BankAccount{account_number: nil},
     %OpenAccount{initial_balance: initial_balance} = command
@@ -149,6 +153,7 @@ defmodule BankAccount do
 
   # State mutators
 
+  @impl Aggregate
   def apply(%BankAccount{} = account, %BankAccountOpened{} = event) do
     %BankAccountOpened{account_number: account_number, initial_balance: initial_balance} = event
 
@@ -192,10 +197,14 @@ defmodule BankAccount do
     state: nil,
   ]
 
+  alias Commanded.Aggregate
   alias Commanded.Aggregate.Multi
+
+  @behaviour Aggregate
 
   # Public API
 
+  @impl Aggregate
   def execute(
     %BankAccount{state: :active} = account,
     %WithdrawMoney{amount: amount})
@@ -209,6 +218,7 @@ defmodule BankAccount do
 
   # State mutators
 
+  @impl Aggregate
   def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}),
     do: %BankAccount{state | balance: balance}
 

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -39,8 +39,13 @@ Here's an example bank account opening feature built using Commanded to demonstr
     defmodule BankAccount do
       defstruct [:account_number, :balance]
 
+      alias Commanded.Aggregates.Aggregate
+
+      @behaviour Aggregate
+
       # Public command API
 
+      @impl Aggregate
       def execute(%BankAccount{account_number: nil}, %OpenBankAccount{account_number: account_number, initial_balance: initial_balance})
         when initial_balance > 0
       do
@@ -48,6 +53,7 @@ Here's an example bank account opening feature built using Commanded to demonstr
       end
 
       # Ensure initial balance is never zero or negative
+      @impl Aggregate
       def execute(%BankAccount{}, %OpenBankAccount{initial_balance: initial_balance})
         when initial_balance <= 0
       do
@@ -55,12 +61,14 @@ Here's an example bank account opening feature built using Commanded to demonstr
       end
 
       # Ensure account has not already been opened
+      @impl Aggregate
       def execute(%BankAccount{}, %OpenBankAccount{}) do
         {:error, :account_already_opened}
       end
 
       # State mutators
 
+      @impl Aggregate
       def apply(%BankAccount{} = account, %BankAccountOpened{} = event) do
         %BankAccountOpened{account_number: account_number, initial_balance: initial_balance} = event
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -113,8 +113,20 @@ defmodule Commanded.Aggregates.Aggregate do
   alias Commanded.Telemetry
 
   @type state :: struct()
-
   @type uuid :: String.t()
+  @type return_event :: struct() | list(struct()) | {:ok, struct()} | {:ok, list(struct())}
+  @type no_return_event :: :ok | {:ok, []} | nil | []
+
+  @doc """
+  Execute a command against the aggregate. Returns either no event, one event, a list of events, or an error tuple.
+  """
+  @callback execute(aggregate :: state(), command :: struct()) ::
+              return_event() | no_return_event() | {:error, term()}
+
+  @doc """
+  Apply an event to the aggregate state. Returns the updated aggregate.
+  """
+  @callback apply(aggregate :: state(), event :: struct()) :: state()
 
   defstruct [
     :application,


### PR DESCRIPTION
There's no issue for this, but after working with `commanded` for a bit, I think it'd be helpful to have a behaviour for aggregates!

I've updated docs as well, but only in a few places.

Ref:
- https://hexdocs.pm/commanded/usage.html
- https://hexdocs.pm/commanded/aggregates.html