### PR TITLE
Allow causation to be nil  nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+* Support `causation_id: nil` as a dispatch option to mark resulting events
+  as chain roots. `:causation_id` is now resolved at the router boundary via
+  `Keyword.fetch/2` so omitting the option still falls back to `command_uuid`
+  (legacy behaviour), while passing `causation_id: nil` explicitly persists
+  events with `causation_id` set to `NULL` — letting
+  `WHERE causation_id IS NULL` identify chain roots without a self-join.
+
 ## v1.4.10
 
 ### Enhancements

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -162,7 +162,6 @@ defmodule Commanded.Commands.Dispatcher do
   defp to_execution_context(%Pipeline{} = pipeline, %Payload{} = payload) do
     %Pipeline{
       command: command,
-      command_uuid: command_uuid,
       causation_id: causation_id,
       metadata: metadata
     } = pipeline
@@ -179,8 +178,7 @@ defmodule Commanded.Commands.Dispatcher do
 
     %ExecutionContext{
       command: command,
-      # honour caller-supplied `:causation_id`; fall back to command_uuid
-      causation_id: causation_id || command_uuid,
+      causation_id: causation_id,
       correlation_id: correlation_id,
       metadata: metadata,
       handler: handler_module,

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -547,13 +547,7 @@ defmodule Commanded.Commands.Router do
           command_uuid = Keyword.get_lazy(opts, :command_uuid, &UUID.uuid4/0)
           consistency = Keyword.fetch!(opts, :consistency)
           correlation_id = Keyword.get_lazy(opts, :correlation_id, &UUID.uuid4/0)
-
-          # Resolve `:causation_id` at the router boundary so the fallback
-          # decision happens once and downstream middleware/handlers see the
-          # final value. Three cases:
-          #   - opt absent              -> fall back to command_uuid (legacy)
-          #   - `causation_id: <uuid>`  -> use the uuid
-          #   - `causation_id: nil`     -> use nil (chain root)
+          # `Keyword.fetch/2` distinguishes absence from explicit `nil`
           causation_id =
             case Keyword.fetch(opts, :causation_id) do
               {:ok, value} -> value

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -436,7 +436,12 @@ defmodule Commanded.Commands.Router do
       Options:
 
         - `causation_id` - an optional UUID used to identify the cause of the
-          command being dispatched.
+          command being dispatched. When the option is omitted, the command's
+          own `command_uuid` is used (preserving prior behaviour). Pass
+          `causation_id: nil` explicitly to mark the resulting events as chain
+          roots — they will be persisted with `causation_id` set to `NULL`,
+          letting `WHERE causation_id IS NULL` queries identify roots without
+          a self-join.
 
         - `command_uuid` - an optional UUID used to identify the command being
           dispatched.
@@ -539,10 +544,22 @@ defmodule Commanded.Commands.Router do
           opts = Keyword.merge(@command_opts, opts)
 
           application = Keyword.fetch!(opts, :application)
-          causation_id = Keyword.get(opts, :causation_id)
           command_uuid = Keyword.get_lazy(opts, :command_uuid, &UUID.uuid4/0)
           consistency = Keyword.fetch!(opts, :consistency)
           correlation_id = Keyword.get_lazy(opts, :correlation_id, &UUID.uuid4/0)
+
+          # Resolve `:causation_id` at the router boundary so the fallback
+          # decision happens once and downstream middleware/handlers see the
+          # final value. Three cases:
+          #   - opt absent              -> fall back to command_uuid (legacy)
+          #   - `causation_id: <uuid>`  -> use the uuid
+          #   - `causation_id: nil`     -> use nil (chain root)
+          causation_id =
+            case Keyword.fetch(opts, :causation_id) do
+              {:ok, value} -> value
+              :error -> command_uuid
+            end
+
           metadata = Keyword.fetch!(opts, :metadata) |> validate_metadata()
 
           retry_attempts = Keyword.get(opts, :retry_attempts)

--- a/test/commands/correlation_causation_test.exs
+++ b/test/commands/correlation_causation_test.exs
@@ -64,6 +64,16 @@ defmodule Commanded.Commands.CorrelationCasuationTest do
       assert event.causation_id == causation_id
     end
 
+    test "should be `nil` on created event when `causation_id: nil` is passed explicitly" do
+      command = %OpenAccount{account_number: "ACC123", initial_balance: 500}
+
+      :ok = BankRouter.dispatch(command, application: BankApp, causation_id: nil)
+
+      [event] = EventStore.stream_forward(BankApp, "ACC123") |> Enum.to_list()
+
+      assert is_nil(event.causation_id)
+    end
+
     test "should be copied onto commands/events by process manager" do
       transfer_uuid = UUID.uuid4()
 


### PR DESCRIPTION
Disclaimer: AI generated code.  The fix seems to works on my side and fits my personal needs. 


-----



Adds support for causation_id: nil as an explicit dispatch option to mark resulting events as chain roots.

Previously, Keyword.get(opts, :causation_id) returned nil whether the option was absent or explicitly nil, so the dispatcher fell back to command_uuid in both cases — there was no way to express "this event has no cause."

:causation_id is now resolved at the router boundary via Keyword.fetch/2, distinguishing three cases:

- opt absent → fall back to command_uuid (legacy behaviour, unchanged)
- causation_id: <uuid> → use the uuid (unchanged)
- causation_id: nil → persist NULL (new)

Side benefit: the dispatcher's to_execution_context/2 drops the || command_uuid fallback and reads pipeline.causation_id directly. Middleware that inspects pipeline.causation_id continues to see a uuid-or-nil, never a sentinel.

Why

WHERE causation_id IS NULL now identifies chain roots without a self-join against the events table — significantly cheaper on large event stores.

Backwards compatibility

- Callers that never pass :causation_id get identical behaviour.
- Callers that pass a uuid get identical behaviour.
- The only new behaviour is opt-in via causation_id: nil.