### PR TITLE
Add module to AggregateStateBuilder telemetry

### DIFF
--- a/lib/commanded/aggregates/aggregate_state_builder.ex
+++ b/lib/commanded/aggregates/aggregate_state_builder.ex
@@ -13,6 +13,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
     measurements: "%{system_time: integer()}",
     metadata: """
     %{application: Commanded.Application.t(),
+      aggregate_module: module(),
       aggregate_uuid: String.t(),
       aggregate_state: struct(),
       aggregate_version: non_neg_integer()}
@@ -25,11 +26,22 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
     measurements: "%{duration: non_neg_integer(), count: non_neg_integer()}",
     metadata: """
     %{application: Commanded.Application.t(),
+      aggregate_module: module(),
       aggregate_uuid: String.t(),
       aggregate_state: struct(),
       aggregate_version: non_neg_integer()}
     """
   })
+
+  @moduledoc """
+  Builds an aggregate's state by loading its snapshot and/or events from the
+  event store.
+
+  ## Telemetry
+
+  #{telemetry_docs()}
+
+  """
 
   @read_event_batch_size 1_000
 
@@ -113,6 +125,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
   defp telemetry_metadata(%Aggregate{} = state) do
     %Aggregate{
       application: application,
+      aggregate_module: aggregate_module,
       aggregate_uuid: aggregate_uuid,
       aggregate_state: aggregate_state,
       aggregate_version: aggregate_version
@@ -120,6 +133,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
 
     %{
       application: application,
+      aggregate_module: aggregate_module,
       aggregate_uuid: aggregate_uuid,
       aggregate_state: aggregate_state,
       aggregate_version: aggregate_version


### PR DESCRIPTION
Adds the aggregate's module to the telemetry events for the AggregateStateBuilder.  

The motivaton is that I am trying to see if any of my aggregates would benefit from snapshotting and would like to have a dashboard for the existing `[:commanded, :aggregate, :populate, :stop]` event, but the existing metadata are either too high cardinatliy (like the `aggregate_uuid`) or too generic to be useful for finding specific aggregates (like `application`).

For my purposes I could have gotten a refefrence to the aggregate type from the existing `aggregate_state` metadata field, but since `aggregate_module` already exists in `Commanded.Aggregates.Aggregate` I thought it safer to copy it from there like we do for all of the other metadata fields.

---

Tested this locally with my commanded branch just to ensure the new metadata field is present:

<img width="1248" height="135" alt="Screenshot 2026-05-14 at 13 56 03" src="https://github.com/user-attachments/assets/a92185a5-e56c-4d87-8369-b720a35dbbcb" />


---

Also adds the existing telemetry events to the docs, so that they will start showing up in HexDocs:

<img width="1840" height="1122" alt="image" src="https://github.com/user-attachments/assets/368a91dc-a7a0-4904-ac89-90da89094b88" />
