### PR TITLE
fix(dispatcher): honour `:causation_id` dispatch option on persisted events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* The `:causation_id` dispatch option is now honored on persisted events.
+  Previously it was silently overridden by the dispatched command's
+  `command_uuid`, which made chain-of-causation impossible to reconstruct from
+  events alone for multi-event flows (closes
+  [#624](https://github.com/commanded/commanded/issues/624)). When
+  `:causation_id` is not supplied, the command's own `command_uuid` is still
+  used as the fallback — so default behaviour is unchanged. This also fixes a
+  latent bug where process-manager- and event-handler-dispatched commands
+  passed the originating event's id as `:causation_id` (see
+  `process_manager_instance.ex:229` and `Commanded.Event.Handler` examples),
+  but it was being thrown away before persistence.
+
 ## v1.4.9
 
 ### Enhancements

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -179,7 +179,7 @@ defmodule Commanded.Commands.Dispatcher do
 
     %ExecutionContext{
       command: command,
-      # honour caller-supplied `:causation_id`; fall back to command_uuid (#624)
+      # honour caller-supplied `:causation_id`; fall back to command_uuid
       causation_id: causation_id || command_uuid,
       correlation_id: correlation_id,
       metadata: metadata,

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -160,7 +160,12 @@ defmodule Commanded.Commands.Dispatcher do
   end
 
   defp to_execution_context(%Pipeline{} = pipeline, %Payload{} = payload) do
-    %Pipeline{command: command, command_uuid: command_uuid, metadata: metadata} = pipeline
+    %Pipeline{
+      command: command,
+      command_uuid: command_uuid,
+      causation_id: causation_id,
+      metadata: metadata
+    } = pipeline
 
     %Payload{
       correlation_id: correlation_id,
@@ -174,7 +179,8 @@ defmodule Commanded.Commands.Dispatcher do
 
     %ExecutionContext{
       command: command,
-      causation_id: command_uuid,
+      # honour caller-supplied `:causation_id`; fall back to command_uuid (#624)
+      causation_id: causation_id || command_uuid,
       correlation_id: correlation_id,
       metadata: metadata,
       handler: handler_module,

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -214,7 +214,7 @@ defmodule Commanded.Commands.Router do
       :ok = BankApp.dispatch(command, causation_id: some_event_id)
 
   When `:causation_id` is not provided, the command's own `command_uuid` is
-  used as the resulting events' `causation_id` — preserving prior behaviour.
+  used as the resulting events' `causation_id`.
 
   Process managers and event handlers that dispatch follow-up commands
   already propagate the handled event's id this way, so the full causation

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -204,6 +204,22 @@ defmodule Commanded.Commands.Router do
 
       :ok = BankApp.dispatch(command, metadata: %{"ip_address" => "127.0.0.1"})
 
+  ## Causation id
+
+  You can associate a `:causation_id` with the dispatched command, which will
+  also be persisted as the `causation_id` of every event the command produces.
+  This lets you reconstruct a chain-of-causation across multiple events
+  without persisting commands separately.
+
+      :ok = BankApp.dispatch(command, causation_id: some_event_id)
+
+  When `:causation_id` is not provided, the command's own `command_uuid` is
+  used as the resulting events' `causation_id` — preserving prior behaviour.
+
+  Process managers and event handlers that dispatch follow-up commands
+  already propagate the handled event's id this way, so the full causation
+  chain is observable on the events alone.
+
   """
 
   alias Commanded.Aggregates.DefaultLifespan

--- a/test/commands/correlation_causation_test.exs
+++ b/test/commands/correlation_causation_test.exs
@@ -100,7 +100,7 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       assert causation_id == transfer_requested.event_id
 
       # events emitted by a PM-dispatched command carry the handled event's
-      # id as their `causation_id` — one hop per PM step (#624)
+      # id as their `causation_id` — one hop per PM step
       money_withdrawn =
         EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list() |> Enum.at(-1)
 

--- a/test/commands/correlation_causation_test.exs
+++ b/test/commands/correlation_causation_test.exs
@@ -42,7 +42,7 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       assert [^causation_id] = CommandAuditMiddleware.dispatched_commands(& &1.causation_id)
     end
 
-    test "should be set from `command_uuid` on created event" do
+    test "should fall back to `command_uuid` on created event when not provided" do
       command = %OpenAccount{account_number: "ACC123", initial_balance: 500}
 
       :ok = BankRouter.dispatch(command, application: BankApp)
@@ -50,8 +50,18 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       [command_uuid] = CommandAuditMiddleware.dispatched_commands(& &1.command_uuid)
       [event] = EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list()
 
-      # an event's `causation_id` is the dispatched command's `command_uuid`
       assert event.causation_id == command_uuid
+    end
+
+    test "should be set from explicit `:causation_id` dispatch option on created event" do
+      causation_id = UUID.uuid4()
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 500}
+
+      :ok = BankRouter.dispatch(command, application: BankApp, causation_id: causation_id)
+
+      [event] = EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list()
+
+      assert event.causation_id == causation_id
     end
 
     test "should be copied onto commands/events by process manager" do
@@ -88,6 +98,17 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       transfer_requested = EventStore.stream_forward(BankApp, transfer_uuid) |> Enum.at(0)
       [_, causation_id, _] = CommandAuditMiddleware.dispatched_commands(& &1.causation_id)
       assert causation_id == transfer_requested.event_id
+
+      # events emitted by a PM-dispatched command carry the handled event's
+      # id as their `causation_id` — one hop per PM step (#624)
+      money_withdrawn =
+        EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list() |> Enum.at(-1)
+
+      money_deposited =
+        EventStore.stream_forward(BankApp, "ACC456") |> Enum.to_list() |> Enum.at(-1)
+
+      assert money_withdrawn.causation_id == transfer_requested.event_id
+      assert money_deposited.causation_id == money_withdrawn.event_id
     end
   end
 
@@ -217,11 +238,8 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
 
       assert causation_id == account_opened.event_id
 
-      # should set created event causation id as the command uuid
-      [_command_uuid, command_uuid] =
-        CommandAuditMiddleware.dispatched_commands(& &1.command_uuid)
-
-      assert money_deposited.causation_id == command_uuid
+      # created event causation id should be the handled event's id (#624)
+      assert money_deposited.causation_id == account_opened.event_id
     end
 
     def start_account_bonus_handler(_context) do

--- a/test/commands/correlation_causation_test.exs
+++ b/test/commands/correlation_causation_test.exs
@@ -99,8 +99,8 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       [_, causation_id, _] = CommandAuditMiddleware.dispatched_commands(& &1.causation_id)
       assert causation_id == transfer_requested.event_id
 
-      # events emitted by a PM-dispatched command carry the handled event's
-      # id as their `causation_id` — one hop per PM step
+      # events emitted by a ProcessManager-dispatched command carry the handled event's
+      # id as their `causation_id`
       money_withdrawn =
         EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list() |> Enum.at(-1)
 


### PR DESCRIPTION

disclaimer: most of this PR is generated with claude code. I might not understand the deep implications of this changes, but the essential pouint is that it fixed my issue and seems to close the issue #624 at the same time.

Thank you for your time !




Closes #624.

`Commanded.Commands.Dispatcher.to_execution_context/2` previously hardcoded `ExecutionContext.causation_id` to the dispatched command's `command_uuid`, silently dropping any `:causation_id` supplied by the caller. As a result the `causation_id` persisted on events always pointed at a command — which is not stored in the event store by default — making it impossible to reconstruct a chain of causation from events alone for multi-event flows.

Read the caller-supplied `:causation_id` from the pipeline and fall back to `command_uuid` when it is not set. Default behaviour is unchanged when no `:causation_id` is supplied.

This also fixes a latent bug where process managers (`process_manager_instance.ex:229`) and event handlers already passed the handled event's id as `:causation_id`, but the value was thrown away before persistence. Events emitted by PM- or handler-dispatched commands now carry the handled event's id as `causation_id`, one hop per dispatch.

  - lib/commanded/commands/dispatcher.ex: read `pipeline.causation_id`, use `causation_id || command_uuid` on the ExecutionContext
  - lib/commanded/commands/router.ex: document the option on `dispatch/2`
  - test/commands/correlation_causation_test.exs: rename default-fallback test for clarity; assert explicit `:causation_id` lands on the event; flip the handler test (which was codifying the bug); add a PM-step assertion (one hop: MoneyTransferRequested → MoneyWithdrawn → MoneyDeposited)
  - CHANGELOG.md: entry under Unreleased / Bug fixes