### PR TITLE
Correction for Process Manager docs

### DIFF
--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -219,7 +219,6 @@ defmodule Commanded.ProcessManagers.ProcessManager do
         use Commanded.ProcessManagers.ProcessManager,
           application: ExampleApp,
           name: "TransferMoneyProcessManager",
-          router: BankRouter,
           event_timeout: :timer.minutes(10)
       end
 


### PR DESCRIPTION
The `:router` option is not one which is supported by the Process Manager.  I poked around the codebase a bit and never saw evidence that this ever worked, and the fact that it was only documented in a section about a different feature (timeouts) makes me believe it has been a copy-and-paste error which has been around for years.

```elixir
defmodule MyApp.MyPM do
  use Commanded.ProcessManagers.ProcessManager,
    router: MyApp.Router
end
```

Results in:

```elixir
** (Mix) Could not start application my_app: MyApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: {MyApp.MyPM, []}
    ** (EXIT) an exception was raised:
        ** (ArgumentError) MyApp.MyPM specifies invalid options: [:router]
            (commanded 1.4.10) lib/commanded/process_managers/process_manager.ex:642: Commanded.ProcessManagers.ProcessManager.parse_config!/2
            (my_app 0.1.0) /Users/tyler/dev.noindex/personal/commanded/lib/commanded/process_managers/process_manager.ex:523: MyApp.MyPM.start_link/1
            (stdlib 7.2) supervisor.erl:996: :supervisor.do_start_child_i/3
            (stdlib 7.2) supervisor.erl:982: :supervisor.do_start_child/3
            (stdlib 7.2) supervisor.erl:966: anonymous fn/3 in :supervisor.start_children/2
            (stdlib 7.2) supervisor.erl:1891: :supervisor.children_map/4
            (stdlib 7.2) supervisor.erl:932: :supervisor.init_children/2
            (stdlib 7.2) gen_server.erl:2276: :gen_server.init_it/2
```

Closes #517 