### PR TITLE
Fix Warnings for Elixir 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: 1.19.x
+            otp: 28
           - elixir: 1.18.x
             otp: 28
           - elixir: 1.17.x
@@ -26,10 +28,6 @@ jobs:
             otp: 26
           - elixir: 1.15.x
             otp: 26
-          - elixir: 1.14.x
-            otp: 26
-          - elixir: 1.13.x
-            otp: 25
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -348,7 +348,7 @@ defmodule Commanded.Aggregates.Aggregate do
         # be taken. When it finishes, it will set the timeout.
         {:reply, formatted_reply, state}
       else
-        state = %Aggregate{state | lifespan_timeout: lifespan_timeout}
+        state = %{state | lifespan_timeout: lifespan_timeout}
 
         reply_with_lifespan(formatted_reply, state)
       end

--- a/lib/commanded/aggregates/aggregate_state_builder.ex
+++ b/lib/commanded/aggregates/aggregate_state_builder.ex
@@ -96,7 +96,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
         %RecordedEvent{data: data, stream_version: stream_version} = event
         %Aggregate{aggregate_module: aggregate_module, aggregate_state: aggregate_state} = state
 
-        state = %Aggregate{
+        state = %{
           state
           | aggregate_version: stream_version,
             aggregate_state: aggregate_module.apply(aggregate_state, data)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Commanded.Mixfile do
     [
       app: :commanded,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),

--- a/test/aggregates/aggregate_subscription_test.exs
+++ b/test/aggregates/aggregate_subscription_test.exs
@@ -60,12 +60,9 @@ defmodule Commanded.Aggregates.AggregateSubscriptionTest do
       events =
         EventStore.stream_forward(DefaultApp, account_number)
         |> Enum.to_list()
-        |> Enum.map(fn recorded_event ->
+        |> Enum.map(fn %EventStore.RecordedEvent{} = recorded_event ->
           # specify invalid stream version
-          %EventStore.RecordedEvent{
-            recorded_event
-            | stream_version: 999
-          }
+          %{recorded_event | stream_version: 999}
         end)
 
       # send invalid events, should stop the aggregate process

--- a/test/event/support/error/error_event_handler.ex
+++ b/test/event/support/error/error_event_handler.ex
@@ -78,7 +78,7 @@ defmodule Commanded.Event.ErrorEventHandler do
       |> Map.put(:delay, delay)
 
     # Record failure count in context map
-    failure_context = %FailureContext{failure_context | context: context}
+    failure_context = %{failure_context | context: context}
 
     if Map.get(context, :failures) >= 3 do
       # Stop error handler after third failure

--- a/test/process_managers/support/error/error_aggregate.ex
+++ b/test/process_managers/support/error/error_aggregate.ex
@@ -98,7 +98,7 @@ defmodule Commanded.ProcessManagers.ErrorAggregate do
     do: {:error, :failed}
 
   def execute(%ErrorAggregate{}, %ContinueProcess{process_uuid: process_uuid, reply_to: reply_to}),
-    do: %ProcessContinued{process_uuid: process_uuid, reply_to: reply_to}
+      do: %ProcessContinued{process_uuid: process_uuid, reply_to: reply_to}
 
   def apply(%ErrorAggregate{} = aggregate, %ProcessStarted{process_uuid: process_uuid}),
     do: %ErrorAggregate{aggregate | process_uuid: process_uuid}

--- a/test/process_managers/support/error/error_aggregate.ex
+++ b/test/process_managers/support/error/error_aggregate.ex
@@ -94,11 +94,13 @@ defmodule Commanded.ProcessManagers.ErrorAggregate do
     raise message
   end
 
-  def execute(%ErrorAggregate{}, %AttemptProcess{}),
-    do: {:error, :failed}
+  def execute(%ErrorAggregate{}, %AttemptProcess{}) do
+    {:error, :failed}
+  end
 
-  def execute(%ErrorAggregate{}, %ContinueProcess{process_uuid: process_uuid, reply_to: reply_to}),
-      do: %ProcessContinued{process_uuid: process_uuid, reply_to: reply_to}
+  def execute(%ErrorAggregate{}, %ContinueProcess{process_uuid: process_uuid, reply_to: reply_to}) do
+    %ProcessContinued{process_uuid: process_uuid, reply_to: reply_to}
+  end
 
   def apply(%ErrorAggregate{} = aggregate, %ProcessStarted{process_uuid: process_uuid}),
     do: %ErrorAggregate{aggregate | process_uuid: process_uuid}


### PR DESCRIPTION
Mimics the changes in the PR for the EventStore: https://github.com/commanded/eventstore/pull/319

- Set the minimum version of Elixir to 1.15
- Add Elixir 1.19 to Github Actions test matrix and fix warnings for 1.19
- Fix formatting warning
