### PR TITLE
Improve Router Registration Error

### DIFF
--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -43,10 +43,11 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     defmodule CommandHandlerRouter do
       use Commanded.Commands.Router
 
+      # Put the :to option at the end and ensure the dispatch still works
       dispatch OpenAccount,
-        to: OpenAccountHandler,
         aggregate: BankAccount,
-        identity: :account_number
+        identity: :account_number,
+        to: OpenAccountHandler
 
       dispatch DepositMoney,
         to: DepositMoneyHandler,
@@ -54,7 +55,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         identity: :account_number
     end
 
-    test "should dispatch command to registered handler" do
+    test "should dispatch command to registered handler, regardless of the router dispatch option order" do
       assert :ok =
                CommandHandlerRouter.dispatch(
                  %OpenAccount{
@@ -240,6 +241,35 @@ defmodule Commanded.Commands.RoutingCommandsTest do
                      end
                    """)
                  end
+  end
+
+  test "should show a helpful message when required :to argument is missing" do
+    assert_raise RuntimeError, "dispatch missing required parameter: :to", fn ->
+      Code.eval_string("""
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule InvalidRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, identity: BankAccount
+        end
+      """)
+    end
+  end
+
+  test "should not depend on the order of the arguments" do
+    Code.eval_string("""
+      alias Commanded.ExampleDomain.{BankAccount, OpenAccountHandler}
+      alias Commanded.ExampleDomain.BankAccount.Commands.{CloseAccount, OpenAccount}
+
+      defmodule AnyOrderRouter do
+        use Commanded.Commands.Router
+
+        dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount
+        dispatch CloseAccount, aggregate: BankAccount, to: OpenAccountHandler
+      end
+    """)
   end
 
   defmodule MultiCommandRouter do

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -258,20 +258,6 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     end
   end
 
-  test "should not depend on the order of the arguments" do
-    Code.eval_string("""
-      alias Commanded.ExampleDomain.{BankAccount, OpenAccountHandler}
-      alias Commanded.ExampleDomain.BankAccount.Commands.{CloseAccount, OpenAccount}
-
-      defmodule AnyOrderRouter do
-        use Commanded.Commands.Router
-
-        dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount
-        dispatch CloseAccount, aggregate: BankAccount, to: OpenAccountHandler
-      end
-    """)
-  end
-
   defmodule MultiCommandRouter do
     use Commanded.Commands.Router
 


### PR DESCRIPTION
If you forgot to include the required `:to` option in `dispatch(...)` during your router registration you would get an unhelpful error (as noted in #422).  This PR fixes that, so that a more helpful error is returned.

Additionally, while trying to replicate this I found another bug with the registration arguments: if the `:to` option was not the first option in the list, things would break.   I've addressed that bug here as well because it was in the same part of the code.

For this PR, the first commit was adding the new tests (which failed), and the second commit is the changes to get the tests passing.

Closes #422 

