### PR TITLE
Support :selector option for InMemory adapter

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -63,7 +63,7 @@
           {Credo.Check.Refactor.MapJoin, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
-          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
           {Credo.Check.Refactor.UnlessWithElse, false},
           {Credo.Check.Refactor.WithClauses, []},
           {Credo.Check.Refactor.FilterFilter, []},

--- a/.credo.exs
+++ b/.credo.exs
@@ -63,7 +63,7 @@
           {Credo.Check.Refactor.MapJoin, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
-          {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
+          {Credo.Check.Refactor.Nesting, []},
           {Credo.Check.Refactor.UnlessWithElse, false},
           {Credo.Check.Refactor.WithClauses, []},
           {Credo.Check.Refactor.FilterFilter, []},

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -95,6 +95,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
       concurrency_limit: Keyword.get(opts, :concurrency_limit),
       name: subscription_name,
       partition_by: Keyword.get(opts, :partition_by),
+      selector: Keyword.get(opts, :selector),
       start_from: start_from,
       stream_uuid: stream_uuid
     }
@@ -483,14 +484,29 @@ defmodule Commanded.EventStore.Adapters.InMemory do
         unseen_event =
           deserialize(state, unseen_event) |> set_event_number_from_version(stream_uuid)
 
-        case PersistentSubscription.publish(subscription, unseen_event) do
-          {:ok, subscription} -> publish_events(state, subscription)
-          {:error, :no_subscriber_available} -> subscription
+        if selected?(unseen_event, subscription) do
+          case PersistentSubscription.publish(subscription, unseen_event) do
+            {:ok, subscription} -> publish_events(state, subscription)
+            {:error, :no_subscriber_available} -> subscription
+          end
+        else
+          %RecordedEvent{event_number: event_number} = unseen_event
+          subscription = PersistentSubscription.checkpoint(subscription, event_number)
+          publish_events(state, subscription)
         end
 
       nil ->
         subscription
     end
+  end
+
+  defp selected?(event, %PersistentSubscription{selector: selector})
+       when is_function(selector, 1) do
+    selector.(event)
+  end
+
+  defp selected?(_event, %PersistentSubscription{}) do
+    true
   end
 
   defp stop_subscription(%State{} = state, subscription) do

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -479,24 +479,27 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
     position = if checkpoint == 0, do: -1, else: -(checkpoint + 1)
 
-    case Enum.at(events, position) do
-      %RecordedEvent{} = unseen_event ->
-        unseen_event =
-          deserialize(state, unseen_event) |> set_event_number_from_version(stream_uuid)
+    unseen_event =
+      with %RecordedEvent{} = event <- Enum.at(events, position) do
+        state
+        |> deserialize(event)
+        |> set_event_number_from_version(stream_uuid)
+      end
 
-        if selected?(unseen_event, subscription) do
-          case PersistentSubscription.publish(subscription, unseen_event) do
-            {:ok, subscription} -> publish_events(state, subscription)
-            {:error, :no_subscriber_available} -> subscription
-          end
-        else
-          %RecordedEvent{event_number: event_number} = unseen_event
-          subscription = PersistentSubscription.checkpoint(subscription, event_number)
-          publish_events(state, subscription)
+    cond do
+      is_nil(unseen_event) ->
+        subscription
+
+      unseen_event && selected?(unseen_event, subscription) ->
+        case PersistentSubscription.publish(subscription, unseen_event) do
+          {:ok, subscription} -> publish_events(state, subscription)
+          {:error, :no_subscriber_available} -> subscription
         end
 
-      nil ->
-        subscription
+      unseen_event ->
+        %RecordedEvent{event_number: event_number} = unseen_event
+        subscription = PersistentSubscription.checkpoint(subscription, event_number)
+        publish_events(state, subscription)
     end
   end
 

--- a/lib/commanded/event_store/adapters/in_memory/persistent_subscription.ex
+++ b/lib/commanded/event_store/adapters/in_memory/persistent_subscription.ex
@@ -11,6 +11,7 @@ defmodule Commanded.EventStore.Adapters.InMemory.PersistentSubscription do
     :name,
     :partition_by,
     :ref,
+    :selector,
     :start_from,
     :stream_uuid,
     subscribers: []
@@ -116,6 +117,13 @@ defmodule Commanded.EventStore.Adapters.InMemory.PersistentSubscription do
     else
       subscription
     end
+  end
+
+  @doc """
+  Set the checkpoint for a subscriber.
+  """
+  def checkpoint(%PersistentSubscription{} = subscription, checkpoint) do
+    %PersistentSubscription{subscription | checkpoint: checkpoint}
   end
 
   # Get the subscriber to send the event to determined by the partition function


### PR DESCRIPTION
The `:selector` option is supported by the "real" eventstore, but not by the InMemory eventstore. This is causing a lot of my unit tests to fail as event handlers are recieving event types that they do not receive in non-test environments.

I tested this in my own project, I can now swap the InMemory adapter for the Postgres implementation and all of my test will still pass 👍
