### PR TITLE
Spelling and grammar errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 
 ### Bug fixes
 
-* `Commanded.Event.ErrorHandler` now keeps surounding failure context by @drteeth in https://github.com/commanded/commanded/issues/617
+* `Commanded.Event.ErrorHandler` now keeps surrounding failure context by @drteeth in https://github.com/commanded/commanded/issues/617
 
 ## v1.4.7
 

--- a/guides/Events.md
+++ b/guides/Events.md
@@ -75,14 +75,14 @@ You should start your event handlers using an OTP `Supervisor` to ensure they ar
 
 You can choose the default error behaviour for *all* of your event handlers in each Application's configuration:
 
-```ellxir
+```elixir
 config :example, ExampleApp,
   on_event_handler_error: :stop # or :backoff or MyCustomErrorHandler
 ```
 
 The default behaviour is to stop the event handler process when any error is encountered. As event handlers are supervised either by a custom supervisor or by the application itself, the handlers are usually restarted right away. If the error is permanent, due to a logic or data bug, then the process will likely crash again right away. This can lead the supervisor itself to give up, crash and this will continue up your supervision tree until it stops your application.
 
-The `:backoff` option, introduced in v1.4.7, cause the even handler to retry after an exponentially increasing backoff period (up to a maximum of 24 hours). The event handler will still not be able to make forward progress until you address the issue, but it won't take your supervisors or applications down with it.
+The `:backoff` option, introduced in v1.4.7, cause the event handler to retry after an exponentially increasing backoff period (up to a maximum of 24 hours). The event handler will still not be able to make forward progress until you address the issue, but it won't take your supervisors or applications down with it.
 
 If you want to provide your own strategy, you can pass in a module that implements an `c:Commanded.Event.Handler.error/3` function that matches the `c:Commanded.Event.Handler.error/3` callback mentioned above.
 
@@ -113,9 +113,9 @@ Transient errors occur due temporary issues such as network connectivity, flakey
 
 #### Permanent errors
 
-Permanent errors occure due to bugs in code, and as such have no hope of resolving themselves. The handler will not be able to make any progress, and will repeatedly crash.
+Permanent errors occur due to bugs in code, and as such have no hope of resolving themselves. The handler will not be able to make any progress, and will repeatedly crash.
 
-Repeated crashes become a problem when the handler crashes more than it's supervisor is configured to tolerate. When that happens, the supervisor itself will crash and this process will continue upwards until finally the application itself crashes. This is obviously bad.
+Repeated crashes become a problem when the handler crashes more than its supervisor is configured to tolerate. When that happens, the supervisor itself will crash and this process will continue upwards until finally the application itself crashes. This is obviously bad.
 
 You can opt to have your event handlers backoff when crashing to avoid this:
 
@@ -128,7 +128,7 @@ This will cause all event handlers from `MyApp.CommandedApp` to back off exponen
 
 It is also possible to configure the error handler for the default behaviour `:stop`.
 
-You can bring your own Commanded application-level behaviour by specifiying a module which implements `c:Commanded.Event.Handler.error/3`
+You can bring your own Commanded application-level behaviour by specifying a module which implements `c:Commanded.Event.Handler.error/3`
 
 ```elixir
 defmodule YoloErrorHandler do

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -336,7 +336,7 @@ defmodule Commanded.Application do
 
             The available options are:
 
-            - `:aggregate_state` - to return the update aggregate state in the
+            - `:aggregate_state` - to return the updated aggregate state in the
               successful response: `{:ok, aggregate_state}`.
 
             - `:aggregate_version` - to include the aggregate stream version

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -180,7 +180,7 @@ defmodule Commanded.Aggregates.Aggregate do
     - `aggregate_uuid` - uniquely identifies an instance of the aggregate.
     - `context` - includes command execution arguments
       (see `Commanded.Aggregates.ExecutionContext` for details).
-    - `timeout` - an non-negative integer which specifies how many milliseconds
+    - `timeout` - a non-negative integer which specifies how many milliseconds
       to wait for a reply, or the atom :infinity to wait indefinitely.
       The default value is five seconds (5,000ms).
 

--- a/lib/commanded/aggregates/aggregate_lifespan.ex
+++ b/lib/commanded/aggregates/aggregate_lifespan.ex
@@ -23,7 +23,7 @@ defmodule Commanded.Aggregates.AggregateLifespan do
 
   ## Supported return values
 
-    - Non-negative integer - specify an inactivity timeout, in millisconds.
+    - Non-negative integer - specify an inactivity timeout, in milliseconds.
     - `:infinity` - prevent the aggregate instance from shutting down.
     - `:hibernate` - send the process into hibernation.
     - `:stop` - immediately shutdown the aggregate process with a `:normal` exit

--- a/lib/commanded/aggregates/aggregate_state_builder.ex
+++ b/lib/commanded/aggregates/aggregate_state_builder.ex
@@ -46,7 +46,7 @@ defmodule Commanded.Aggregates.AggregateStateBuilder do
   @read_event_batch_size 1_000
 
   @doc """
-  Populate the aggregate's state from a snapshot, if present, and it's events.
+  Populate the aggregate's state from a snapshot, if present, and its events.
 
   Attempt to fetch a snapshot for the aggregate to use as its initial state.
   If the snapshot exists, fetch any subsequent events to rebuild its state.

--- a/lib/commanded/aggregates/multi.ex
+++ b/lib/commanded/aggregates/multi.ex
@@ -65,7 +65,7 @@ defmodule Commanded.Aggregate.Multi do
 
   If `step_name` is provided, the aggregate state after that step is
   stored under that name. That can be useful in a long multi step multi
-  in which one needs to know what was the agg state while procesisng
+  in which one needs to know what was the agg state while processing
   the multi. It's possible, then, to pattern match the step name in the
   second parameter of the anonymous function to be executed.
 
@@ -100,7 +100,7 @@ defmodule Commanded.Aggregate.Multi do
 
   If `step_name` is provided, the aggregate state after that step will be
   stored under that name. That can be useful in a long multi step multi
-  in which one needs to know what was the agg state while procesisng
+  in which one needs to know what was the agg state while processing
   the multi. It's possible, then, to pattern match the step name in the
   third parameter of the anonymous function to be executed.
 

--- a/lib/commanded/commands/execution_result.ex
+++ b/lib/commanded/commands/execution_result.ex
@@ -15,7 +15,7 @@ defmodule Commanded.Commands.ExecutionResult do
 
     - `events` - a list of the created events, it may be an empty list.
 
-    - `metadata` - an map containing the metadata associated with the command
+    - `metadata` - a map containing the metadata associated with the command
       dispatch.
 
   """

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -141,7 +141,7 @@ defmodule Commanded.Commands.Router do
 
   The supported options are:
 
-    - `:aggregate_state` - to return the update aggregate state.
+    - `:aggregate_state` - to return the updated aggregate state.
 
     - `:aggregate_version` - to return only the aggregate version.
 
@@ -161,7 +161,7 @@ defmodule Commanded.Commands.Router do
       {:ok, %BankAccount{}} = BankApp.dispatch(command, returning: :aggregate_state)
 
   This is useful when you want to immediately return fields from the aggregate's
-  state without requiring an read model projection and waiting for the event(s)
+  state without requiring a read model projection and waiting for the event(s)
   to be projected. It may also be appropriate to use this feature for unit
   tests.
 
@@ -458,7 +458,7 @@ defmodule Commanded.Commands.Router do
 
             The available options are:
 
-            - `:aggregate_state` - to return the update aggregate state in the
+            - `:aggregate_state` - to return the updated aggregate state in the
               successful response: `{:ok, aggregate_state}`.
 
             - `:aggregate_version` - to include the aggregate stream version

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -273,7 +273,7 @@ defmodule Commanded.Event.Handler do
   one at a time in order. The `:concurrency` option determines how many event
   handler processes are started. It must be a positive integer.
 
-  Note with concurrent processing events will likely by processed out of order.
+  Note with concurrent processing events will likely be processed out of order.
   If you need to enforce an order, such as per stream or by using a field from
   an event, you can define a `c:partition_by/2` callback function in the event
   handler module. The function will receive each event and its metadata and must
@@ -288,7 +288,7 @@ defmodule Commanded.Event.Handler do
 
   ### Example
 
-      defmodule ConcurrentProcssingEventHandler do
+      defmodule ConcurrentProcessingEventHandler do
         alias Commanded.EventStore.RecordedEvent
 
         use Commanded.Event.Handler,
@@ -620,7 +620,7 @@ defmodule Commanded.Event.Handler do
   the event handler using the exact error reason returned from the `handle/2`
   function. If the event handler is supervised using restart `permanent` or
   `transient` stopping on error will cause the handler to be restarted. It will
-  likely crash again as it will reprocesse the problematic event. This can lead
+  likely crash again as it will reprocess the problematic event. This can lead
   to cascading failures going up the supervision tree.
 
   ### Example error handling

--- a/lib/commanded/event/mapper.ex
+++ b/lib/commanded/event/mapper.ex
@@ -69,7 +69,7 @@ defmodule Commanded.Event.Mapper do
   end
 
   @doc """
-  Map an `Commanded.EventStore.RecordedEvent` struct to its event data.
+  Map a `Commanded.EventStore.RecordedEvent` struct to its event data.
   """
   @spec map_from_recorded_event(RecordedEvent.t()) :: event
   def map_from_recorded_event(%RecordedEvent{data: data}), do: data

--- a/lib/commanded/process_managers/process_manager.ex
+++ b/lib/commanded/process_managers/process_manager.ex
@@ -269,7 +269,7 @@ defmodule Commanded.ProcessManagers.ProcessManager do
 
   ### Example
 
-  Start an process manager for each tenant in a multi-tenanted app, guaranteeing
+  Start a process manager for each tenant in a multi-tenanted app, guaranteeing
   that the data and processing remains isolated between tenants.
 
       for tenant <- [:tenant1, :tenant2, :tenant3] do

--- a/lib/commanded/registration/global_registry.ex
+++ b/lib/commanded/registration/global_registry.ex
@@ -71,7 +71,7 @@ defmodule Commanded.Registration.GlobalRegistry do
         {:ok, pid}
 
       {:error, :killed} ->
-        # Process may be killed due to `:global` name registation when another node connects.
+        # Process may be killed due to `:global` name registration when another node connects.
         # Attempting to start again should link to the other named existing process.
         start_link(adapter_meta, name, module, args, start_opts)
 

--- a/lib/commanded/serialization/json_decoder.ex
+++ b/lib/commanded/serialization/json_decoder.ex
@@ -3,7 +3,7 @@ defprotocol Commanded.Serialization.JsonDecoder do
   Protocol to allow additional decoding of a value that has been deserialized
   using the `Commanded.Serialization.JsonSerializer`.
 
-  The protocol is optional. The default behaviour is to to return the value if
+  The protocol is optional. The default behaviour is to return the value if
   an explicit protocol is not defined.
   """
   @fallback_to_any true


### PR DESCRIPTION
Fixes spelling and grammar errors.  Doesn't change any British-vs-American spelling differences, those were all left as-is.