### PR TITLE
Fix flakey test

### DIFF
--- a/test/event/reset_batch_event_handler_test.exs
+++ b/test/event/reset_batch_event_handler_test.exs
@@ -55,6 +55,10 @@ defmodule Commanded.Event.BatchResetEventHandlerTest do
 
       send(handler, :reset)
 
+      # Wait for the :reset message to be handled, otherwise there is a risk the append_to_stream
+      # below gets sent to the old subscription.
+      _ = :sys.get_state(handler)
+
       new_event = [%BankAccountOpened{account_number: "ACC1234", initial_balance: 1_000}]
       :ok = EventStore.append_to_stream(BankApp, stream_uuid, 1, to_event_data(new_event))
 


### PR DESCRIPTION
There was a race condition where the `append_to_stream` function could be sent to the old subscription instead of the reset one.

The failure was pretty easy to reproduce locally by running the following:

```
mix test test/event/reset_batch_event_handler_test.exs --repeat-until-failure 10
```

I have now run the test many times, and the test is passing every time.