### PR TITLE
Handle :trim return value from command execution

### DIFF
--- a/guides/Aggregates.md
+++ b/guides/Aggregates.md
@@ -20,7 +20,7 @@ end
 
 ## Command functions
 
-A command function receives the aggregate's state and the command to execute. It must return the resultant domain events, which may be one event or multiple events. You can return a single event or a list of events: `%Event{}`, `[%Event{}]`, `{:ok, %Event{}}`, or `{:ok, [%Event{}]}`.
+A command function receives the aggregate's state and the command to execute. It must return the resultant domain events, which may be one event or multiple events. You can return a single event or a list of events: `%Event{}`, `[%Event{}]`, `{:ok, %Event{}}`, `{:ok, [%Event{}]}`, or `{:trim, <one_or_more_events>}`.
 
 To respond without returning an event you can return `:ok`, `nil` or an empty list as either `[]` or `{:ok, []}`.
 
@@ -316,3 +316,52 @@ Note: The default JSON encoding of a `DateTime` struct uses the `to_iso8601/1` f
 ### Rebuilding an aggregate snapshot
 
 Whenever you change the structure of an aggregate's state you **MUST** increment the `snapshot_version` number. The aggregate state will be rebuilt from its events, ignoring any existing snapshots. They will be overwritten when the next snapshot is taken.
+
+### Returning `:trim` instead of `:ok`
+
+If you return `:trim` instead of `:ok`, with one or more events, then the following will
+happen:
+- The event(s) is/are appended to the event store as normal
+- The aggregate's event stream's _origin_, the oldest valid event, gets set to the
+  first event in this returned set.
+
+This means that whenever you return this, effectively you make all previous events invisible
+and start "fresh". There are a couple of use cases where this can be used:
+
+#### Closing the books.
+
+The aggregate knows it can close itself. It will emit a single event that will
+act as a tombstone: an indicator that the aggregate is closed:
+
+``` elixir
+tombstone = %BooksClosed{new_book_id: abc123, giga_watts_collected: 1.21, frobbers_frobulated: 15}
+{:trim, tombstone}
+```
+
+In this case, the aggregate closes itself with a reference to its successor, and some
+statistics about its lifecycle which presumably will feed into reporting. Presumably, too,
+the aggregate will now throw errors on any attempts to send it further commands.
+
+#### Rolling up a balance
+
+Say that every Sunday night we roll up a balance and replace individual ledger entries
+with just a balance. It's very similar to the previous example, the main difference is
+in your business logic: here you would accept new commands:
+
+```elixir
+balance = %PeriodClosed{period_id: 42, balance: {-1234450, :millicads}}
+{:trim, balance}
+```
+
+The advantage here is faster startup without needing snapshots or indeed any
+in-memory state that is just there to help snapshotting (it is, frankly, very
+close to snapshotting). On restart, the trimmed aggregate stream will just read
+this single event.
+
+#### Garbage collection
+
+Trimmed event streams will result in "unreachable" events. To support that, EventStore
+will support garbage collection, effectively removing events that the application doesn't
+need anymore. See [the EventStore documentation](https://hexdocs.pm/eventstore)
+for details (at the moment of writing this, it is not supported, but plans are to
+add it shortly).

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -216,6 +216,7 @@ defmodule Commanded.Aggregates.Aggregate do
     end
   end
 
+  @spec aggregate_state(atom(), atom(), binary(), :infinity | non_neg_integer()) :: any()
   @doc false
   def aggregate_state(application, aggregate_module, aggregate_uuid, timeout \\ 5_000) do
     name = via_name(application, aggregate_module, aggregate_uuid)
@@ -525,6 +526,9 @@ defmodule Commanded.Aggregates.Aggregate do
         {:ok, pending_events} ->
           apply_and_persist_events(pending_events, context, state)
 
+        {:trim, pending_events} ->
+          apply_and_persist_events(pending_events, context, state, trim: true)
+
         pending_events ->
           apply_and_persist_events(pending_events, context, state)
       end
@@ -540,23 +544,23 @@ defmodule Commanded.Aggregates.Aggregate do
       {{:error, error, stacktrace}, state}
   end
 
-  defp apply_and_persist_events(pending_events, context, %Aggregate{} = state) do
+  defp apply_and_persist_events(pending_events, context, %Aggregate{} = state, opts \\ []) do
     %Aggregate{aggregate_module: aggregate_module, aggregate_state: aggregate_state} = state
 
     pending_events = List.wrap(pending_events)
     aggregate_state = apply_events(aggregate_module, aggregate_state, pending_events)
 
-    persist_events(pending_events, aggregate_state, context, state)
+    persist_events(pending_events, aggregate_state, context, state, opts)
   end
 
   defp apply_events(aggregate_module, aggregate_state, events) do
     Enum.reduce(events, aggregate_state, &aggregate_module.apply(&2, &1))
   end
 
-  defp persist_events(pending_events, aggregate_state, context, %Aggregate{} = state) do
+  defp persist_events(pending_events, aggregate_state, context, %Aggregate{} = state, opts \\ []) do
     %Aggregate{aggregate_version: expected_version} = state
 
-    with :ok <- append_to_stream(pending_events, context, state) do
+    with :ok <- append_to_stream(pending_events, context, state, opts) do
       aggregate_version = expected_version + length(pending_events)
 
       state = %Aggregate{
@@ -589,9 +593,9 @@ defmodule Commanded.Aggregates.Aggregate do
     end
   end
 
-  defp append_to_stream([], _context, _state), do: :ok
+  defp append_to_stream([], _context, _state, _opts), do: :ok
 
-  defp append_to_stream(pending_events, %ExecutionContext{} = context, %Aggregate{} = state) do
+  defp append_to_stream(pending_events, %ExecutionContext{} = context, %Aggregate{} = state, opts) do
     %Aggregate{
       application: application,
       aggregate_uuid: aggregate_uuid,
@@ -611,7 +615,7 @@ defmodule Commanded.Aggregates.Aggregate do
         metadata: metadata
       )
 
-    EventStore.append_to_stream(application, aggregate_uuid, expected_version, event_data)
+    EventStore.append_to_stream(application, aggregate_uuid, expected_version, event_data, opts)
   end
 
   defp do_take_snapshot(%Aggregate{} = state) do

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -65,10 +65,10 @@ defmodule Commanded.EventStore.Adapters.InMemory do
   end
 
   @impl Commanded.EventStore.Adapter
-  def append_to_stream(adapter_meta, stream_uuid, expected_version, events, _opts \\ []) do
+  def append_to_stream(adapter_meta, stream_uuid, expected_version, events, opts \\ []) do
     event_store = event_store_name(adapter_meta)
 
-    GenServer.call(event_store, {:append, stream_uuid, expected_version, events})
+    GenServer.call(event_store, {:append, stream_uuid, expected_version, events, opts})
   end
 
   @impl Commanded.EventStore.Adapter
@@ -152,10 +152,11 @@ defmodule Commanded.EventStore.Adapters.InMemory do
   end
 
   @impl GenServer
-  def handle_call({:append, stream_uuid, expected_version, events}, _from, %State{} = state) do
+  def handle_call({:append, stream_uuid, expected_version, events, opts}, _from, %State{} = state) do
+    trim = Keyword.get(opts, :trim, false)
     %State{streams: streams} = state
 
-    stream_events = Map.get(streams, stream_uuid)
+    stream_events = if trim, do: [], else: Map.get(streams, stream_uuid)
 
     {reply, state} =
       case {expected_version, stream_events} do

--- a/test/event_store/support/append_events_test_case.ex
+++ b/test/event_store/support/append_events_test_case.ex
@@ -147,6 +147,31 @@ defmodule Commanded.EventStore.AppendEventsTestCase do
 
         assert :ok == event_store.append_to_stream(event_store_meta, "stream", 3, build_events(1))
       end
+
+      test "should handle :trim ", %{
+        event_store: event_store,
+        event_store_meta: event_store_meta
+      } do
+        assert :ok ==
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :any_version,
+                   build_events(3)
+                 )
+
+        assert :ok ==
+                 event_store.append_to_stream(
+                   event_store_meta,
+                   "stream",
+                   :any_version,
+                   build_events(4),
+                   trim: true
+                 )
+
+        read_events = event_store.stream_forward(event_store_meta, "stream") |> Enum.to_list()
+        assert length(read_events) == 4
+      end
     end
 
     describe "stream events from an unknown stream" do

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -127,7 +127,7 @@ defmodule Commanded.ExampleDomain.BankAccount do
   end
 
   def close_account(%BankAccount{state: :active}, %CloseAccount{account_number: account_number}) do
-    %BankAccountClosed{account_number: account_number}
+    {:trim, %BankAccountClosed{account_number: account_number}}
   end
 
   # State mutators


### PR DESCRIPTION
Context: https://github.com/commanded/commanded/discussions/639

Second of a series of upcoming PRs to implement what's discussed there. This PR adds the option to return `:trim` from a command handler which will be passed on as-is to the underlying event store. It also implements this for the in-memory store.